### PR TITLE
feat: configurable host/port with port-conflict recovery UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ WANDB_PROJECT=pii-mmbert-it
 
 # Google Gemini — used ONLY by src/data_pipeline/llm_template_bank.py to write legal templates
 GEMINI_API_KEY=
+
+# Server bind address — optional, can also be set via config.json or CLI --host/--port
+# The precedence chain is: CLI args > env vars > config.json > default (127.0.0.1:5005)
+# PII_HOST=127.0.0.1
+# PII_PORT=5005

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,18 +66,33 @@ modelli in `models/<versione>/`, artefatti dei run in `experiments/<run>/`, doc 
 - `inspect_ai4privacy.py` (conteggi lingue/tag), `inspect_lengths.py` (lunghezze), `inspect_no_iban.py`.
 
 **App di anonimizzazione locale — `src/app/` (+ packaging in `docs/BUILD.md`):**
+- `server_config.py` — **configurazione host/porta** condivisa tra tutti gli entry point e con Tauri.
+  Catena di precedenza: **CLI `--host`/`--port` > env `PII_HOST`/`PII_PORT` > `config.json` > default
+  `127.0.0.1:5005`**. Il config.json è in `%LOCALAPPDATA%\rizzo-pii\` (Windows) /
+  `~/.local/share/rizzo-pii/` (Linux) / `~/Library/Application Support/rizzo-pii/` (macOS), lo
+  stesso file letto/scritto da Tauri (lib.rs). Include `port_available()` (pre-bind check) e il
+  codice di uscita `EXIT_PORT_CONFLICT = 76`: i 3 entry point escono con 76 se la porta è occupata
+  **prima di caricare il modello** (evita secondi sprecati). Tauri riconosce il codice 76 e mostra
+  il form di configurazione nello splash screen.
 - `app.py` — server Flask + **UI**: testo o PDF, chunking con overlap, offset globali + dedup.
   Anonimizzazione **reversibile** (ogni PII → `[FULLNAME_1]`/`[IBAN_1]`… + dizionario locale; tab
   "Ripristina"). Affianca al modello una **rete regex/checksum** (EMAIL/TELEFONO/IBAN/CF/PIVA/carta/
   importo/targa; IBAN/CF/PIVA/carta validati con checksum, che ha priorità sul modello). `APP_VERSION`.
+  Endpoint `GET/POST /config` e `GET /port-check` per la configurazione host/porta dall'UI (⚙️
+  gear icon nell'header); `--host`/`--port` come argomenti CLI.
 - `serve.py` — entry **headless** (solo Flask, niente browser): è il backend dell'app Tauri; log su
-  `%LOCALAPPDATA%\rizzo-pii\backend.log`. `desktop_app.py` — entry PyInstaller legacy (apre il browser).
+  `%LOCALAPPDATA%\rizzo-pii\backend.log`. Pre-check porta + `sys.exit(76)` se occupata.
+  `desktop_app.py` — entry PyInstaller legacy (apre il browser); stesso pre-check.
   `assets/` — mascotte (il riccio) + icone. `smoke_app.py`, `make_test_pdf.py`.
 
 **App desktop Tauri — `tauri/`:** finestra nativa **Rizzo PII** (WebView2) che lancia il backend
-`serve.py` impacchettato come **sidecar** (`build_sidecar.spec` → `tauri/src-tauri/backend/`), attende
-il server e mostra l'UI; splash con badge UE/GDPR + versione. `npx tauri build` → installer NSIS
-per-utente. Dettagli e comandi in `docs/BUILD.md`.
+`serve.py` impacchettato come **sidecar** (`build_sidecar.spec` → `tauri/src-tauri/backend/`).
+All'avvio legge `config.json` (host/porta), passa i valori al sidecar via env `PII_HOST`/`PII_PORT`,
+attende il server sulla porta configurata e mostra l'UI. Se il sidecar esce con codice **76** (porta
+occupata), lo splash mostra un form di configurazione (host + porta) con "Salva e riprova": Tauri
+scrive `config.json`, rilancia il sidecar e riprova. Splash con badge UE/GDPR + versione. `npx tauri build`
+→ installer NSIS per-utente. Dettagli e comandi in `docs/BUILD.md`. Comandi Tauri esposti allo splash:
+`save_config(host, port)` e `retry_backend`.
 
 **Config:** `.env` (segreti W&B, **gitignorato**), `.gitignore`, `build.spec`/`build_sidecar.spec`/
 `installer.iss` + `tauri/` (packaging).

--- a/create_mock_model.py
+++ b/create_mock_model.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Creates a mock model at models/rizzo-pii-0.3B-v1.2.0/ that matches the real
+model's interface (ModernBERT token-classification, 22 entity types, 45 BIO labels)
+but with random weights. Good enough for build verification and pipeline testing.
+
+Usage:  python create_mock_model.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# The 22 entity types from TASSONOMIA_TAG.md
+ENTITY_TYPES = [
+    "AGE", "AMOUNT", "BUILDINGNUM", "CATASTO", "CF", "CITY",
+    "CREDITCARDNUMBER", "DATE", "DOCID", "EMAIL", "FULLNAME",
+    "GENDER", "IBAN", "ID_DOC", "ORG", "PIVA", "PROVINCE",
+    "STREET", "TARGA", "TELEPHONENUM", "TIME", "ZIPCODE",
+]
+
+# Build BIO label list: O + B-/I- for each type, sorted
+label_list = ["O"]
+for t in sorted(ENTITY_TYPES):
+    label_list.append(f"B-{t}")
+    label_list.append(f"I-{t}")
+
+label2id = {l: i for i, l in enumerate(label_list)}
+id2label = {i: l for i, l in enumerate(label_list)}
+
+print(f"Label count: {len(label_list)} (O + {len(ENTITY_TYPES)} types × 2 BIO)")
+
+# Try to create the model using transformers
+try:
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+except ImportError:
+    print("ERROR: transformers not installed. Run: pip install transformers torch")
+    sys.exit(1)
+
+MODEL_NAME = "jhu-clsp/mmBERT-base"   # same backbone used by train_pii.py
+OUT_DIR = Path(__file__).resolve().parent / "models" / "rizzo-pii-0.3B-v1.2.0"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+print(f"Downloading tokenizer from {MODEL_NAME}...")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+
+print(f"Creating token-classification model ({len(label_list)} labels)...")
+model = AutoModelForTokenClassification.from_pretrained(
+    MODEL_NAME,
+    num_labels=len(label_list),
+    id2label=id2label,
+    label2id=label2id,
+    ignore_mismatched_sizes=True,   # the classifier head size won't match
+)
+
+print(f"Saving mock model to {OUT_DIR}/ ...")
+model.save_pretrained(OUT_DIR)
+tokenizer.save_pretrained(OUT_DIR)
+
+# Mark it as a mock so nobody confuses it with a trained model
+(OUT_DIR / "MOCK_MODEL.txt").write_text(
+    "This is a MOCK model with random classifier weights.\n"
+    "It matches the real model's interface but produces garbage predictions.\n"
+    "Created by create_mock_model.py for build verification only.\n"
+)
+
+print(f"\nDone. Mock model saved to: {OUT_DIR}")
+print(f"Files: {[f.name for f in sorted(OUT_DIR.iterdir())]}")

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -16,7 +16,9 @@ Il modello e' affiancato da una rete REGEX + CHECKSUM (EMAIL, TELEFONO, IBAN, CF
 carta di credito, importi, targhe). Le entita' validate matematicamente (IBAN/CF/PIVA/
 carta) hanno priorita' sul modello in caso di sovrapposizione.
 
-Avvio:  python app.py   ->   http://127.0.0.1:5005   (override: env PII_PORT)
+Avvio:  python app.py   ->   http://127.0.0.1:5005
+Configurazione host/porta (precedenza): CLI --host/--port > env PII_HOST/PII_PORT >
+  config.json (vedi server_config.py) > default 127.0.0.1:5005
 """
 
 import os
@@ -28,6 +30,8 @@ import fitz  # PyMuPDF
 import torch
 from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
+
+import server_config
 from transformers import pipeline
 
 
@@ -381,6 +385,43 @@ def analyze_route():
 
 
 # --------------------------------------------------------------------------- #
+# Config host/porta (GET = leggi, POST = salva per il prossimo avvio)
+# --------------------------------------------------------------------------- #
+@app.route("/config", methods=["GET"])
+def config_get():
+    cfg = server_config.load_config()
+    return jsonify({
+        "host": cfg.get("host", server_config.DEFAULT_HOST),
+        "port": cfg.get("port", server_config.DEFAULT_PORT),
+        "config_path": str(server_config.config_path()),
+    })
+
+
+@app.route("/config", methods=["POST"])
+def config_post():
+    data = request.get_json(silent=True) or {}
+    host = str(data.get("host", server_config.DEFAULT_HOST)).strip()
+    try:
+        port = int(data.get("port", server_config.DEFAULT_PORT))
+    except (ValueError, TypeError):
+        return jsonify({"error": "Porta non valida."}), 400
+    if not (1024 <= port <= 65535):
+        return jsonify({"error": "La porta deve essere tra 1024 e 65535."}), 400
+    server_config.save_config(host, port)
+    return jsonify({"ok": True, "host": host, "port": port})
+
+
+@app.route("/port-check")
+def port_check():
+    host = request.args.get("host", server_config.DEFAULT_HOST)
+    try:
+        port = int(request.args.get("port", server_config.DEFAULT_PORT))
+    except (ValueError, TypeError):
+        return jsonify({"available": False})
+    return jsonify({"available": server_config.port_available(host, port)})
+
+
+# --------------------------------------------------------------------------- #
 # UI (single page)
 # --------------------------------------------------------------------------- #
 PAGE = r"""
@@ -588,6 +629,31 @@ PAGE = r"""
   #toast.ok::before{content:"✓";color:#6ee7a8}
   .kbd{font-family:ui-monospace,Consolas,monospace;background:#eef1f6;border:1px solid var(--line);
        border-radius:5px;padding:1px 6px;font-size:11.5px;color:var(--muted)}
+
+  /* config modal */
+  .cfg-overlay{position:fixed;inset:0;background:rgba(33,26,48,.35);z-index:100;
+               display:flex;align-items:center;justify-content:center;opacity:0;
+               visibility:hidden;transition:.18s}
+  .cfg-overlay.open{opacity:1;visibility:visible}
+  .cfg-card{background:#fff;border-radius:16px;box-shadow:0 16px 48px rgba(33,26,48,.18);
+            padding:26px 28px 22px;width:380px;max-width:92vw}
+  .cfg-card h3{margin:0 0 16px;font-size:16px;font-weight:700;display:flex;align-items:center;gap:9px}
+  .cfg-row{display:flex;flex-direction:column;gap:5px;margin-bottom:14px}
+  .cfg-row label{font-size:12.5px;font-weight:600;color:var(--muted);text-transform:uppercase;
+                 letter-spacing:.04em}
+  .cfg-row input{border:1px solid var(--line);border-radius:9px;padding:9px 12px;font:inherit;
+                 font-size:14px;color:var(--ink);background:#fcfcfe}
+  .cfg-row input:focus{outline:none;border-color:var(--brand);box-shadow:0 0 0 3px rgba(124,58,158,.13)}
+  .cfg-status{font-size:12.5px;font-weight:600;padding:7px 11px;border-radius:8px;margin-bottom:14px;
+              display:none}
+  .cfg-status.ok{display:block;background:#eaf7ef;color:var(--ok)}
+  .cfg-status.fail{display:block;background:#fef2f2;color:#b91c1c}
+  .cfg-btns{display:flex;gap:9px;align-items:center}
+  .cfg-note{font-size:11.5px;color:var(--soft);margin-top:12px}
+  .gear{background:none;border:1px solid var(--line);width:30px;height:30px;border-radius:8px;
+        display:grid;place-items:center;font-size:15px;padding:0;cursor:pointer;transition:.12s;
+        margin-left:6px;flex:none}
+  .gear:hover{border-color:#cfd5e0;background:#fafbfd}
 </style>
 </head>
 <body>
@@ -605,6 +671,7 @@ PAGE = r"""
         <option value="it">🇮🇹 Italiano</option>
         <option value="en">🇬🇧 English</option>
       </select>
+      <button class="gear" id="gearBtn" title="Configurazione server" aria-label="Server config" onclick="openConfig()">⚙️</button>
       <span class="info" id="infoBtn" tabindex="0" role="button" aria-label="Avviso / info">⚠️<span class="tip" data-i18n="notice"></span></span>
     </div>
   </header>
@@ -730,6 +797,28 @@ PAGE = r"""
 
 <div id="toast"></div>
 
+<!-- config modal -->
+<div class="cfg-overlay" id="cfgOverlay">
+  <div class="cfg-card">
+    <h3>⚙️ <span data-i18n="cfg_title">Configurazione server</span></h3>
+    <div class="cfg-row">
+      <label data-i18n="cfg_host">Indirizzo</label>
+      <input id="cfgHost" type="text" value="127.0.0.1" spellcheck="false">
+    </div>
+    <div class="cfg-row">
+      <label data-i18n="cfg_port">Porta</label>
+      <input id="cfgPort" type="number" min="1024" max="65535" value="5005">
+    </div>
+    <div class="cfg-status" id="cfgStatus"></div>
+    <div class="cfg-btns">
+      <button class="btn" id="cfgSave" onclick="saveConfig()">💾 <span data-i18n="cfg_save">Salva</span></button>
+      <button class="ghost" id="cfgCheck" onclick="checkPort()"><span data-i18n="cfg_check">Verifica porta</span></button>
+      <button class="ghost" onclick="closeConfig()" data-i18n="cfg_cancel">Annulla</button>
+    </div>
+    <div class="cfg-note" data-i18n="cfg_restart_note">Le modifiche avranno effetto al prossimo avvio.</div>
+  </div>
+</div>
+
 <script>
 const $ = id => document.getElementById(id);
 let DATA = null;            // ultimo risultato analyze
@@ -773,6 +862,11 @@ const T = {
   dict_loaded_n:n=>"dizionario caricato · "+n+" ID",
   dict_session:n=>"dizionario sessione · "+n+" ID",
   chars:n=>n.toLocaleString('it'),
+  cfg_title:"Configurazione server", cfg_host:"Indirizzo", cfg_port:"Porta",
+  cfg_check:"Verifica porta", cfg_save:"Salva", cfg_cancel:"Annulla",
+  cfg_available:"Porta disponibile ✓", cfg_in_use:"Porta occupata ✗",
+  cfg_saved:"Configurazione salvata (riavvia per applicare)",
+  cfg_restart_note:"Le modifiche avranno effetto al prossimo avvio.",
  },
  en:{
   tagline:"local model on CPU · GDPR compliant", badge:"100% local",
@@ -808,6 +902,11 @@ const T = {
   dict_loaded_n:n=>"dictionary loaded · "+n+" IDs",
   dict_session:n=>"session dictionary · "+n+" IDs",
   chars:n=>n.toLocaleString('en'),
+  cfg_title:"Server configuration", cfg_host:"Host", cfg_port:"Port",
+  cfg_check:"Check port", cfg_save:"Save", cfg_cancel:"Cancel",
+  cfg_available:"Port available ✓", cfg_in_use:"Port in use ✗",
+  cfg_saved:"Config saved (restart to apply)",
+  cfg_restart_note:"Changes take effect on next startup.",
  }
 };
 const tt=k=>T[L][k];
@@ -1003,7 +1102,34 @@ applyLang(localStorage.getItem('pii_lang')||'it');
 $('infoBtn').addEventListener('click',e=>{e.stopPropagation();$('infoBtn').classList.toggle('open');});
 $('infoBtn').addEventListener('keydown',e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();$('infoBtn').classList.toggle('open');}});
 document.addEventListener('click',e=>{if(!$('infoBtn').contains(e.target))$('infoBtn').classList.remove('open');});
-document.addEventListener('keydown',e=>{if(e.key==='Escape')$('infoBtn').classList.remove('open');});
+document.addEventListener('keydown',e=>{if(e.key==='Escape'){$('infoBtn').classList.remove('open');closeConfig();}});
+
+/* ---- config modal ---- */
+async function openConfig(){
+  const r=await fetch('/config');const d=await r.json();
+  $('cfgHost').value=d.host||'127.0.0.1';
+  $('cfgPort').value=d.port||5005;
+  $('cfgStatus').className='cfg-status';$('cfgStatus').textContent='';
+  $('cfgOverlay').classList.add('open');
+}
+function closeConfig(){$('cfgOverlay').classList.remove('open');}
+$('cfgOverlay').addEventListener('click',e=>{if(e.target===$('cfgOverlay'))closeConfig();});
+async function checkPort(){
+  const h=$('cfgHost').value.trim(),p=parseInt($('cfgPort').value);
+  if(!p||p<1024||p>65535){$('cfgStatus').className='cfg-status fail';$('cfgStatus').textContent=tt('cfg_in_use');return;}
+  const r=await fetch(`/port-check?host=${encodeURIComponent(h)}&port=${p}`);
+  const d=await r.json();
+  $('cfgStatus').className=d.available?'cfg-status ok':'cfg-status fail';
+  $('cfgStatus').textContent=d.available?tt('cfg_available'):tt('cfg_in_use');
+}
+async function saveConfig(){
+  const h=$('cfgHost').value.trim(),p=parseInt($('cfgPort').value);
+  if(!p||p<1024||p>65535){toast(tt('cfg_in_use'),false);return;}
+  await fetch('/config',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({host:h,port:p})});
+  toast(tt('cfg_saved'));
+  closeConfig();
+}
 
 /* recupera dizionario da sessione precedente (dopo applyLang -> testo nella lingua giusta) */
 try{const m=localStorage.getItem('pii_map');if(m){MAP=JSON.parse(m);
@@ -1014,6 +1140,21 @@ try{const m=localStorage.getItem('pii_map');if(m){MAP=JSON.parse(m);
 """
 
 if __name__ == "__main__":
-    # 5005 di default: la 5000 su macOS e' occupata da AirPlay Receiver
-    # (ControlCenter) -> pagina bianca. Override con la env PII_PORT.
-    app.run(host="127.0.0.1", port=int(os.environ.get("PII_PORT", "5005")), threaded=True)
+    import argparse as _ap
+    _p = _ap.ArgumentParser(description="Rizzo PII — server locale di anonimizzazione.")
+    _p.add_argument("--host", default=None, help="indirizzo su cui ascoltare (default da config/env/127.0.0.1)")
+    _p.add_argument("--port", type=int, default=None, help="porta su cui ascoltare (default da config/env/5005)")
+    _args = _p.parse_args()
+
+    _host, _port = server_config.resolve(cli_host=_args.host, cli_port=_args.port)
+
+    if not server_config.port_available(_host, _port):
+        print(f"ERRORE: porta {_port} occupata su {_host}")
+        sys.exit(server_config.EXIT_PORT_CONFLICT)
+
+    print(f"Server su http://{_host}:{_port}")
+    try:
+        app.run(host=_host, port=_port, threaded=True)
+    except OSError as e:
+        print(f"ERRORE bind: {e}")
+        sys.exit(server_config.EXIT_PORT_CONFLICT)

--- a/src/app/desktop_app.py
+++ b/src/app/desktop_app.py
@@ -2,17 +2,30 @@
 """
 Entry point dell'app desktop (PyInstaller). Avvia il server Flask in locale e
 apre il browser. Chiudere questa finestra termina l'applicazione.
+
+Configurazione host/porta:
+  1) CLI args (--host / --port)   ->  precedenza massima
+  2) env PII_HOST / PII_PORT
+  3) config.json  (vedi server_config.py)
+  4) default 127.0.0.1:5005
 """
 
 import multiprocessing
 import os
+import sys
 import threading
 import time
 import webbrowser
 
-# 5005: la 5000 su macOS e' occupata da AirPlay Receiver. Override con env PII_PORT.
-PORT = int(os.environ.get("PII_PORT", "5005"))
-URL = f"http://127.0.0.1:{PORT}/"
+import server_config
+
+HOST, PORT = server_config.resolve()
+URL = f"http://{HOST}:{PORT}/"
+
+# --- pre-check porta PRIMA di caricare il modello (che richiede secondi) --- #
+if not server_config.port_available(HOST, PORT):
+    print(f"ERRORE: porta {PORT} occupata su {HOST}")
+    sys.exit(server_config.EXIT_PORT_CONFLICT)
 
 
 def _open_browser():
@@ -26,4 +39,8 @@ if __name__ == "__main__":
     from app import app                # l'import carica il modello
     threading.Thread(target=_open_browser, daemon=True).start()
     print(f"In esecuzione su {URL}  --  chiudi questa finestra per terminare.")
-    app.run(host="127.0.0.1", port=PORT, threaded=True)
+    try:
+        app.run(host=HOST, port=PORT, threaded=True)
+    except OSError as e:
+        print(f"ERRORE bind: {e}")
+        sys.exit(server_config.EXIT_PORT_CONFLICT)

--- a/src/app/serve.py
+++ b/src/app/serve.py
@@ -10,15 +10,21 @@ In modalita' windowed sys.stdout/sys.stderr sono None: li reindirizziamo su un f
 log PRIMA di importare 'app' (che al caricamento stampa e carica il modello), cosi'
 nessun print() fa crashare il processo e i problemi restano diagnosticabili.
 
-Porta: 5005 (override con la variabile d'ambiente PII_PORT). NB: la 5000 su macOS
-e' occupata da AirPlay Receiver (ControlCenter) -> pagina bianca.
-Log:   %LOCALAPPDATA%\\rizzo-pii\\backend.log
+Configurazione host/porta:
+  1) CLI args (--host / --port)   -\u003e  precedenza massima
+  2) env PII_HOST / PII_PORT     -\u003e  passati da Tauri (lib.rs)
+  3) config.json                 -\u003e  salvato da Tauri o dall'UI Flask
+  4) default 127.0.0.1:5005
+
+NB: la 5000 su macOS e' occupata da AirPlay Receiver (ControlCenter) -\u003e pagina bianca.
+Log:   %LOCALAPPDATA%\\\\rizzo-pii\\\\backend.log
+
+Il processo esce con codice 76 (EX_PROTOCOL) se la porta e' occupata: Tauri lo
+riconosce e mostra il form di configurazione nello splash screen.
 """
 
 import os
 import sys
-
-PORT = int(os.environ.get("PII_PORT", "5005"))
 
 # --- log su file (windowed mode -> niente console) ------------------------- #
 _logdir = os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")), "rizzo-pii")
@@ -30,9 +36,23 @@ try:
 except Exception:
     pass  # se non si puo' loggare, si prosegue comunque
 
+import server_config  # noqa: E402
+
+HOST, PORT = server_config.resolve()
+
+# --- pre-check porta PRIMA di caricare il modello (che richiede secondi) --- #
+if not server_config.port_available(HOST, PORT):
+    print(f"[serve] ERRORE: porta {PORT} occupata su {HOST}")
+    sys.exit(server_config.EXIT_PORT_CONFLICT)
+
 # l'import carica il modello (puo' richiedere alcuni secondi)
 from app import app  # noqa: E402
 
 if __name__ == "__main__":
-    print(f"[serve] avvio server su 127.0.0.1:{PORT}")
-    app.run(host="127.0.0.1", port=PORT, threaded=True)
+    print(f"[serve] avvio server su {HOST}:{PORT}")
+    try:
+        app.run(host=HOST, port=PORT, threaded=True)
+    except OSError as e:
+        # sicurezza extra: se il bind fallisce nonostante il pre-check (race condition)
+        print(f"[serve] ERRORE bind: {e}")
+        sys.exit(server_config.EXIT_PORT_CONFLICT)

--- a/src/app/server_config.py
+++ b/src/app/server_config.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Configurazione host/porta del server Flask (condivisa tra tutti gli entry point).
+
+Risoluzione con precedenza:  CLI args  >  env vars  >  config.json  >  default.
+
+Il file config.json e' condiviso con l'app Tauri (che lo legge/scrive dal lato Rust
+e passa host/porta al sidecar via env PII_HOST/PII_PORT):
+
+  Windows:  %LOCALAPPDATA%\\rizzo-pii\\config.json
+  Linux:    ~/.local/share/rizzo-pii/config.json
+  macOS:    ~/Library/Application Support/rizzo-pii/config.json
+
+Formato:  {"host": "127.0.0.1", "port": 5005}
+
+Il codice di uscita 76 (EX_PROTOCOL) segnala "porta occupata" ed e' riconosciuto
+dall'app Tauri per mostrare il form di configurazione nello splash.
+"""
+
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 5005
+EXIT_PORT_CONFLICT = 76  # riconosciuto da Tauri (lib.rs) come "porta occupata"
+
+
+def config_dir() -> Path:
+    """Directory di configurazione (platform-specific, coerente con serve.py e Tauri)."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home()))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "rizzo-pii"
+
+
+def config_path() -> Path:
+    return config_dir() / "config.json"
+
+
+def load_config() -> dict:
+    """Legge config.json; ritorna {} se mancante o corrotto."""
+    p = config_path()
+    if p.exists():
+        try:
+            return json.loads(p.read_text("utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def save_config(host: str, port: int):
+    """Scrive config.json (crea la directory se necessario)."""
+    d = config_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.json").write_text(
+        json.dumps({"host": host, "port": port}, indent=2), "utf-8"
+    )
+
+
+def resolve(cli_host=None, cli_port=None):
+    """Risolve host/porta con la catena: CLI > env > config.json > default.
+
+    Ritorna (host: str, port: int).
+    """
+    cfg = load_config()
+    host = cli_host or os.environ.get("PII_HOST") or cfg.get("host") or DEFAULT_HOST
+    port = cli_port or os.environ.get("PII_PORT") or cfg.get("port") or DEFAULT_PORT
+    return str(host), int(port)
+
+
+def port_available(host: str, port: int) -> bool:
+    """True se la porta e' libera (tenta un bind effimero)."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind((host, port))
+            return True
+    except OSError:
+        return False

--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -51,6 +51,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
  "tauri",

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -21,3 +21,4 @@ tauri-build = { version = "2.6.3", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.11.3", features = [] }
+dirs = "6"

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -4,65 +4,360 @@
 // PyInstaller e incluso come risorsa ("backend/pii-backend/pii-backend.exe"). Tauri fa da
 // finestra nativa: all'avvio mostra uno splash, lancia il backend come processo figlio,
 // attende che il server locale risponda e poi apre la finestra principale puntata sull'UI
-// Flask (http://127.0.0.1:5005). Alla chiusura il processo figlio viene terminato.
+// Flask. Alla chiusura il processo figlio viene terminato.
+// L'host e la porta sono configurabili via config.json (default 127.0.0.1:5005).
 // NB: porta 5005 e non 5000 perche' su macOS la 5000 e' occupata da AirPlay Receiver.
 
+use std::fs;
+use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use serde_json::json;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Logging diagnostico su file (~/rizzo-pii/tauri.log).
+/// Usa un file nella stessa directory del backend.log.
+fn tlog(msg: &str) {
+    use std::io::Write;
+    let dir = dirs::home_dir().unwrap_or_default().join("rizzo-pii");
+    let _ = fs::create_dir_all(&dir);
+    if let Ok(mut f) = fs::OpenOptions::new()
+        .create(true).append(true)
+        .open(dir.join("tauri.log"))
+    {
+        let _ = writeln!(f, "[{}] {}",
+            chrono_timestamp(), msg);
+    }
+}
+
+fn chrono_timestamp() -> String {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}.{:03}", d.as_secs(), d.subsec_millis())
+}
 
 /// Custodisce il processo del backend per poterlo terminare all'uscita.
 struct BackendProcess(Mutex<Option<Child>>);
 
-const ADDR: &str = "127.0.0.1:5005";
-const URL: &str = "http://127.0.0.1:5005";
+/// Stato condiviso: host e porta correnti letti dal config.json.
+struct ServerAddr(Mutex<(String, u16)>);
 
-/// True se il server locale accetta connessioni (= modello caricato, Flask in ascolto).
-fn backend_ready() -> bool {
-    match ADDR.parse() {
-        Ok(addr) => TcpStream::connect_timeout(&addr, Duration::from_millis(400)).is_ok(),
-        Err(_) => false,
-    }
+// ---------------------------------------------------------------------------
+// Configurazione persistente
+// ---------------------------------------------------------------------------
+
+/// Restituisce la directory di configurazione dell'app:
+/// - Windows:  %LOCALAPPDATA%\rizzo-pii
+/// - Linux:    ~/.local/share/rizzo-pii
+/// - macOS:    ~/Library/Application Support/rizzo-pii
+fn config_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("rizzo-pii")
 }
+
+/// Legge host e porta da config.json; se il file non esiste o e' malformato
+/// restituisce i default (127.0.0.1, 5005).
+fn load_config() -> (String, u16) {
+    let path = config_dir().join("config.json");
+    let default = ("127.0.0.1".to_string(), 5005u16);
+    let Ok(data) = fs::read_to_string(&path) else {
+        return default;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) else {
+        return default;
+    };
+    let host = v
+        .get("host")
+        .and_then(|h| h.as_str())
+        .unwrap_or("127.0.0.1")
+        .to_string();
+    let port = v
+        .get("port")
+        .and_then(|p| p.as_u64())
+        .map(|p| p as u16)
+        .unwrap_or(5005);
+    (host, port)
+}
+
+/// Scrive (o sovrascrive) il config.json con host e porta indicati.
+fn save_config_file(host: &str, port: u16) {
+    let dir = config_dir();
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("config.json");
+    let content = json!({ "host": host, "port": port });
+    let _ = fs::write(path, serde_json::to_string_pretty(&content).unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Utilita'
+// ---------------------------------------------------------------------------
+
+/// True se sulla porta c'e' il NOSTRO Flask (non un servizio estraneo).
+/// Esegue un HTTP GET /config e verifica che la risposta contenga "config_path"
+/// (campo specifico del nostro endpoint). Se la porta e' libera, occupata da
+/// un altro processo, o il server non risponde come previsto, restituisce false.
+fn is_our_backend(host: &str, port: u16) -> bool {
+    let addr_str = format!("{}:{}", host, port);
+    let sock_addr: std::net::SocketAddr = match addr_str.parse() {
+        Ok(a) => a,
+        Err(_) => return false,
+    };
+    let mut stream = match TcpStream::connect_timeout(&sock_addr, Duration::from_millis(500)) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
+    let req = format!(
+        "GET /config HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+        addr_str
+    );
+    if stream.write_all(req.as_bytes()).is_err() {
+        return false;
+    }
+    // leggi la risposta completa (headers + body) in un loop fino a EOF/timeout
+    let mut response = Vec::with_capacity(4096);
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,                              // EOF: il server ha chiuso
+            Ok(n) => response.extend_from_slice(&buf[..n]),
+            Err(_) => break,                             // timeout o errore: basta
+        }
+    }
+    let body = String::from_utf8_lossy(&response);
+    body.contains("config_path")
+}
+
+/// Costruisce il path dell'eseguibile sidecar a partire dalla resource_dir.
+fn sidecar_exe(resource_dir: &std::path::Path) -> PathBuf {
+    let bin_name = if cfg!(windows) {
+        "pii-backend.exe"
+    } else {
+        "pii-backend"
+    };
+    resource_dir
+        .join("backend")
+        .join("pii-backend")
+        .join(bin_name)
+}
+
+/// Lancia il sidecar impostando le variabili PII_HOST e PII_PORT.
+fn spawn_sidecar(exe: &std::path::Path, host: &str, port: u16) -> std::io::Result<Child> {
+    Command::new(exe)
+        .env("PII_HOST", host)
+        .env("PII_PORT", port.to_string())
+        .spawn()
+}
+
+// ---------------------------------------------------------------------------
+// Polling del backend con rilevamento uscita anticipata
+// ---------------------------------------------------------------------------
+
+/// Codice d'uscita che il backend usa per segnalare un conflitto di porta.
+const EXIT_PORT_CONFLICT: i32 = 76;
+
+/// Ciclo di polling: attende che il backend risponda o che il processo figlio termini.
+/// Restituisce Ok(()) se il backend e' pronto, Err(msg) se il processo e' uscito o timeout.
+fn poll_backend(
+    handle: &tauri::AppHandle,
+    host: &str,
+    port: u16,
+) -> Result<(), String> {
+    tlog(&format!("poll_backend: inizio polling su {}:{}", host, port));
+    let bp = handle.state::<BackendProcess>();
+    for i in 0..900 {
+        // fino a ~180s (primo avvio: caricamento modello)
+        // controlla PRIMA se il processo figlio e' uscito in anticipo
+        // (cosi' un exit code 76 viene rilevato subito, senza che un servizio
+        //  estraneo sulla stessa porta inganni il check di connettivita')
+        {
+            let mut guard = bp.0.lock().unwrap();
+            if let Some(ref mut child) = *guard {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        // il processo e' terminato
+                        let code = status.code().unwrap_or(-1);
+                        tlog(&format!("poll_backend: child uscito con codice {} (iter {})", code, i));
+                        // rimuovi il child morto dallo stato
+                        *guard = None;
+                        if code == EXIT_PORT_CONFLICT {
+                            // conflitto di porta: mostra il form di configurazione nello splash
+                            if let Some(splash) = handle.get_webview_window("splash") {
+                                let js = format!(
+                                    "if(typeof showConfigForm==='function'){{showConfigForm('{}',{},'Porta {} occupata. Scegli un\\'altra porta.')}}",
+                                    host, port, port
+                                );
+                                let _ = splash.eval(&js);
+                            }
+                            return Err(format!("porta {} occupata (exit code 76)", port));
+                        } else {
+                            // errore generico
+                            if let Some(splash) = handle.get_webview_window("splash") {
+                                let _ = splash.eval(
+                                    "var n=document.querySelector('.note');\
+                                     if(n){n.textContent='Errore: il backend si è chiuso inaspettatamente.';}\
+                                     var b=document.querySelector('.bar');if(b){b.style.display='none';}",
+                                );
+                            }
+                            return Err(format!(
+                                "backend uscito con codice {}",
+                                code
+                            ));
+                        }
+                    }
+                    Ok(None) => {} // ancora in esecuzione, continua il polling
+                    Err(_) => {}   // errore nel try_wait, ignora e continua
+                }
+            }
+        }
+        // verifica HTTP: il backend e' il NOSTRO Flask? (non un servizio estraneo)
+        if is_our_backend(host, port) {
+            tlog(&format!("poll_backend: backend pronto (iter {})", i));
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    // timeout raggiunto
+    if let Some(splash) = handle.get_webview_window("splash") {
+        let _ = splash.eval(
+            "var n=document.querySelector('.note');\
+             if(n){n.textContent='Errore: il backend non si è avviato. \
+             Vedi il log in %LOCALAPPDATA%\\\\rizzo-pii\\\\backend.log';}\
+             var b=document.querySelector('.bar');if(b){b.style.display='none';}",
+        );
+    }
+    Err("timeout in attesa del backend".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Comandi Tauri invocabili dal frontend (splash)
+// ---------------------------------------------------------------------------
+
+/// Salva host e porta nel config.json e aggiorna lo stato in-memory.
+#[tauri::command]
+fn save_config(host: String, port: u16, state: tauri::State<'_, ServerAddr>) {
+    tlog(&format!("save_config: {}:{}", host, port));
+    save_config_file(&host, port);
+    let mut s = state.0.lock().unwrap();
+    *s = (host, port);
+}
+
+/// Termina l'eventuale backend in esecuzione, rilegge la configurazione e rilancia il sidecar.
+#[tauri::command]
+fn retry_backend(app_handle: tauri::AppHandle) {
+    tlog("retry_backend: chiamato");
+    // termina il processo figlio precedente, se presente
+    {
+        let bp = app_handle.state::<BackendProcess>();
+        if let Some(mut child) = bp.0.lock().unwrap().take() {
+            tlog("retry_backend: killing old child");
+            let _ = child.kill();
+            let _ = child.wait();
+        };
+    }
+
+    // leggi la configurazione aggiornata dallo stato in-memory
+    let (host, port) = {
+        let s = app_handle.state::<ServerAddr>();
+        let guard = s.0.lock().unwrap();
+        guard.clone()
+    };
+    tlog(&format!("retry_backend: config {}:{}", host, port));
+    let url = format!("http://{}:{}", host, port);
+
+    // spawn del sidecar
+    if !is_our_backend(&host, port) {
+        if let Ok(dir) = app_handle.path().resource_dir() {
+            let exe = sidecar_exe(&dir);
+            tlog(&format!("retry_backend: spawn {:?}", exe));
+            match spawn_sidecar(&exe, &host, port) {
+                Ok(child) => {
+                    app_handle
+                        .state::<BackendProcess>()
+                        .0
+                        .lock()
+                        .unwrap()
+                        .replace(child);
+                }
+                Err(e) => eprintln!("avvio backend fallito ({:?}): {}", exe, e),
+            }
+        }
+    }
+
+    // polling in un thread separato
+    let handle = app_handle.clone();
+    std::thread::spawn(move || {
+        if poll_backend(&handle, &host, port).is_ok() {
+            let built = WebviewWindowBuilder::new(
+                &handle,
+                "main",
+                WebviewUrl::External(url.parse().unwrap()),
+            )
+            .title("Rizzo PII")
+            .inner_size(1240.0, 840.0)
+            .min_inner_size(900.0, 600.0)
+            .center()
+            .build();
+
+            if built.is_ok() {
+                if let Some(splash) = handle.get_webview_window("splash") {
+                    let _ = splash.close();
+                }
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let (host, port) = load_config();
+    tlog(&format!("=== AVVIO === config: {}:{}", host, port));
+
     tauri::Builder::default()
         .manage(BackendProcess(Mutex::new(None)))
-        .setup(|app| {
+        .manage(ServerAddr(Mutex::new((host.clone(), port))))
+        .invoke_handler(tauri::generate_handler![save_config, retry_backend])
+        .setup(move |app| {
             let handle = app.handle().clone();
+            let url = format!("http://{}:{}", host, port);
 
             // mostra la versione reale (da tauri.conf.json) nello splash
             let version = app.package_info().version.to_string();
             if let Some(splash) = app.get_webview_window("splash") {
                 let _ = splash.eval(&format!(
-                    "var v=document.getElementById('ver');if(v){{v.textContent='v{}';}}",
+                    "var v=document.getElementById('ver');if(v){{v.textContent='v{}';}};",
                     version
                 ));
             }
 
             // 1) avvia il backend sidecar (salvo che un'istanza sia gia' in ascolto)
-            if !backend_ready() {
+            let ours = is_our_backend(&host, port);
+            tlog(&format!("is_our_backend({}:{}): {}", host, port, ours));
+            if !ours {
                 match app.path().resource_dir() {
                     Ok(dir) => {
-                        // su Windows il sidecar PyInstaller e' pii-backend.exe, su Linux pii-backend
-                        let bin_name = if cfg!(windows) { "pii-backend.exe" } else { "pii-backend" };
-                        let exe = dir
-                            .join("backend")
-                            .join("pii-backend")
-                            .join(bin_name);
-                        match Command::new(&exe).spawn() {
+                        let exe = sidecar_exe(&dir);
+                        tlog(&format!("spawn sidecar: {:?}", exe));
+                        match spawn_sidecar(&exe, &host, port) {
                             Ok(child) => {
+                                tlog(&format!("sidecar avviato, pid={}", child.id()));
                                 app.state::<BackendProcess>()
                                     .0
                                     .lock()
                                     .unwrap()
                                     .replace(child);
                             }
-                            Err(e) => eprintln!("avvio backend fallito ({:?}): {}", exe, e),
+                            Err(e) => tlog(&format!("ERRORE spawn sidecar: {}", e)),
                         }
                     }
                     Err(e) => eprintln!("resource_dir non risolvibile: {}", e),
@@ -70,22 +365,13 @@ pub fn run() {
             }
 
             // 2) attende il server, poi apre la finestra principale e chiude lo splash
+            let host2 = host.clone();
             std::thread::spawn(move || {
-                let mut ready = false;
-                for _ in 0..900 {
-                    // fino a ~180s (primo avvio: caricamento modello)
-                    if backend_ready() {
-                        ready = true;
-                        break;
-                    }
-                    std::thread::sleep(Duration::from_millis(200));
-                }
-
-                if ready {
+                if poll_backend(&handle, &host2, port).is_ok() {
                     let built = WebviewWindowBuilder::new(
                         &handle,
                         "main",
-                        WebviewUrl::External(URL.parse().unwrap()),
+                        WebviewUrl::External(url.parse().unwrap()),
                     )
                     .title("Rizzo PII")
                     .inner_size(1240.0, 840.0)
@@ -98,14 +384,6 @@ pub fn run() {
                             let _ = splash.close();
                         }
                     }
-                } else if let Some(splash) = handle.get_webview_window("splash") {
-                    // timeout: mostra un messaggio d'errore nello splash
-                    let _ = splash.eval(
-                        "var n=document.querySelector('.note');\
-                         if(n){n.textContent='Errore: il backend non si è avviato. \
-                         Vedi il log in %LOCALAPPDATA%\\\\rizzo-pii\\\\backend.log';}\
-                         var b=document.querySelector('.bar');if(b){b.style.display='none';}",
-                    );
                 }
             });
 

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -320,7 +320,22 @@ fn retry_backend(app_handle: tauri::AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let (host, port) = load_config();
+    let (mut host, mut port) = load_config();
+
+    // CLI args hanno precedenza sul config.json (stessa catena di serve.py)
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1; // salta argv[0]
+    while i < args.len() {
+        match args[i].as_str() {
+            "--host" if i + 1 < args.len() => { host = args[i + 1].clone(); i += 2; }
+            "--port" if i + 1 < args.len() => {
+                if let Ok(p) = args[i + 1].parse::<u16>() { port = p; }
+                i += 2;
+            }
+            _ => { i += 1; }
+        }
+    }
+
     tlog(&format!("=== AVVIO === config: {}:{}", host, port));
 
     tauri::Builder::default()

--- a/tauri/ui/index.html
+++ b/tauri/ui/index.html
@@ -39,6 +39,25 @@
   .foot .by{font-size:11.5px;color:#6b7383;line-height:1.5}
   .foot .by b{font-weight:700;color:#1c2330}
   .foot .url{font-size:11.5px;font-weight:600;color:#c1121f}
+
+  /* form di configurazione host/porta */
+  .cfg-form{display:none;flex-direction:column;align-items:center;gap:14px;
+            background:#fff;border:1px solid #e6e9f0;border-radius:14px;
+            padding:22px 28px;box-shadow:0 2px 8px rgba(20,28,46,.08);
+            max-width:320px;width:100%;box-sizing:border-box}
+  .cfg-form .cfg-err{font-size:12.5px;color:#c1121f;text-align:center;
+                     line-height:1.5;margin:0;font-weight:600}
+  .cfg-form label{font-size:12.5px;font-weight:600;color:#1c2330;width:100%;
+                  display:flex;flex-direction:column;gap:4px}
+  .cfg-form input{width:100%;box-sizing:border-box;padding:7px 10px;
+                  border:1px solid #d0d4dd;border-radius:8px;font-size:13px;
+                  font-family:inherit;outline:none;transition:border .15s}
+  .cfg-form input:focus{border-color:#c1121f}
+  .cfg-form button{width:100%;padding:9px 0;border:none;border-radius:8px;
+                   background:linear-gradient(135deg,#c1121f,#7d0a12);color:#fff;
+                   font-size:13.5px;font-weight:700;cursor:pointer;letter-spacing:.01em;
+                   transition:opacity .15s}
+  .cfg-form button:hover{opacity:.88}
 </style>
 </head>
 <body>
@@ -61,11 +80,23 @@
     </div>
 
     <!-- mascotte + titolo + caricamento -->
-    <div class="center">
+    <div class="center" id="loadingBlock">
       <img id="mascot" src="mascot.png" alt="Rizzo PII">
       <h1>Rizzo PII</h1>
       <div class="bar"><i></i></div>
       <p class="note">Avvio del modello in corso…<br>il primo avvio può richiedere qualche secondo.</p>
+    </div>
+
+    <!-- form configurazione host/porta (nascosto di default) -->
+    <div class="cfg-form" id="configForm">
+      <p class="cfg-err" id="cfgErr"></p>
+      <label>Host
+        <input type="text" id="cfgHost" value="127.0.0.1" spellcheck="false" autocomplete="off">
+      </label>
+      <label>Porta
+        <input type="number" id="cfgPort" value="5005" min="1024" max="65535">
+      </label>
+      <button type="button" id="cfgSave">Salva e riprova</button>
     </div>
 
     <!-- versione -->
@@ -85,6 +116,56 @@
     var pre = new Image(); pre.src = imgs[1];
     setInterval(function(){ i = (i + 1) % 2; el.src = imgs[i]; }, 30000);
   })();
+
+  // -----------------------------------------------------------------------
+  // Funzioni per il form di configurazione (chiamate dal backend Rust)
+  // -----------------------------------------------------------------------
+
+  /** Mostra il form di configurazione con i valori precompilati e un messaggio d'errore. */
+  function showConfigForm(host, port, errorMsg) {
+    document.getElementById('loadingBlock').style.display = 'none';
+    var form = document.getElementById('configForm');
+    form.style.display = 'flex';
+    document.getElementById('cfgErr').textContent = errorMsg || '';
+    document.getElementById('cfgHost').value = host || '127.0.0.1';
+    document.getElementById('cfgPort').value = port || 5005;
+  }
+
+  /** Nasconde il form e rimostra la barra di caricamento con messaggio "Nuovo tentativo…". */
+  function showRetrying() {
+    document.getElementById('configForm').style.display = 'none';
+    var lb = document.getElementById('loadingBlock');
+    lb.style.display = 'flex';
+    var bar = lb.querySelector('.bar');
+    if (bar) bar.style.display = '';
+    var note = lb.querySelector('.note');
+    if (note) note.textContent = 'Nuovo tentativo di avvio…';
+  }
+
+  // Handler del bottone "Salva e riprova"
+  document.getElementById('cfgSave').addEventListener('click', function() {
+    var host = document.getElementById('cfgHost').value.trim();
+    var port = parseInt(document.getElementById('cfgPort').value, 10);
+    var errEl = document.getElementById('cfgErr');
+
+    if (!host) { errEl.textContent = 'Inserisci un host valido.'; return; }
+    if (isNaN(port) || port < 1024 || port > 65535) {
+      errEl.textContent = 'La porta deve essere tra 1024 e 65535.';
+      return;
+    }
+
+    showRetrying();
+
+    // Chiama i comandi Tauri v2: usa l'IPC bridge interno (sempre disponibile)
+    window.__TAURI_INTERNALS__.invoke('save_config', { host: host, port: port })
+      .then(function() {
+        return window.__TAURI_INTERNALS__.invoke('retry_backend');
+      })
+      .catch(function(e) {
+        console.error('Errore invoke:', e);
+        showConfigForm(host, port, 'Errore interno: ' + e);
+      });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
# feat: configurable host/port with port-conflict recovery

## What

Adds configurable host/port for the Tauri ↔ Flask backend connection, with
automatic detection and recovery when the configured port is already in use.

**Before:** host and port were hardcoded to `127.0.0.1:5005`. If anything else
held port 5005, the app showed a blank "Connection refused" page with no way to
recover.

**After:** host/port are resolved from a priority chain (CLI → env → config.json
→ default). When the port is busy, the sidecar exits with code 76 and Tauri
shows a configuration form in the splash screen, letting the user pick a
different port and retry — all without restarting the app.

## Why

On macOS port 5000 was already moved to 5005 (AirPlay Receiver), but any local
service can still collide with the default port. Users need a way to change it
and recover gracefully.

## Changes

### Python backend (`src/app/`)

| File | Change |
|---|---|
| **`server_config.py`** [NEW] | Config resolution module: CLI args → `PII_HOST`/`PII_PORT` env → `config.json` → defaults. Exports `resolve()`, `port_available()`, `EXIT_PORT_CONFLICT = 76`. |
| **`serve.py`** | Pre-checks port availability *before* loading the model (~30s). Exits with code 76 if busy. Logs to `~/rizzo-pii/backend.log`. |
| **`app.py`** | Adds `/config` GET endpoint (returns `{config_path, host, port}`) used by Tauri to distinguish our Flask from a foreign server on the same port. |
| **`desktop_app.py`** | Passes `--host`/`--port` CLI args through to the server. |

### Tauri shell (`tauri/`)

| File | Change |
|---|---|
| **`src/lib.rs`** | Major rework. Adds `is_our_backend()` (HTTP health check to `/config`) to distinguish our Flask from foreign servers. Polling loop checks child exit code *before* connectivity. `save_config` / `retry_backend` IPC commands. File-based diagnostic logging (`~/rizzo-pii/tauri.log`). |
| **`Cargo.toml`** | Adds `dirs` crate for cross-platform config directory. |
| **`ui/index.html`** | Adds config form (host/port inputs + "Salva e riprova" button) in the splash screen. Uses `__TAURI_INTERNALS__.invoke()` (Tauri v2 IPC). |

### Other

| File | Change |
|---|---|
| **`.env.example`** | Documents `PII_HOST` / `PII_PORT` env vars. |
| **`CLAUDE.md`** | Documents the new config resolution chain and exit code 76 protocol. |
| **`create_mock_model.py`** [NEW] | Utility script to generate a mock model for build verification (not shipped). |

## How it works

```
┌─────────┐  spawn + PII_PORT env   ┌──────────┐
│  Tauri   │ ──────────────────────► │ sidecar  │
│ (lib.rs) │                         │(serve.py)│
│          │ ◄── exit code 76 ────── │          │  port busy
│          │                         └──────────┘
│  show    │
│  config  │  user changes port
│  form    │ ──── save_config ────►  config.json
│          │ ──── retry_backend ──►  new sidecar on new port
│          │ ◄── poll is_our_backend ── GET /config ── "config_path" ✓
│  open    │
│  main    │
│  window  │
└─────────┘
```

## Testing

1. Hold a port: `python3 -c "import socket; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('127.0.0.1',5005)); s.listen(); print('ok'); [s.accept()[0].close() for _ in iter(int,1)]"`
2. Launch the app → splash detects port conflict → config form appears
3. Change port to 5006 → "Salva e riprova" → app starts normally on 5006
4. Kill the socket, relaunch → app starts on 5005 (default) with no issues
