### PR TITLE
[codex] add reproducible TARGA generator and stress test

### DIFF
--- a/docs/targa_generation_notes.md
+++ b/docs/targa_generation_notes.md
@@ -1,0 +1,72 @@
+# Generazione sintetica TARGA
+
+`src/data_pipeline/generate_targa_it.py` genera un corpus italiano mirato alla
+disambiguazione contestuale delle targhe.
+
+Il corpus contiene:
+
+- **40% positivi**: targhe in contesti automobilistici, assicurativi e legali;
+- **30% hard negative**: codici con forma `AA999AA` usati come ordini, ticket,
+  password o identificativi documentali;
+- **30% mixed PII**: targa insieme a nomi, organizzazioni, indirizzi, e-mail,
+  telefoni e partite IVA valide.
+
+Esecuzione riproducibile:
+
+```powershell
+python src/data_pipeline/generate_targa_it.py `
+  -n 3000 `
+  --seed 20260704 `
+  --out dataset/synthetic/synthetic_targa_it_3k.jsonl
+```
+
+Ogni record viene validato prima della scrittura:
+
+- tokenizzazione conforme a `docs/FORMATO_DATI.md`;
+- stessa lunghezza per `tokens` e `bio_labels`;
+- offset delle entità coerenti con `source_text`;
+- label BIO ricalcolate dagli offset;
+- nessun `source_text` duplicato.
+
+Con seed `20260704` il generatore riproduce byte per byte il file proposto nella
+[PR dataset #2](https://huggingface.co/datasets/rizzoaiacademy/rizzo-pii-it-dataset/discussions/2):
+SHA-256 `F84E1771749F8D452C600E96990E269D1B701C06F198AC7C93D3B7A17F717098`.
+
+Nota di produzione: gli hard negative migliorano il modello, ma l'applicazione
+desktop assegna attualmente priorità alla regex TARGA. Per trasferire il beneficio
+all'app, la regex dovrà diventare un candidato contestuale invece di un override.
+
+## Stress test separato dal training
+
+Lo stress test usa famiglie di template diverse da quelle dei 3.000 record e non
+deve essere aggiunto al training:
+
+```powershell
+python src/data_pipeline/generate_targa_stress.py
+python src/training/evaluate_targa_stress.py
+```
+
+Produce 300 righe bilanciate:
+
+- 100 targhe positive in contesti non presenti nel training;
+- 100 codici `AA999AA` semanticamente non riferiti a veicoli;
+- 100 targhe insieme ad altre PII.
+
+La valutazione confronta il modello neurale puro con la pipeline usata
+dall'applicazione (`modello + regex`) usando match esatto degli offset di `TARGA`.
+Il report include precision, recall, F1, quota di documenti completamente corretti
+e falsi positivi sugli hard negative.
+
+### Baseline v1.2.0
+
+Sul modello `rizzo-pii-0.3B-v1.2.0`:
+
+| Pipeline | Precision | Recall | F1 | Documenti esatti | Hard negative con FP |
+|---|---:|---:|---:|---:|---:|
+| Modello puro | 0,295 | 0,600 | 0,395 | 39,3% | 100/100 |
+| Modello + regex | 0,575 | 0,900 | 0,702 | 59,7% | 100/100 |
+
+La regex migliora nettamente la copertura dei positivi, ma marca come `TARGA`
+tutti i 100 codici formalmente validi usati come password, ordini, ticket o altri
+identificativi. Lo stress test rende quindi misurabile il compromesso che i nuovi
+hard negative intendono correggere.

--- a/reports/targa_stress_baseline.json
+++ b/reports/targa_stress_baseline.json
@@ -1,0 +1,490 @@
+{
+  "generated_at": "2026-07-05T19:33:50.860688+00:00",
+  "model": "rizzo-pii-0.3B-v1.2.0",
+  "dataset": "dataset/validation/validation_targa_it_stress_300.jsonl",
+  "rows": 300,
+  "metric": "exact character-span match for TARGA",
+  "raw_model": {
+    "overall": {
+      "tp": 120,
+      "fp": 287,
+      "fn": 80,
+      "documents": 300,
+      "documents_exact": 118,
+      "documents_with_fp": 171,
+      "precision": 0.29484,
+      "recall": 0.6,
+      "f1": 0.395387,
+      "document_exact_rate": 0.393333,
+      "false_positive_document_rate": 0.57
+    },
+    "by_category": {
+      "hard_negative": {
+        "tp": 0,
+        "fp": 163,
+        "fn": 0,
+        "documents": 100,
+        "documents_exact": 0,
+        "documents_with_fp": 100,
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": 0.0,
+        "document_exact_rate": 0.0,
+        "false_positive_document_rate": 1.0
+      },
+      "mixed_pii": {
+        "tp": 56,
+        "fp": 67,
+        "fn": 44,
+        "documents": 100,
+        "documents_exact": 54,
+        "documents_with_fp": 40,
+        "precision": 0.455285,
+        "recall": 0.56,
+        "f1": 0.502242,
+        "document_exact_rate": 0.54,
+        "false_positive_document_rate": 0.4
+      },
+      "positive": {
+        "tp": 64,
+        "fp": 57,
+        "fn": 36,
+        "documents": 100,
+        "documents_exact": 64,
+        "documents_with_fp": 31,
+        "precision": 0.528926,
+        "recall": 0.64,
+        "f1": 0.579186,
+        "document_exact_rate": 0.64,
+        "false_positive_document_rate": 0.31
+      }
+    }
+  },
+  "model_plus_regex": {
+    "overall": {
+      "tp": 180,
+      "fp": 133,
+      "fn": 20,
+      "documents": 300,
+      "documents_exact": 179,
+      "documents_with_fp": 116,
+      "precision": 0.57508,
+      "recall": 0.9,
+      "f1": 0.701754,
+      "document_exact_rate": 0.596667,
+      "false_positive_document_rate": 0.386667
+    },
+    "by_category": {
+      "hard_negative": {
+        "tp": 0,
+        "fp": 100,
+        "fn": 0,
+        "documents": 100,
+        "documents_exact": 0,
+        "documents_with_fp": 100,
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": 0.0,
+        "document_exact_rate": 0.0,
+        "false_positive_document_rate": 1.0
+      },
+      "mixed_pii": {
+        "tp": 93,
+        "fp": 8,
+        "fn": 7,
+        "documents": 100,
+        "documents_exact": 92,
+        "documents_with_fp": 5,
+        "precision": 0.920792,
+        "recall": 0.93,
+        "f1": 0.925373,
+        "document_exact_rate": 0.92,
+        "false_positive_document_rate": 0.05
+      },
+      "positive": {
+        "tp": 87,
+        "fp": 25,
+        "fn": 13,
+        "documents": 100,
+        "documents_exact": 87,
+        "documents_with_fp": 11,
+        "precision": 0.776786,
+        "recall": 0.87,
+        "f1": 0.820755,
+        "document_exact_rate": 0.87,
+        "false_positive_document_rate": 0.11
+      }
+    }
+  },
+  "error_examples": {
+    "raw_model": [
+      {
+        "category": "mixed_pii",
+        "text": "La segnalazione di Franco Gallo, inviata da arianna.conte@example.it, riguarda JD509PK.",
+        "expected": [
+          [
+            79,
+            86
+          ]
+        ],
+        "predicted": [
+          [
+            79,
+            82
+          ],
+          [
+            84,
+            86
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "Il mezzo FL141FY è assegnato a Industriale Padana S. de R.L. e affidato a Diego Sorrentino.",
+        "expected": [
+          [
+            9,
+            16
+          ]
+        ],
+        "predicted": [
+          [
+            9,
+            16
+          ],
+          [
+            90,
+            91
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "Per informazioni su AK-202-XT, scrivere a giuseppe.pellegrino@example.it indicando Debora Gentile.",
+        "expected": [
+          [
+            20,
+            29
+          ]
+        ],
+        "predicted": []
+      },
+      {
+        "category": "hard_negative",
+        "text": "Inserire XX941CZ nel campo codice di verifica.",
+        "expected": [],
+        "predicted": [
+          [
+            9,
+            11
+          ],
+          [
+            14,
+            16
+          ]
+        ]
+      },
+      {
+        "category": "positive",
+        "text": "La vettura sostava in doppia fila: HD-412-KC.",
+        "expected": [
+          [
+            35,
+            44
+          ]
+        ],
+        "predicted": [
+          [
+            35,
+            41
+          ],
+          [
+            42,
+            44
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il lotto farmaceutico SA619KH è stato richiamato.",
+        "expected": [],
+        "predicted": [
+          [
+            22,
+            29
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "Silvio Ceccarelli ha ritirato MY584PM; recapito telefonico +39 316 8141117.",
+        "expected": [
+          [
+            30,
+            37
+          ]
+        ],
+        "predicted": [
+          [
+            30,
+            33
+          ],
+          [
+            35,
+            37
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il buono sconto RV271MM può essere utilizzato una sola volta.",
+        "expected": [],
+        "predicted": [
+          [
+            16,
+            19
+          ],
+          [
+            19,
+            23
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "La segnalazione di Cosimo Di Maio, inviata da ennio.esposito@example.it, riguarda JB 189 XN.",
+        "expected": [
+          [
+            82,
+            91
+          ]
+        ],
+        "predicted": []
+      },
+      {
+        "category": "positive",
+        "text": "Nel box numero sette era parcheggiata KM-239-YE.",
+        "expected": [
+          [
+            38,
+            47
+          ]
+        ],
+        "predicted": [
+          [
+            38,
+            40
+          ],
+          [
+            41,
+            44
+          ],
+          [
+            45,
+            47
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "Per informazioni su BA 721 FV, scrivere a mattia.greco@example.it indicando Arianna Pellegrini.",
+        "expected": [
+          [
+            20,
+            29
+          ]
+        ],
+        "predicted": [
+          [
+            20,
+            22
+          ],
+          [
+            25,
+            29
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Inserire JJ498PZ nel campo codice di verifica.",
+        "expected": [],
+        "predicted": [
+          [
+            9,
+            12
+          ],
+          [
+            14,
+            16
+          ]
+        ]
+      }
+    ],
+    "model_plus_regex": [
+      {
+        "category": "mixed_pii",
+        "text": "Il mezzo FL141FY è assegnato a Industriale Padana S. de R.L. e affidato a Diego Sorrentino.",
+        "expected": [
+          [
+            9,
+            16
+          ]
+        ],
+        "predicted": [
+          [
+            9,
+            16
+          ],
+          [
+            90,
+            91
+          ]
+        ]
+      },
+      {
+        "category": "mixed_pii",
+        "text": "Per informazioni su AK-202-XT, scrivere a giuseppe.pellegrino@example.it indicando Debora Gentile.",
+        "expected": [
+          [
+            20,
+            29
+          ]
+        ],
+        "predicted": []
+      },
+      {
+        "category": "hard_negative",
+        "text": "Inserire XX941CZ nel campo codice di verifica.",
+        "expected": [],
+        "predicted": [
+          [
+            9,
+            16
+          ]
+        ]
+      },
+      {
+        "category": "positive",
+        "text": "La vettura sostava in doppia fila: HD-412-KC.",
+        "expected": [
+          [
+            35,
+            44
+          ]
+        ],
+        "predicted": [
+          [
+            35,
+            41
+          ],
+          [
+            42,
+            44
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il lotto farmaceutico SA619KH è stato richiamato.",
+        "expected": [],
+        "predicted": [
+          [
+            22,
+            29
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il buono sconto RV271MM può essere utilizzato una sola volta.",
+        "expected": [],
+        "predicted": [
+          [
+            16,
+            23
+          ]
+        ]
+      },
+      {
+        "category": "positive",
+        "text": "Nel box numero sette era parcheggiata KM-239-YE.",
+        "expected": [
+          [
+            38,
+            47
+          ]
+        ],
+        "predicted": [
+          [
+            38,
+            40
+          ],
+          [
+            41,
+            44
+          ],
+          [
+            45,
+            47
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Inserire JJ498PZ nel campo codice di verifica.",
+        "expected": [],
+        "predicted": [
+          [
+            9,
+            16
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "La pratica software usa come chiave interna ZW934MP.",
+        "expected": [],
+        "predicted": [
+          [
+            44,
+            51
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "L'ordine web YV958RH è stato rimborsato.",
+        "expected": [],
+        "predicted": [
+          [
+            13,
+            20
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il numero della richiesta tecnica è ED595FM.",
+        "expected": [],
+        "predicted": [
+          [
+            36,
+            43
+          ]
+        ]
+      },
+      {
+        "category": "hard_negative",
+        "text": "Il codice del componente sostituito è DK230XL.",
+        "expected": [],
+        "predicted": [
+          [
+            38,
+            45
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/src/data_pipeline/generate_targa_it.py
+++ b/src/data_pipeline/generate_targa_it.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Genera esempi sintetici italiani mirati alla disambiguazione di TARGA.
+
+Il dataset contiene tre famiglie:
+  * positive: una targa in contesto automobilistico;
+  * hard_negative: un codice con forma da targa usato con un altro significato;
+  * mixed_pii: una targa insieme ad altre PII.
+
+L'output segue docs/FORMATO_DATI.md e viene validato prima della scrittura.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src" / "data_pipeline"))
+
+import generate_synthetic_pii as base  # noqa: E402
+
+
+GENERATOR_VERSION = "targa-it-1.0.0"
+DEFAULT_SEED = 20260704
+DEFAULT_OUT = ROOT / "dataset" / "synthetic" / "synthetic_targa_it_3k.jsonl"
+
+POSITIVE_TEMPLATES = [
+    "Il veicolo con targa {TARGA} è stato sottoposto a sequestro.",
+    "Dal verbale risulta il transito dell'autovettura targata {TARGA}.",
+    "La copertura assicurativa del mezzo {TARGA} scade il prossimo mese.",
+    "Nel sinistro è rimasto coinvolto il veicolo identificato dalla targa {TARGA}.",
+    "Targa del veicolo: {TARGA}.",
+    "Il contratto di leasing riguarda l'automobile {TARGA}.",
+    "La Polizia Locale ha identificato il mezzo targato {TARGA}.",
+    "Il fermo amministrativo è stato iscritto sul veicolo {TARGA}.",
+    "Nel registro PRA il mezzo risulta associato alla targa {TARGA}.",
+    "L'officina ha preso in consegna l'autovettura {TARGA} per la riparazione.",
+    "Si richiede la restituzione del veicolo recante targa {TARGA}.",
+    "Il conducente viaggiava a bordo del mezzo con targa {TARGA}.",
+    "Dati identificativi del veicolo — {TARGA}.",
+    "La fotografia allegata mostra chiaramente la targa {TARGA}.",
+    "Il bene pignorato è l'autoveicolo targato {TARGA}.",
+    "Automezzo aziendale {TARGA}, immatricolato in Italia.",
+    "La targa rilevata dal dispositivo elettronico è {TARGA}.",
+    "Per il veicolo {TARGA} è stata presentata denuncia di furto.",
+    "Il passaggio di proprietà interessa la vettura {TARGA}.",
+    "Mezzo sostitutivo consegnato: targa {TARGA}.",
+]
+
+NEGATIVE_O_TEMPLATES = [
+    "Il codice dell'ordine è {CODE}.",
+    "Usare la password temporanea {CODE} al primo accesso.",
+    "Il ticket di assistenza {CODE} è stato chiuso.",
+    "Il coupon promozionale {CODE} non è più valido.",
+    "La spedizione è identificata dal codice {CODE}.",
+    "Il lotto di produzione {CODE} ha superato il collaudo.",
+    "Inserire il codice sessione {CODE} per continuare.",
+    "La richiesta interna {CODE} è in attesa di approvazione.",
+    "Il codice articolo {CODE} non è disponibile a magazzino.",
+    "La chiave di recupero {CODE} scade tra dieci minuti.",
+    "Il riferimento del pagamento è {CODE}.",
+    "La prenotazione {CODE} è stata annullata.",
+]
+
+NEGATIVE_DOCID_TEMPLATES = [
+    "La pratica amministrativa {CODE} è stata archiviata.",
+    "Il fascicolo interno {CODE} è assegnato all'ufficio competente.",
+    "Il protocollo {CODE} è richiamato nella comunicazione.",
+    "Il procedimento identificato come {CODE} risulta ancora pendente.",
+]
+
+MIXED_TEMPLATES = [
+    "Il veicolo con targa {TARGA} è intestato a {FULLNAME}.",
+    "L'automezzo {TARGA} appartiene a {ORG}, P. IVA {PIVA}.",
+    "Il mezzo targato {TARGA} è custodito presso {ADDRESS}.",
+    "{FULLNAME} ha denunciato il furto dell'autovettura {TARGA}.",
+    "La società {ORG} utilizza il veicolo aziendale {TARGA}.",
+    "Per il veicolo {TARGA} contattare {EMAIL} o il numero {PHONE}.",
+    "Il contratto tra {FULLNAME} e {ORG} riguarda il mezzo {TARGA}.",
+    "La fattura di {ORG}, P. IVA {PIVA}, riporta la targa {TARGA}.",
+    "Il veicolo {TARGA}, intestato a {FULLNAME}, risulta domiciliato in {ADDRESS}.",
+    "{ORG} ha consegnato a {FULLNAME} l'automezzo targato {TARGA}.",
+    "Nel verbale relativo a {TARGA} compare il nominativo {FULLNAME}.",
+    "La richiesta inviata da {EMAIL} riguarda il veicolo {TARGA}.",
+]
+
+
+def plate_code() -> str:
+    letters = base.PLATE_LETTERS
+    return (
+        "".join(random.choice(letters) for _ in range(2))
+        + f"{random.randint(100, 999)}"
+        + "".join(random.choice(letters) for _ in range(2))
+    )
+
+
+def plate_value() -> str:
+    code = plate_code()
+    style = random.choices(("compact", "spaces", "hyphens"), (50, 35, 15), k=1)[0]
+    if style == "spaces":
+        return f"{code[:2]} {code[2:5]} {code[5:]}"
+    if style == "hyphens":
+        return f"{code[:2]}-{code[2:5]}-{code[5:]}"
+    return code
+
+
+def full_name_piece():
+    given, surname, _ = base._person()
+    return [(f"{given} {surname}", "FULLNAME")]
+
+
+def piva_ok(value: str) -> bool:
+    digits = "".join(character for character in value if character.isdigit())
+    if len(digits) != 11:
+        return False
+    total = 0
+    for index, character in enumerate(digits[:10]):
+        number = int(character)
+        if index % 2:
+            number *= 2
+            if number > 9:
+                number -= 9
+        total += number
+    return (10 - total % 10) % 10 == int(digits[-1])
+
+
+def render(template: str, slots: dict[str, list[tuple[str, str | None]]]):
+    text = ""
+    entities = []
+    for part in re.split(r"(\{\w+\})", template):
+        match = base.SLOT_RE.fullmatch(part)
+        if not match:
+            text += part
+            continue
+        for value, label in slots[match.group(1)]:
+            start = len(text)
+            text += value
+            if label:
+                entities.append(
+                    {"value": value, "label": label, "start": start, "end": len(text)}
+                )
+    return text, entities
+
+
+def mixed_slots():
+    return {
+        "TARGA": [(plate_value(), "TARGA")],
+        "FULLNAME": full_name_piece(),
+        "ORG": base.org_piece(),
+        "PIVA": base.piva_piece(),
+        "ADDRESS": base.address(),
+        "EMAIL": base.email_piece(),
+        "PHONE": base.phone_piece(),
+    }
+
+
+def make_record(kind: str, index: int, seed: int):
+    if kind == "positive":
+        template = random.choice(POSITIVE_TEMPLATES)
+        text, entities = render(template, {"TARGA": [(plate_value(), "TARGA")]})
+    elif kind == "hard_negative":
+        code = plate_code()
+        if random.random() < 0.25:
+            template = random.choice(NEGATIVE_DOCID_TEMPLATES)
+            label = "DOCID"
+        else:
+            template = random.choice(NEGATIVE_O_TEMPLATES)
+            label = None
+        text, entities = render(template, {"CODE": [(code, label)]})
+    elif kind == "mixed_pii":
+        template = random.choice(MIXED_TEMPLATES)
+        text, entities = render(template, mixed_slots())
+    else:
+        raise ValueError(f"categoria sconosciuta: {kind}")
+
+    tokens, bio = base.to_bio(text, entities)
+    return {
+        "source_text": text,
+        "language": "it",
+        "tokens": tokens,
+        "bio_labels": bio,
+        "entities": entities,
+        "meta": {
+            "contributor": "rizzoaiacademy",
+            "seed": seed,
+            "generator_version": GENERATOR_VERSION,
+            "synthetic": True,
+            "category": kind,
+            "row_index": index,
+        },
+    }
+
+
+def validate_record(record: dict) -> None:
+    text = record["source_text"]
+    expected_tokens = base.TOKEN_RE.findall(text)
+    if record["tokens"] != expected_tokens:
+        raise ValueError("tokenizzazione non coerente")
+    if len(record["tokens"]) != len(record["bio_labels"]):
+        raise ValueError("tokens e bio_labels hanno lunghezze diverse")
+    for entity in record["entities"]:
+        if text[entity["start"] : entity["end"]] != entity["value"]:
+            raise ValueError(f"offset non valido: {entity}")
+    expected_bio = base.to_bio(text, record["entities"])[1]
+    if record["bio_labels"] != expected_bio:
+        raise ValueError("label BIO non coerenti con le entità")
+    for entity in record["entities"]:
+        if entity["label"] == "PIVA" and not piva_ok(entity["value"]):
+            raise ValueError(f"PIVA non valida: {entity['value']}")
+
+
+def generate(n: int, seed: int):
+    random.seed(seed)
+    counts = {
+        "positive": int(n * 0.40),
+        "hard_negative": int(n * 0.30),
+    }
+    counts["mixed_pii"] = n - sum(counts.values())
+    kinds = [kind for kind, count in counts.items() for _ in range(count)]
+    random.shuffle(kinds)
+
+    rows = []
+    seen = set()
+    attempts = 0
+    while len(rows) < n:
+        attempts += 1
+        if attempts > n * 20:
+            raise RuntimeError("troppi duplicati durante la generazione")
+        kind = kinds[len(rows)]
+        record = make_record(kind, len(rows), seed)
+        if record["source_text"] in seen:
+            continue
+        validate_record(record)
+        seen.add(record["source_text"])
+        rows.append(record)
+    return rows
+
+
+def summarize(rows):
+    categories = Counter(row["meta"]["category"] for row in rows)
+    labels = Counter(
+        entity["label"] for row in rows for entity in row["entities"]
+    )
+    return categories, labels
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-n", type=int, default=3000)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+    if args.n < 1:
+        parser.error("-n deve essere positivo")
+
+    rows = generate(args.n, args.seed)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8", newline="\n") as output:
+        for row in rows:
+            output.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    categories, labels = summarize(rows)
+    print(f"Scritti {len(rows)} record validi in {args.out}")
+    print("Categorie:", dict(categories))
+    print("Entità:", dict(labels))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_pipeline/generate_targa_stress.py
+++ b/src/data_pipeline/generate_targa_stress.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Genera uno stress test TARGA sintetico, separato dai dati di training.
+
+Le famiglie di template definite qui non compaiono in generate_targa_it.py.
+Il file risultante serve solo per regression test e confronto tra modello puro
+e pipeline applicativa modello+regex; non deve entrare nel training.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PIPELINE_DIR = ROOT / "src" / "data_pipeline"
+sys.path.insert(0, str(PIPELINE_DIR))
+
+import generate_synthetic_pii as base  # noqa: E402
+import generate_targa_it as train_gen  # noqa: E402
+
+
+DEFAULT_SEED = 20260705
+DEFAULT_OUT = ROOT / "dataset" / "validation" / "validation_targa_it_stress_300.jsonl"
+GENERATOR_VERSION = "targa-stress-1.0.0"
+
+# Nessuna frase è condivisa con POSITIVE_TEMPLATES del generatore di training.
+POSITIVE_TEMPLATES = [
+    "La telecamera al varco ha registrato {TARGA} alle ore 23:14.",
+    "Sul parabrezza del mezzo {TARGA} era esposto il contrassegno scaduto.",
+    "Dalla banca dati della motorizzazione emerge {TARGA} come identificativo del mezzo.",
+    "Nel filmato si distingue l'automobile {TARGA} mentre lascia il parcheggio.",
+    "Il carro attrezzi ha rimosso {TARGA} dall'area riservata.",
+    "Alla frontiera è stato controllato il mezzo {TARGA}.",
+    "Il perito ha fotografato cofano e contrassegno posteriore di {TARGA}.",
+    "Nel box numero sette era parcheggiata {TARGA}.",
+    "La vettura sostava in doppia fila: {TARGA}.",
+    "Dal portale dell'assicuratore risulta ancora attivo il mezzo {TARGA}.",
+    "Rilevazione automatica\nmezzo: {TARGA}\nvelocità: 87 km/h.",
+    "Nel registro di ingresso compare {TARGA}, entrata alle 08:42.",
+    "Il numero impresso sulla placca posteriore era {TARGA}.",
+    "L'autorimessa conferma di avere custodito {TARGA} per tre notti.",
+    "La vettura riconsegnata al locatore riportava {TARGA}.",
+]
+
+HARD_NEGATIVE_TEMPLATES = [
+    "La password monouso comunicata al cliente è {CODE}.",
+    "Il pacco contrassegnato {CODE} è arrivato al centro logistico.",
+    "Per aprire la segnalazione indicare il ticket {CODE}.",
+    "Il buono sconto {CODE} può essere utilizzato una sola volta.",
+    "La commessa di lavorazione {CODE} termina venerdì.",
+    "Il codice del componente sostituito è {CODE}.",
+    "L'ordine web {CODE} è stato rimborsato.",
+    "La prenotazione alberghiera {CODE} comprende due camere.",
+    "Inserire {CODE} nel campo codice di verifica.",
+    "Il lotto farmaceutico {CODE} è stato richiamato.",
+    "La pratica software usa come chiave interna {CODE}.",
+    "La spedizione internazionale {CODE} è ferma in dogana.",
+    "Il coupon {CODE} è riservato ai nuovi clienti.",
+    "Il numero della richiesta tecnica è {CODE}.",
+    "La sessione {CODE} è terminata per inattività.",
+]
+
+MIXED_TEMPLATES = [
+    "{FULLNAME} ha parcheggiato {TARGA} davanti alla sede di {ORG}.",
+    "Il mezzo {TARGA} è stato consegnato a {FULLNAME} presso {ADDRESS}.",
+    "La segnalazione di {FULLNAME}, inviata da {EMAIL}, riguarda {TARGA}.",
+    "{ORG}, P. IVA {PIVA}, ha noleggiato il mezzo {TARGA}.",
+    "Per informazioni su {TARGA}, scrivere a {EMAIL} indicando {FULLNAME}.",
+    "Il custode {FULLNAME} ha registrato {TARGA} all'indirizzo {ADDRESS}.",
+    "La manutenzione di {TARGA} è stata fatturata da {ORG}, P. IVA {PIVA}.",
+    "{FULLNAME} ha ritirato {TARGA}; recapito telefonico {PHONE}.",
+    "Il mezzo {TARGA} è assegnato a {ORG} e affidato a {FULLNAME}.",
+    "La comunicazione spedita a {ADDRESS} menziona il veicolo {TARGA}.",
+]
+
+
+def stress_plate_value() -> str:
+    """Varianti plausibili ma distribuite diversamente dal training."""
+    code = train_gen.plate_code()
+    style = random.choices(("compact", "spaces", "hyphens"), (45, 40, 15), k=1)[0]
+    if style == "spaces":
+        value = f"{code[:2]} {code[2:5]} {code[5:]}"
+    elif style == "hyphens":
+        value = f"{code[:2]}-{code[2:5]}-{code[5:]}"
+    else:
+        value = code
+    # Una piccola quota riproduce trascrizioni manuali in minuscolo.
+    return value.lower() if random.random() < 0.08 else value
+
+
+def mixed_slots():
+    return {
+        "TARGA": [(stress_plate_value(), "TARGA")],
+        "FULLNAME": train_gen.full_name_piece(),
+        "ORG": base.org_piece(),
+        "PIVA": base.piva_piece(),
+        "ADDRESS": base.address(),
+        "EMAIL": base.email_piece(),
+        "PHONE": base.phone_piece(),
+    }
+
+
+def make_record(kind: str, index: int, seed: int):
+    if kind == "positive":
+        template_id = random.randrange(len(POSITIVE_TEMPLATES))
+        text, entities = train_gen.render(
+            POSITIVE_TEMPLATES[template_id],
+            {"TARGA": [(stress_plate_value(), "TARGA")]},
+        )
+    elif kind == "hard_negative":
+        template_id = random.randrange(len(HARD_NEGATIVE_TEMPLATES))
+        # Compatto e formalmente identico a una targa: il contesto è l'unico segnale.
+        text, entities = train_gen.render(
+            HARD_NEGATIVE_TEMPLATES[template_id],
+            {"CODE": [(train_gen.plate_code(), None)]},
+        )
+    elif kind == "mixed_pii":
+        template_id = random.randrange(len(MIXED_TEMPLATES))
+        text, entities = train_gen.render(MIXED_TEMPLATES[template_id], mixed_slots())
+    else:
+        raise ValueError(f"categoria sconosciuta: {kind}")
+
+    tokens, bio_labels = base.to_bio(text, entities)
+    record = {
+        "source_text": text,
+        "language": "it",
+        "tokens": tokens,
+        "bio_labels": bio_labels,
+        "entities": entities,
+        "meta": {
+            "contributor": "rizzoaiacademy",
+            "seed": seed,
+            "generator_version": GENERATOR_VERSION,
+            "synthetic": True,
+            "split": "stress",
+            "category": kind,
+            "template_id": template_id,
+            "row_index": index,
+        },
+    }
+    train_gen.validate_record(record)
+    return record
+
+
+def generate(per_category: int, seed: int):
+    random.seed(seed)
+    kinds = [
+        kind
+        for kind in ("positive", "hard_negative", "mixed_pii")
+        for _ in range(per_category)
+    ]
+    random.shuffle(kinds)
+
+    rows = []
+    seen = set()
+    while len(rows) < len(kinds):
+        record = make_record(kinds[len(rows)], len(rows), seed)
+        if record["source_text"] in seen:
+            continue
+        seen.add(record["source_text"])
+        rows.append(record)
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--per-category", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+    if args.per_category < 1:
+        parser.error("--per-category deve essere positivo")
+
+    rows = generate(args.per_category, args.seed)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8", newline="\n") as output:
+        for row in rows:
+            output.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    categories = Counter(row["meta"]["category"] for row in rows)
+    print(f"Scritti {len(rows)} record stress validi in {args.out}")
+    print("Categorie:", dict(categories))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/evaluate_targa_stress.py
+++ b/src/training/evaluate_targa_stress.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Valuta TARGA sullo stress test per modello puro e pipeline app completa."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_DIR = ROOT / "src" / "app"
+DEFAULT_DATA = ROOT / "dataset" / "validation" / "validation_targa_it_stress_300.jsonl"
+DEFAULT_OUT = ROOT / "reports" / "targa_stress_baseline.json"
+
+
+def exact_spans(entities):
+    return {
+        (int(entity["start"]), int(entity["end"]))
+        for entity in entities
+        if entity["label"] == "TARGA"
+    }
+
+
+def trim_span(text: str, start: int, end: int):
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def calculate(rows, predictions):
+    totals = {
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "documents": len(rows),
+        "documents_exact": 0,
+        "documents_with_fp": 0,
+    }
+    by_category = defaultdict(
+        lambda: {
+            "tp": 0,
+            "fp": 0,
+            "fn": 0,
+            "documents": 0,
+            "documents_exact": 0,
+            "documents_with_fp": 0,
+        }
+    )
+
+    for row, predicted in zip(rows, predictions):
+        expected = exact_spans(row["entities"])
+        category = row["meta"]["category"]
+        stats = by_category[category]
+        stats["documents"] += 1
+
+        tp = len(expected & predicted)
+        fp = len(predicted - expected)
+        fn = len(expected - predicted)
+        for target in (totals, stats):
+            target["tp"] += tp
+            target["fp"] += fp
+            target["fn"] += fn
+            if expected == predicted:
+                target["documents_exact"] += 1
+            if fp:
+                target["documents_with_fp"] += 1
+
+    def finalize(stats):
+        precision = stats["tp"] / (stats["tp"] + stats["fp"]) if stats["tp"] + stats["fp"] else 0.0
+        recall = stats["tp"] / (stats["tp"] + stats["fn"]) if stats["tp"] + stats["fn"] else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+        result = dict(stats)
+        result.update(
+            {
+                "precision": round(precision, 6),
+                "recall": round(recall, 6),
+                "f1": round(f1, 6),
+                "document_exact_rate": round(
+                    stats["documents_exact"] / stats["documents"], 6
+                ),
+                "false_positive_document_rate": round(
+                    stats["documents_with_fp"] / stats["documents"], 6
+                ),
+            }
+        )
+        return result
+
+    return {
+        "overall": finalize(totals),
+        "by_category": {
+            category: finalize(stats) for category, stats in sorted(by_category.items())
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--model-dir", type=Path, default=None)
+    parser.add_argument("--batch-size", type=int, default=16)
+    args = parser.parse_args()
+
+    if args.model_dir:
+        os.environ["PII_MODEL_DIR"] = str(args.model_dir.resolve())
+    sys.path.insert(0, str(APP_DIR))
+    import app as pii_app  # noqa: E402
+
+    rows = [
+        json.loads(line)
+        for line in args.data.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    texts = [row["source_text"] for row in rows]
+    results = pii_app.nlp(texts, batch_size=args.batch_size)
+
+    raw_predictions = []
+    app_predictions = []
+    examples = {"raw_model": [], "model_plus_regex": []}
+    for row, result in zip(rows, results):
+        text = row["source_text"]
+        model_entities = []
+        raw_spans = set()
+        for entity in result:
+            start, end = trim_span(text, int(entity["start"]), int(entity["end"]))
+            candidate = {
+                "label": entity["entity_group"],
+                "start": start,
+                "end": end,
+                "score": float(entity["score"]),
+                "validated": False,
+                "source": "modello",
+            }
+            model_entities.append(candidate)
+            if candidate["label"] == "TARGA":
+                raw_spans.add((start, end))
+
+        merged = pii_app._merge(
+            [dict(entity) for entity in model_entities] + pii_app.detect_regex(text),
+            text,
+        )
+        merged_spans = exact_spans(merged)
+        expected = exact_spans(row["entities"])
+        raw_predictions.append(raw_spans)
+        app_predictions.append(merged_spans)
+
+        for name, predicted in (
+            ("raw_model", raw_spans),
+            ("model_plus_regex", merged_spans),
+        ):
+            if predicted != expected and len(examples[name]) < 12:
+                examples[name].append(
+                    {
+                        "category": row["meta"]["category"],
+                        "text": text,
+                        "expected": sorted(expected),
+                        "predicted": sorted(predicted),
+                    }
+                )
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "model": Path(pii_app.MODEL_DIR).name,
+        "dataset": (
+            args.data.resolve().relative_to(ROOT).as_posix()
+            if args.data.resolve().is_relative_to(ROOT)
+            else str(args.data)
+        ),
+        "rows": len(rows),
+        "metric": "exact character-span match for TARGA",
+        "raw_model": calculate(rows, raw_predictions),
+        "model_plus_regex": calculate(rows, app_predictions),
+        "error_examples": examples,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+    print(f"Stress test: {len(rows)} righe")
+    for name in ("raw_model", "model_plus_regex"):
+        overall = report[name]["overall"]
+        negative = report[name]["by_category"]["hard_negative"]
+        print(
+            f"{name}: P={overall['precision']:.3f} R={overall['recall']:.3f} "
+            f"F1={overall['f1']:.3f} document_exact={overall['document_exact_rate']:.3f} "
+            f"hard_negative_FP_docs={negative['documents_with_fp']}/{negative['documents']}"
+        )
+    print(f"Report -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_targa_generators.py
+++ b/tests/test_targa_generators.py
@@ -1,0 +1,70 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "data_pipeline"))
+
+import generate_targa_it as train_gen
+import generate_targa_stress as stress_gen
+
+
+class TargaGeneratorTests(unittest.TestCase):
+    def test_training_mix_and_schema(self):
+        rows = train_gen.generate(30, seed=123)
+        counts = train_gen.summarize(rows)[0]
+        self.assertEqual(
+            counts, {"positive": 12, "hard_negative": 9, "mixed_pii": 9}
+        )
+        self.assertEqual(len({row["source_text"] for row in rows}), 30)
+        for row in rows:
+            train_gen.validate_record(row)
+
+    def test_stress_mix_has_exact_categories(self):
+        rows = stress_gen.generate(per_category=5, seed=456)
+        counts = {
+            category: sum(row["meta"]["category"] == category for row in rows)
+            for category in ("positive", "hard_negative", "mixed_pii")
+        }
+        self.assertEqual(counts, {"positive": 5, "hard_negative": 5, "mixed_pii": 5})
+        for row in rows:
+            train_gen.validate_record(row)
+
+    def test_stress_templates_are_disjoint_from_training_templates(self):
+        training = set(
+            train_gen.POSITIVE_TEMPLATES
+            + train_gen.NEGATIVE_O_TEMPLATES
+            + train_gen.NEGATIVE_DOCID_TEMPLATES
+            + train_gen.MIXED_TEMPLATES
+        )
+        stress = set(
+            stress_gen.POSITIVE_TEMPLATES
+            + stress_gen.HARD_NEGATIVE_TEMPLATES
+            + stress_gen.MIXED_TEMPLATES
+        )
+        self.assertFalse(training & stress)
+
+    def test_plate_alphabet_excludes_ambiguous_letters(self):
+        allowed = set(train_gen.base.PLATE_LETTERS)
+        self.assertFalse(allowed & set("IOQU"))
+        for _ in range(100):
+            code = train_gen.plate_code()
+            self.assertEqual(len(code), 7)
+            self.assertTrue(set(code[:2] + code[-2:]) <= allowed)
+            self.assertTrue(code[2:5].isdigit())
+
+    def test_hard_negatives_have_no_targa_label(self):
+        rows = stress_gen.generate(per_category=10, seed=789)
+        negatives = [
+            row for row in rows if row["meta"]["category"] == "hard_negative"
+        ]
+        self.assertTrue(negatives)
+        for row in negatives:
+            self.assertNotIn("B-TARGA", row["bio_labels"])
+            self.assertFalse(
+                any(entity["label"] == "TARGA" for entity in row["entities"])
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds a deterministic generator for the 3,000-row Italian `TARGA` contribution proposed in [Hugging Face dataset PR #2](https://huggingface.co/datasets/rizzoaiacademy/rizzo-pii-it-dataset/discussions/2)
- adds a separate 300-row stress generator with 100 positives, 100 hard negatives, and 100 mixed-PII examples; its templates are disjoint from the training generator
- adds an evaluator that compares the raw token-classification model with the production model+regex merge using exact character-span matching
- adds unit tests, generation notes, and a reproducible v1.2.0 baseline report

## Why

`TARGA` is underrepresented, and shape-only examples encourage the model to treat every `AA999AA` code as a plate. The hard negatives use the same surface format for passwords, orders, tickets, coupons, and other non-vehicle identifiers so contextual disambiguation can be learned and measured.

The baseline confirms the issue: the current model+regex pipeline reaches 0.900 recall on the stress suite, but produces a false-positive TARGA in 100/100 hard-negative documents because the regex has priority over model context.

## Developer impact

The committed scripts reproduce the dataset contribution byte-for-byte with seed `20260704` (SHA-256 `F84E1771749F8D452C600E96990E269D1B701C06F198AC7C93D3B7A17F717098`) and provide a regression benchmark that remains outside training.

## Validation

- `python -m unittest discover -s tests -v` — 5 tests passed
- `python -m compileall -q src tests`
- generated 3,000 rows twice and verified identical SHA-256
- generated and schema-validated 300 stress rows
- ran `evaluate_targa_stress.py` against `rizzo-pii-0.3B-v1.2.0`

Baseline summary:

| Pipeline | Precision | Recall | F1 | Exact documents | Hard-negative documents with FP |
|---|---:|---:|---:|---:|---:|
| Raw model | 0.295 | 0.600 | 0.395 | 39.3% | 100/100 |
| Model + regex | 0.575 | 0.900 | 0.702 | 59.7% | 100/100 |
