### PR TITLE
macOS: use port 5005 (5000 is taken by AirPlay Receiver)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ python src/training/train_pii.py --type full --version 1.2.0  # oppure versione 
 
 # inferenza / app
 python src/training/test_pii.py "Mi chiamo Mario Rossi, IBAN ..."
-python src/app/app.py            # http://127.0.0.1:5000
+python src/app/app.py            # http://127.0.0.1:5005
 
 # ispezione read-only
 python src/inspect/inspect_ai4privacy.py

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ python src/training/train_pii.py --type full --version 1.2.0   # or an explicit 
 
 ```powershell
 python src/training/test_pii.py "Mi chiamo Mario Rossi, IBAN IT60X0542811101000000123456"
-python src/app/app.py            # http://127.0.0.1:5000  (paste text or upload a PDF)
+python src/app/app.py            # http://127.0.0.1:5005  (paste text or upload a PDF)
 ```
 
 The web app assigns every PII a **reversible ID** (`[FULLNAME_1]`, `[IBAN_1]`…) plus a local

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -16,7 +16,8 @@ Esistono due modi di impacchettare, entrambi CPU/offline:
 Il motore dell'app è **Python + PyTorch + il modello mmBERT**: non gira dentro Rust/WebView.
 Per questo, sia con Tauri sia col build legacy, il backend è il **server Flask** (`src/app/app.py`)
 impacchettato con PyInstaller. Con Tauri la finestra nativa lo lancia come **processo figlio
-(sidecar)**, attende che risponda su `127.0.0.1:5000`, poi mostra l'UI; alla chiusura lo termina.
+(sidecar)**, attende che risponda su `127.0.0.1:5005`, poi mostra l'UI; alla chiusura lo termina.
+La porta è la **5005** (non la 5000, occupata di default da AirPlay Receiver su macOS); override con `PII_PORT`.
 
 ---
 
@@ -122,7 +123,7 @@ build_env\Scripts\python.exe -m pip install "transformers==4.57.3" tokenizers sa
 build_env\Scripts\pyinstaller.exe build.spec --noconfirm
 ```
 Output: `dist\AnonimizzatorePII\AnonimizzatorePII.exe` (cartella autocontenuta, include il modello).
-Avviabile direttamente con doppio clic — apre il browser su http://127.0.0.1:5000/.
+Avviabile direttamente con doppio clic — apre il browser su http://127.0.0.1:5005/.
 
 ### 3. Installer (opzionale, per distribuirlo)
 Installa Inno Setup (https://jrsoftware.org/isdl.php), poi:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,17 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-06-29 — Fix porta backend: 5000 → 5005 (conflitto AirPlay su macOS)
+
+Su macOS la porta **5000** è occupata di default da **AirPlay Receiver**. Effetto sull'app Tauri:
+`backend_ready()` vedeva la 5000 già in ascolto (AirPlay), **non avviava il backend reale** e apriva
+la WebView sul server sbagliato → **schermata bianca**. Il backend predefinito è spostato alla **5005**
+e Tauri passa la porta al sidecar via env **`PII_PORT`** (Rust e Flask non possono più divergere).
+File: `tauri/src-tauri/src/lib.rs`, `src/app/serve.py`, `src/app/app.py`, `src/app/desktop_app.py`.
+Override con la variabile `PII_PORT`.
+
+---
+
 ## 2026-06-28 — App di anonimizzazione: revisione completa + app desktop Tauri
 
 Riscrittura dell'app locale (`src/app/`) e nuovo packaging desktop. Nessun impatto su training.
@@ -31,7 +42,7 @@ serviti da `/assets/` con fallback emoji. Asset in `src/app/assets/`.
 **5. App desktop Tauri** (`tauri/`). Architettura **sidecar**: il backend Python/Flask
 (`serve.py`, headless) è impacchettato con PyInstaller (`build_sidecar.spec`, CPU, ~1,8 GB col
 modello) in `tauri/src-tauri/backend/`; la finestra nativa **Rizzo PII** (WebView2) lo lancia come
-processo figlio, attende il server su `127.0.0.1:5000`, mostra l'UI e lo termina alla chiusura.
+processo figlio, attende il server su `127.0.0.1:5005`, mostra l'UI e lo termina alla chiusura.
 Splash con badge **UE / GDPR compliant**, **versione** (iniettata da Rust dalla config) e crediti
 nell'app (Simone Rizzo · Rizzo AI Academy). `npx tauri build` → **installer NSIS per-utente**
 (`Rizzo PII_1.0.0_x64-setup.exe`, ~1,3 GB, non firmato → avviso SmartScreen atteso).

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -16,7 +16,7 @@ Il modello e' affiancato da una rete REGEX + CHECKSUM (EMAIL, TELEFONO, IBAN, CF
 carta di credito, importi, targhe). Le entita' validate matematicamente (IBAN/CF/PIVA/
 carta) hanno priorita' sul modello in caso di sovrapposizione.
 
-Avvio:  python app.py   ->   http://127.0.0.1:5000
+Avvio:  python app.py   ->   http://127.0.0.1:5005
 """
 
 import os
@@ -1014,4 +1014,4 @@ try{const m=localStorage.getItem('pii_map');if(m){MAP=JSON.parse(m);
 """
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=5000, threaded=True)
+    app.run(host="127.0.0.1", port=int(os.environ.get("PII_PORT", "5005")), threaded=True)

--- a/src/app/desktop_app.py
+++ b/src/app/desktop_app.py
@@ -5,11 +5,12 @@ apre il browser. Chiudere questa finestra termina l'applicazione.
 """
 
 import multiprocessing
+import os
 import threading
 import time
 import webbrowser
 
-PORT = 5000
+PORT = int(os.environ.get("PII_PORT", "5005"))
 URL = f"http://127.0.0.1:{PORT}/"
 
 

--- a/src/app/serve.py
+++ b/src/app/serve.py
@@ -10,14 +10,14 @@ In modalita' windowed sys.stdout/sys.stderr sono None: li reindirizziamo su un f
 log PRIMA di importare 'app' (che al caricamento stampa e carica il modello), cosi'
 nessun print() fa crashare il processo e i problemi restano diagnosticabili.
 
-Porta: 5000 (override con la variabile d'ambiente PII_PORT).
+Porta: 5005 (5000 e' occupata da AirPlay Receiver su macOS; override con PII_PORT).
 Log:   %LOCALAPPDATA%\\rizzo-pii\\backend.log
 """
 
 import os
 import sys
 
-PORT = int(os.environ.get("PII_PORT", "5000"))
+PORT = int(os.environ.get("PII_PORT", "5005"))
 
 # --- log su file (windowed mode -> niente console) ------------------------- #
 _logdir = os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")), "rizzo-pii")

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -4,7 +4,10 @@
 // PyInstaller e incluso come risorsa ("backend/pii-backend/pii-backend.exe"). Tauri fa da
 // finestra nativa: all'avvio mostra uno splash, lancia il backend come processo figlio,
 // attende che il server locale risponda e poi apre la finestra principale puntata sull'UI
-// Flask (http://127.0.0.1:5000). Alla chiusura il processo figlio viene terminato.
+// Flask (http://127.0.0.1:5005). Alla chiusura il processo figlio viene terminato.
+//
+// Porta 5005, non 5000: su macOS la 5000 e' occupata da AirPlay Receiver, che rispondeva al
+// check di backend_ready() -> WebView aperta sul server sbagliato (schermata bianca).
 
 use std::net::TcpStream;
 use std::process::{Child, Command};
@@ -16,8 +19,10 @@ use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 /// Custodisce il processo del backend per poterlo terminare all'uscita.
 struct BackendProcess(Mutex<Option<Child>>);
 
-const ADDR: &str = "127.0.0.1:5000";
-const URL: &str = "http://127.0.0.1:5000";
+// Passata al sidecar via PII_PORT (sotto) cosi' Flask e Tauri non possono divergere.
+const PORT: &str = "5005";
+const ADDR: &str = "127.0.0.1:5005";
+const URL: &str = "http://127.0.0.1:5005";
 
 /// True se il server locale accetta connessioni (= modello caricato, Flask in ascolto).
 fn backend_ready() -> bool {
@@ -53,7 +58,7 @@ pub fn run() {
                             .join("backend")
                             .join("pii-backend")
                             .join(bin_name);
-                        match Command::new(&exe).spawn() {
+                        match Command::new(&exe).env("PII_PORT", PORT).spawn() {
                             Ok(child) => {
                                 app.state::<BackendProcess>()
                                     .0


### PR DESCRIPTION
On macOS AirPlay Receiver occupies port 5000. backend_ready() saw it already listening, so Tauri never started the real backend and pointed the WebView at the wrong server -> blank screen. Backend moved to 5005; Tauri passes the port to the sidecar via the PII_PORT env var (Rust and Flask stay in sync). Override with PII_PORT. The Rust-side fix takes effect after rebuilding (npx tauri build).