### PR TITLE
Scarica PDF anonimizzato (punto 1 della #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,24 @@ modelli in `models/<versione>/`, artefatti dei run in `experiments/<run>/`, doc 
 - `app.py` — server Flask + **UI**: testo o PDF, chunking con overlap, offset globali + dedup.
   Anonimizzazione **reversibile** (ogni PII → `[FULLNAME_1]`/`[IBAN_1]`… + dizionario locale; tab
   "Ripristina"). Affianca al modello una **rete regex/checksum** (EMAIL/TELEFONO/IBAN/CF/PIVA/carta/
-  importo/targa; IBAN/CF/PIVA/carta validati con checksum, che ha priorità sul modello). `APP_VERSION`.
+  importo/targa/date numeriche; IBAN/CF/PIVA/carta validati con checksum, che ha priorità sul modello). **Entità manuali**: dall'UI si seleziona il testo sfuggito al modello e lo si aggiunge come PII (label a scelta, campo `extra` di `/analyze`); le aggiunte manuali hanno priorità massima nella fusione, quindi correggono anche le etichette sbagliate del modello e finiscono nel dizionario (e quindi nel PDF redatto). `APP_VERSION`.
   Endpoint `GET/POST /config` e `GET /port-check` per la configurazione host/porta dall'UI (⚙️
   gear icon nell'header); `--host`/`--port` come argomenti CLI.
 - `serve.py` — entry **headless** (solo Flask, niente browser): è il backend dell'app Tauri; log su
   `%LOCALAPPDATA%\rizzo-pii\backend.log`. Pre-check porta + `sys.exit(76)` se occupata.
   `desktop_app.py` — entry PyInstaller legacy (apre il browser); stesso pre-check.
+- `pdf_export.py` — **download del PDF anonimizzato** (issue #7, punto 1), endpoint `POST /pdf`
+  in `app.py` (pulsante "Scarica PDF anonimizzato" nell'UI). Due modalita': **redazione vera** del
+  PDF caricato (le PII sono rimosse dal content stream con `apply_redactions`, i placeholder del
+  dizionario scritti al loro posto, layout conservato, metadati/XMP azzerati) oppure **PDF
+  ricostruito** dal solo testo anonimizzato quando l'input era testo incollato. Matching
+  CHAR-PRECISO con confini di parola (indice per carattere da `rawdict` + regex ancorate,
+  whitespace flessibile, multi-riga): niente redazioni di sottostringhe dentro altre parole.
+  I valori troppo corti/ambigui (frammenti del modello su testi tabellari) sono saltati e
+  riportati (`report["skipped"]`, header `X-PII-Skipped`); verifica finale dei
+  **residui** (valori ancora leggibili nell'output → header `X-PII-Residual`, avviso nell'UI).
+  Limite: niente OCR, il testo dentro immagini raster non viene redatto (punti 2-4 della issue).
+  Nessuna dipendenza dal modello: testabile in isolamento.
   `assets/` — mascotte (il riccio) + icone. `smoke_app.py`, `make_test_pdf.py`.
 
 **App desktop Tauri — `tauri/`:** finestra nativa **Rizzo PII** (WebView2) che lancia il backend

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ rizzo_pii/
 │   ├─ inspect/                       read-only utilities (counts, lengths, checksums)
 │   └─ app/                           local anonymization app
 │       ├─ app.py                     Flask server: reversible anonymization + regex/checksum net
+│       ├─ pdf_export.py              anonymized-PDF download: true redaction of the uploaded PDF
 │       ├─ serve.py                   headless entry (backend of the Tauri app, no browser)
 │       ├─ desktop_app.py             legacy PyInstaller entry (opens the browser)
 │       └─ assets/                    mascot (the hedgehog) and icons

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -31,6 +31,7 @@ import torch
 from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
 
+import pdf_export
 import server_config
 from transformers import pipeline
 
@@ -187,6 +188,11 @@ DETECTORS = [
     ("TARGA",
      re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b"),
      None, True),
+    ("DATE",
+     re.compile(r"(?<!\d)(?:0?[1-9]|[12]\d|3[01])[/.\-]"
+                r"(?:0?[1-9]|1[0-2])[/.\-](?:19|20)\d{2}"
+                r"(?:\s+\d{1,2}[:.]\d{2})?(?!\d)"),
+     None, True),
 ]
 
 
@@ -283,9 +289,36 @@ def _norm(s):
     return re.sub(r"\s+", " ", s.strip()).casefold()
 
 
-def analyze(text):
+def _manual_candidates(text, extra):
+    """Entita' aggiunte A MANO dall'utente (issue #7): per ogni {label, value}
+    trova TUTTE le occorrenze del valore nel testo (case-insensitive, spazi
+    flessibili, confini di parola). validated=True + score 1.0: nella fusione
+    vincono sul modello, quindi correggono anche le sue etichette sbagliate."""
+    cands = []
+    for item in (extra or []):
+        if not isinstance(item, dict):
+            continue
+        label = re.sub(r"[^A-Z_]", "", str(item.get("label", "")).upper())[:24] or "PII"
+        val = str(item.get("value", "")).strip()
+        toks = [re.escape(t) for t in _norm(val).split(" ") if t]
+        if not toks:
+            continue
+        rx = re.compile(r"(?<!\w)" + r"\s+".join(toks) + r"(?!\w)", re.IGNORECASE)
+        for m in rx.finditer(text):
+            cands.append({
+                "label": label,
+                "start": m.start(),
+                "end": m.end(),
+                "score": 1.0,
+                "validated": True,
+                "source": "manuale",
+            })
+    return cands
+
+
+def analyze(text, extra=None):
     model_ents, n_chunks = detect_model(text)
-    cands = model_ents + detect_regex(text)
+    cands = model_ents + detect_regex(text) + _manual_candidates(text, extra)
     kept = _merge(cands, text)
 
     # ID reversibili: stesso (label, valore-normalizzato) -> stesso placeholder.
@@ -369,19 +402,79 @@ def not_found(_e):
 
 @app.route("/analyze", methods=["POST"])
 def analyze_route():
-    text = ""
+    import json as _json
+    text, extra = "", []
     if "pdf" in request.files and request.files["pdf"].filename:
         data = request.files["pdf"].read()
         with fitz.open(stream=data, filetype="pdf") as doc:
             text = "\n".join(page.get_text() for page in doc)
+        try:
+            extra = _json.loads(request.form.get("extra") or "[]")
+        except ValueError:
+            extra = []
     else:
-        text = (request.get_json(silent=True) or {}).get("text", "")
+        payload = request.get_json(silent=True) or {}
+        text = payload.get("text", "")
+        extra = payload.get("extra") or []
     text = text.strip()
     if not text:
         return jsonify({"error": "Nessun testo da analizzare."}), 400
-    out = analyze(text)
+    out = analyze(text, extra if isinstance(extra, list) else [])
     out["source_text"] = text
     return jsonify(out)
+
+
+@app.route("/pdf", methods=["POST"])
+def pdf_route():
+    """Scarica il PDF anonimizzato (issue #7, punto 1). Due modalita':
+
+    - multipart con file 'pdf' + campo 'mapping' (JSON {placeholder: valore},
+      il dizionario restituito da /analyze): REDAZIONE VERA del PDF originale.
+      Le PII vengono rimosse dal content stream e sostituite dai placeholder,
+      il layout resta quello del documento. Metadati ripuliti.
+    - JSON {"text": "<testo anonimizzato>"}: PDF ricostruito dal solo testo
+      (usato quando l'input era testo incollato, senza PDF originale).
+
+    Header di risposta: X-PII-Redactions = redazioni applicate;
+    X-PII-Residual = valori del dizionario ANCORA leggibili nel testo
+    dell'output (verifica finale: deve essere 0, altrimenti l'UI avvisa).
+    """
+    import json as _json
+    if "pdf" in request.files and request.files["pdf"].filename:
+        data = request.files["pdf"].read()
+        try:
+            mapping = _json.loads(request.form.get("mapping") or "{}")
+        except ValueError:
+            return jsonify({"error": "Dizionario non valido."}), 400
+        try:
+            out, report = pdf_export.redact_pdf(data, mapping)
+        except pdf_export.PdfError as e:
+            return jsonify({"error": str(e)}), 400
+        if report["occurrences"] == 0:
+            return jsonify({"error": "Nessuna occorrenza trovata nel PDF: se il "
+                            "documento e' una scansione (testo in immagine) la "
+                            "redazione del layer testuale non puo' agire."}), 422
+        resp = app.response_class(out, mimetype="application/pdf")
+        resp.headers["Content-Disposition"] = \
+            "attachment; filename=documento_anonimizzato.pdf"
+        resp.headers["X-PII-Redactions"] = str(report["occurrences"])
+        resp.headers["X-PII-Residual"] = str(len(report["residual"]))
+        resp.headers["X-PII-Skipped"] = str(len(report["skipped"]))
+        return resp
+
+    text = ((request.get_json(silent=True) or {}).get("text") or "").strip()
+    if not text:
+        return jsonify({"error": "Nessun testo da impaginare."}), 400
+    try:
+        out = pdf_export.text_to_pdf(text)
+    except pdf_export.PdfError as e:
+        return jsonify({"error": str(e)}), 400
+    resp = app.response_class(out, mimetype="application/pdf")
+    resp.headers["Content-Disposition"] = \
+        "attachment; filename=documento_anonimizzato.pdf"
+    resp.headers["X-PII-Redactions"] = "0"
+    resp.headers["X-PII-Residual"] = "0"
+    return resp
 
 
 # --------------------------------------------------------------------------- #
@@ -517,6 +610,7 @@ PAGE = r"""
   button:disabled{opacity:.55;cursor:default}
   .spin{width:15px;height:15px;border:2px solid rgba(255,255,255,.45);border-top-color:#fff;
         border-radius:50%;animation:sp .7s linear infinite}
+  .ghost .spin{border-color:rgba(124,58,158,.25);border-top-color:var(--brand)}
   @keyframes sp{to{transform:rotate(360deg)}}
   .hint{color:var(--soft);font-size:12.5px;margin-left:auto}
 
@@ -700,6 +794,16 @@ PAGE = r"""
             <input type="file" id="pdf" accept="application/pdf" hidden>
           </label>
           <div class="row">
+            <select id="mlabel" class="lang" title="Tipo PII" aria-label="Tipo PII">
+              <option>FULLNAME</option><option>DATE</option><option>CITY</option>
+              <option>STREET</option><option>ORG</option><option>ID_DOC</option>
+              <option>CF</option><option>EMAIL</option><option>TELEPHONENUM</option>
+              <option>PII</option>
+            </select>
+            <button class="ghost" id="addsel">➕ <span data-i18n="addsel">Aggiungi selezione come PII</span></button>
+          </div>
+          <div id="mchips" class="legend" style="padding:8px 0 0;border-top:0;display:none"></div>
+          <div class="row">
             <button class="btn lg" id="go">🛡️ <span data-i18n="go">Anonimizza</span></button>
             <button class="ghost" id="clear" data-i18n="clear">Pulisci</button>
             <span class="hint"><span class="kbd">Ctrl</span>+<span class="kbd">Enter</span></span>
@@ -730,6 +834,7 @@ PAGE = r"""
                     data-i18n-ph="anon_ph" placeholder="Il testo anonimizzato apparirà qui."></textarea>
           <div class="row">
             <button class="btn" id="copy">📋 <span data-i18n="copy">Copia per ChatGPT</span></button>
+            <button class="ghost" id="dlpdf">📄 <span data-i18n="dlpdf">Scarica PDF anonimizzato</span></button>
             <button class="ghost" id="dl">⬇️ <span data-i18n="dl">Scarica dizionario</span></button>
             <span class="hint" id="ulock"></span>
           </div>
@@ -839,7 +944,10 @@ const T = {
   out_title:"② Risultato", v_prev:"Anteprima", v_text:"Testo da copiare",
   empty_prev:"L'anteprima con le PII evidenziate apparirà qui.",
   anon_ph:"Il testo anonimizzato apparirà qui.",
-  copy:"Copia per ChatGPT", dl:"Scarica dizionario",
+  copy:"Copia per ChatGPT", dl:"Scarica dizionario", dlpdf:"Scarica PDF anonimizzato",
+  t_pdf_making:"Genero il PDF…", t_pdf_ok:"PDF anonimizzato scaricato",
+  t_pdf_err:"Errore nella creazione del PDF",
+  t_pdf_residual:n=>"PDF scaricato · ATTENZIONE: "+n+(n===1?" valore ancora leggibile":" valori ancora leggibili")+" nel file, verificalo",
   dict_title:"Dizionario reversibile", dict_hint:"resta solo qui, in locale",
   th_id:"ID", th_val:"Valore originale", th_type:"Tipo",
   callout:"Incolla qui la <b>risposta dell'LLM</b> (che contiene i placeholder come <span class=\"kbd\">[FULLNAME_1]</span>): l'app rimette i valori veri usando il dizionario di questa sessione. Se hai chiuso e riaperto l'app, <b>carica il dizionario .json</b> che avevi salvato.",
@@ -857,6 +965,8 @@ const T = {
   t_nothing_copy:"Niente da copiare", t_restored_copied:"Testo ripristinato copiato",
   t_dict_loaded:"Dizionario caricato", t_json_invalid:"JSON non valido",
   t_drag_pdf:"Trascina un file PDF",
+  addsel:"Aggiungi selezione come PII",
+  t_select_first:"Seleziona prima nell'editor il testo da anonimizzare",
   pii_found:(n,u)=>n+" PII trovate · "+u+" valori unici",
   dict_n:n=>n+" ID nel dizionario",
   dict_loaded_n:n=>"dizionario caricato · "+n+" ID",
@@ -879,7 +989,10 @@ const T = {
   out_title:"② Result", v_prev:"Preview", v_text:"Text to copy",
   empty_prev:"The preview with highlighted PII will appear here.",
   anon_ph:"The anonymized text will appear here.",
-  copy:"Copy for ChatGPT", dl:"Download dictionary",
+  copy:"Copy for ChatGPT", dl:"Download dictionary", dlpdf:"Download anonymized PDF",
+  t_pdf_making:"Building the PDF…", t_pdf_ok:"Anonymized PDF downloaded",
+  t_pdf_err:"Error while creating the PDF",
+  t_pdf_residual:n=>"PDF downloaded · WARNING: "+n+(n===1?" value still readable":" values still readable")+" in the file, please check it",
   dict_title:"Reversible dictionary", dict_hint:"stays here only, locally",
   th_id:"ID", th_val:"Original value", th_type:"Type",
   callout:"Paste here the <b>LLM's answer</b> (containing placeholders like <span class=\"kbd\">[FULLNAME_1]</span>): the app puts the real values back using this session's dictionary. If you closed and reopened the app, <b>load the .json dictionary</b> you saved.",
@@ -897,6 +1010,8 @@ const T = {
   t_nothing_copy:"Nothing to copy", t_restored_copied:"Restored text copied",
   t_dict_loaded:"Dictionary loaded", t_json_invalid:"Invalid JSON",
   t_drag_pdf:"Drop a PDF file",
+  addsel:"Add selection as PII",
+  t_select_first:"First select in the editor the text to anonymize",
   pii_found:(n,u)=>n+" PII found · "+u+" unique values",
   dict_n:n=>n+" IDs in the dictionary",
   dict_loaded_n:n=>"dictionary loaded · "+n+" IDs",
@@ -955,6 +1070,25 @@ function showTab(n){
 }
 
 /* ---- analyze ---- */
+let EXTRA=[];              // entita' aggiunte a mano: [{label, value}]
+function renderChips(){
+  const c=$('mchips');c.innerHTML='';c.style.display=EXTRA.length?'':'none';
+  EXTRA.forEach((e,i)=>{
+    const col=colors(e.label);const el=document.createElement('span');
+    el.className='chip';el.title=e.value;
+    const v=e.value.length>28?e.value.slice(0,28)+'…':e.value;
+    el.innerHTML=`<span class="sw" style="background:${col.bd}"></span>${e.label}: ${escapeHtml(v)} ✕`;
+    el.onclick=()=>{EXTRA.splice(i,1);renderChips();run();};
+    c.appendChild(el);
+  });
+}
+$('addsel').onclick=()=>{
+  const s=$('src');
+  const val=s.value.substring(s.selectionStart,s.selectionEnd).trim();
+  if(!val){toast(tt('t_select_first'),false);return;}
+  EXTRA.push({label:$('mlabel').value,value:val});
+  renderChips();run();
+};
 async function run(){
   const file=$('pdf').files[0];const text=$('src').value.trim();
   if(!file&&!text){toast(tt('t_need_input'),false);return;}
@@ -963,9 +1097,10 @@ async function run(){
   try{
     let resp;
     if(file){const fd=new FormData();fd.append('pdf',file);
+      fd.append('extra',JSON.stringify(EXTRA));
       resp=await fetch('/analyze',{method:'POST',body:fd});}
     else resp=await fetch('/analyze',{method:'POST',headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({text})});
+      body:JSON.stringify({text,extra:EXTRA})});
     const d=await resp.json();
     if(!resp.ok){toast(d.error||tt('t_error'),false);return;}
     if(d.source_text&&file)$('src').value=d.source_text;
@@ -1043,6 +1178,34 @@ $('dl').onclick=()=>{if(!DATA||!Object.keys(MAP).length){toast(tt('t_nothing_dl'
   a.download='dizionario_anonimizzazione.json';a.click();URL.revokeObjectURL(a.href);
   toast(tt('t_dl_ok'));};
 
+/* ---- PDF anonimizzato (issue #7): redazione del PDF caricato, oppure
+       PDF ricostruito dal testo anonimizzato se l'input era testo ---- */
+$('dlpdf').onclick=async()=>{
+  if(!DATA){toast(tt('t_need_anon'),false);return;}
+  const file=$('pdf').files[0];
+  const btn=$('dlpdf');btn.disabled=true;const old=btn.innerHTML;
+  btn.innerHTML='<span class="spin"></span> '+tt('t_pdf_making');
+  try{
+    let resp;
+    if(file){
+      const fd=new FormData();fd.append('pdf',file);
+      fd.append('mapping',JSON.stringify(DATA.mapping||{}));
+      resp=await fetch('/pdf',{method:'POST',body:fd});
+    }else{
+      resp=await fetch('/pdf',{method:'POST',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({text:DATA.anonymized_text})});
+    }
+    if(!resp.ok){const d=await resp.json().catch(()=>({}));toast(d.error||tt('t_pdf_err'),false);return;}
+    const blob=await resp.blob();
+    const name=file?file.name.replace(/\.pdf$/i,'')+'_anonimizzato.pdf':'documento_anonimizzato.pdf';
+    const a=document.createElement('a');a.href=URL.createObjectURL(blob);
+    a.download=name;a.click();URL.revokeObjectURL(a.href);
+    const res=parseInt(resp.headers.get('X-PII-Residual')||'0',10);
+    if(res>0)toast(T[L].t_pdf_residual(res),false);else toast(tt('t_pdf_ok'));
+  }catch(e){toast(tt('t_pdf_err')+': '+e.message,false);}
+  finally{btn.disabled=false;btn.innerHTML=old;}
+};
+
 /* ---- reverse ---- */
 function reverse(){
   const txt=$('rin').value;
@@ -1075,6 +1238,7 @@ $('dictFile').onchange=e=>{const f=e.target.files[0];if(!f)return;
 /* ---- input helpers ---- */
 $('go').onclick=run;
 $('clear').onclick=()=>{$('src').value='';$('pdf').value='';$('dropTxt').innerHTML=tt('drop');
+  EXTRA=[];renderChips();
   DATA=null;$('prev').style.display='none';$('emptyPrev').style.display='';
   $('anon').value='';$('meta').innerHTML='';$('legend').innerHTML='';
   $('dictCard').style.display='none';$('ulock').textContent='';

--- a/src/app/pdf_export.py
+++ b/src/app/pdf_export.py
@@ -1,0 +1,350 @@
+# -*- coding: utf-8 -*-
+"""
+Generazione del PDF anonimizzato (issue #7, punto 1).
+
+Due modalita', entrambe 100% in locale e senza dipendenze dal modello
+(il modulo lavora solo su bytes + dizionario {placeholder -> valore}):
+
+  redact_pdf(pdf_bytes, mapping)
+      Redazione VERA del PDF originale: per ogni valore del dizionario cerca
+      le occorrenze nelle pagine, RIMUOVE il testo dal content stream
+      (page.apply_redactions(), non un rettangolo disegnato sopra) e scrive il
+      placeholder al suo posto. Layout conservato, metadati/XMP azzerati.
+
+      Il matching e' CHAR-PRECISO con CONFINI DI PAROLA: la pagina viene
+      indicizzata carattere per carattere (get_text("rawdict"), ogni glifo con
+      il suo bbox) e i valori sono cercati con regex ancorate (?<!\\w)...(?!\\w),
+      spazi flessibili e supporto multi-riga. Cosi' "DE" NON viene redatto
+      dentro "CORDELLA" o "DENSITA'" e una cifra non cancella i numeri di un
+      referto: si redige solo il token/la sequenza esatta, ovunque ma intera.
+      I valori "rumore" non localizzabili in modo sicuro (meno di 2 caratteri
+      alfanumerici, o 2 sole cifre: frammenti prodotti a volte dal modello su
+      documenti tabellari) vengono SALTATI e riportati in report["skipped"].
+
+      Ritorna (pdf_bytes_out, report); report["residual"] = valori ancora
+      leggibili nel testo estraibile dell'output (verifica finale: deve essere
+      vuota, altrimenti l'UI avvisa).
+
+  text_to_pdf(text)
+      PDF "ricostruito" solo testo, impaginato da zero a partire dal testo
+      anonimizzato (usato quando l'input era testo incollato).
+
+Limiti noti (coerenti con i punti 2-4 della issue #7, sviluppi futuri):
+  - testo dentro immagini raster (scansioni, loghi, blocchi firma): non esiste
+    nel layer testuale, quindi non puo' essere trovato ne' redatto (serve OCR);
+  - parole sillabate a cavallo di riga ("Fran-\\ncesco"): non riconosciute dal
+    matcher; in tal caso il valore finisce in "residual" e l'UI avvisa.
+"""
+
+import re
+import unicodedata
+
+import fitz  # PyMuPDF
+
+
+class PdfError(ValueError):
+    """Errore d'uso (PDF non valido, protetto, dizionario vuoto...)."""
+
+
+# --------------------------------------------------------------------------- #
+# Utility comuni
+# --------------------------------------------------------------------------- #
+# caratteri tipografici frequenti nei PDF estratti -> equivalenti Latin-1
+# (il font base "helv" copre Latin-1; cosi' la sostituzione e' deterministica)
+_TRANSLATE = str.maketrans({
+    "\u2018": "'", "\u2019": "'", "\u201c": '"', "\u201d": '"',
+    "\u2013": "-", "\u2014": "-", "\u2026": "...", "\u20ac": "EUR",
+    "\u00a0": " ", "\u2022": "-", "\ufb01": "fi", "\ufb02": "fl",
+})
+
+
+def _norm(s):
+    """Spazi compressi + casefold: stessa normalizzazione usata in app.py."""
+    return re.sub(r"\s+", " ", (s or "").strip()).casefold()
+
+
+def _fit_fontsize(text, rect, max_fs=10.0, min_fs=4.0):
+    """Corpo del testo per far stare `text` dentro `rect` (0 = non ci sta:
+    meglio nessuna etichetta che un'etichetta illeggibile o troncata)."""
+    try:
+        w10 = fitz.get_text_length(text, fontname="helv", fontsize=10.0)
+    except Exception:
+        return 0
+    if w10 <= 0:
+        return 0
+    fs = min(max_fs, rect.height * 0.82, 10.0 * max(rect.width - 2.0, 0.0) / w10)
+    return round(fs, 1) if fs >= min_fs else 0
+
+
+def _covered(rect, taken, thr=0.85):
+    """True se `rect` e' gia' (quasi) tutto dentro una redazione precedente:
+    evita doppioni quando un valore e' contenuto in un altro (es. "Rossi"
+    dentro "Mario Rossi", redatto prima perche' piu' lungo)."""
+    area = rect.get_area()
+    if area <= 0:
+        return True
+    for t in taken:
+        inter = fitz.Rect(rect)
+        inter.intersect(t)
+        if not inter.is_empty and inter.get_area() / area >= thr:
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Indice char-preciso della pagina + ricerca con confini di parola
+# --------------------------------------------------------------------------- #
+def _page_char_index(page):
+    """(testo, [bbox per carattere]) dalla pagina: ogni carattere del layer
+    testuale con il suo rettangolo (None per i newline di fine riga)."""
+    raw = page.get_text("rawdict")
+    chars, boxes = [], []
+    for block in raw.get("blocks", []):
+        if block.get("type") != 0:          # solo blocchi di testo
+            continue
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                for ch in span.get("chars", []):
+                    c = ch.get("c") or ""
+                    for cc in c:            # ligature -> piu' caratteri, stesso bbox
+                        chars.append(cc)
+                        boxes.append(fitz.Rect(ch["bbox"]))
+            chars.append("\n")
+            boxes.append(None)
+    return "".join(chars), boxes
+
+
+def _value_pattern(value):
+    """Regex del valore: token esatti con CONFINI DI PAROLA agli estremi,
+    whitespace flessibile (anche a cavallo di riga) tra i token. Niente match
+    di sottostringhe dentro altre parole."""
+    toks = [re.escape(t) for t in _norm(value).split(" ") if t]
+    if not toks:
+        return None
+    return re.compile(r"(?<!\w)" + r"\s*".join(toks) + r"(?!\w)",
+                      re.IGNORECASE)
+
+
+def _match_rects(boxes, m):
+    """Bbox dei caratteri del match, uniti per riga (overlap verticale)."""
+    rects, cur = [], None
+    for i in range(m.start(), m.end()):
+        b = boxes[i]
+        if b is None or b.is_empty:
+            continue
+        if cur is None:
+            cur = fitz.Rect(b)
+        elif b.y0 < cur.y1 and b.y1 > cur.y0:      # stessa riga
+            cur |= b
+        else:                                       # riga nuova
+            rects.append(cur)
+            cur = fitz.Rect(b)
+    if cur is not None and not cur.is_empty:
+        rects.append(cur)
+    return rects
+
+
+def _too_noisy(value):
+    """Valori non localizzabili in modo sicuro in un PDF: frammenti con meno
+    di 2 caratteri alfanumerici, o di 2 sole cifre (es. "1", "C", "05"
+    prodotti a volte dal modello su testi tabellari). Meglio saltarli e
+    dichiararlo nel report che devastare il documento."""
+    alnum = re.sub(r"[\W_]+", "", _norm(value))
+    return len(alnum) < 2 or (len(alnum) == 2 and alnum.isdigit())
+
+
+# --------------------------------------------------------------------------- #
+# Metadati + verifica finale
+# --------------------------------------------------------------------------- #
+def _scrub_metadata(doc):
+    """Azzera i metadati classici e l'XMP: possono contenere PII (autore...)."""
+    try:
+        # set_metadata aggiorna SOLO le chiavi passate: vanno azzerate tutte
+        # esplicitamente, altrimenti autore/titolo originali restano nel file
+        doc.set_metadata({
+            "title": "", "author": "", "subject": "", "keywords": "",
+            "creationDate": "", "modDate": "", "trapped": "",
+            "creator": "rizzo-pii", "producer": "rizzo-pii",
+        })
+    except Exception:
+        pass
+    f = getattr(doc, "del_xml_metadata", None) or getattr(doc, "delXmlMetadata", None)
+    if f:
+        try:
+            f()
+        except Exception:
+            pass
+
+
+def _verify_residuals(pdf_bytes, items):
+    """Placeholder i cui valori sono ANCORA leggibili nel testo estraibile
+    dell'output. Rete di sicurezza finale: deve tornare [].
+    NB: non vede il testo dentro immagini raster (loghi, firme, scansioni)."""
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        text = _norm(" ".join(page.get_text() for page in doc))
+    residual = []
+    for ph, val in items:
+        nv = _norm(val)
+        if not nv:
+            continue
+        pat = r"(?<!\w)" + re.escape(nv) + r"(?!\w)"
+        if re.search(pat, text):
+            residual.append(ph)
+    return residual
+
+
+# --------------------------------------------------------------------------- #
+# API pubblica
+# --------------------------------------------------------------------------- #
+def redact_pdf(pdf_bytes, mapping,
+               fill=(0.93, 0.92, 0.97), text_color=(0.39, 0.18, 0.50)):
+    """PDF originale -> PDF con redazione vera + placeholder al posto delle PII.
+
+    mapping: {"[FULLNAME_1]": "Mario Rossi", ...} (il dizionario di analyze()).
+    Ritorna (bytes, report) con report = {
+        "occurrences":  occorrenze redatte in totale,
+        "by_placeholder": {placeholder: n_occorrenze},
+        "not_found":    placeholder cercati ma senza occorrenze,
+        "skipped":      placeholder saltati perche' troppo corti/ambigui,
+        "residual":     placeholder ancora leggibili nell'output (deve essere []),
+    }
+    """
+    if not isinstance(mapping, dict) or not mapping:
+        raise PdfError("Dizionario vuoto: anonimizza prima il documento.")
+    items = [(ph, v) for ph, v in mapping.items()
+             if isinstance(ph, str) and isinstance(v, str) and v.strip()]
+    if not items:
+        raise PdfError("Dizionario non valido.")
+
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception:
+        raise PdfError("File PDF non valido o danneggiato.")
+    if doc.needs_pass:
+        doc.close()
+        raise PdfError("PDF protetto da password: rimuovi la protezione e riprova.")
+
+    # valori lunghi per primi: cosi' "Rossi" non spezza la redazione di
+    # "Mario Rossi" (i rect gia' coperti vengono saltati da _covered)
+    items.sort(key=lambda kv: -len(kv[1]))
+
+    skipped, usable = [], []
+    for ph, val in items:
+        if _too_noisy(val):
+            skipped.append(ph)
+            continue
+        pat = _value_pattern(val)
+        if pat:
+            usable.append((ph, val, pat))
+
+    by_ph = {ph: 0 for ph, _, _ in usable}
+    total = 0
+    for page in doc:
+        text, boxes = _page_char_index(page)
+        if not text.strip():
+            continue
+        taken = []
+        for ph, val, pat in usable:
+            for m in pat.finditer(text):
+                rects = _match_rects(boxes, m)
+                placed_any, labeled = False, False
+                for r in rects:
+                    if _covered(r, taken):
+                        continue
+                    fs = 0 if labeled else _fit_fontsize(ph, r)
+                    page.add_redact_annot(
+                        r,
+                        text=ph if fs else None,
+                        fontname="helv",
+                        fontsize=fs or 6,
+                        align=fitz.TEXT_ALIGN_CENTER,
+                        fill=fill,
+                        text_color=text_color,
+                    )
+                    taken.append(fitz.Rect(r))
+                    placed_any = True
+                    labeled = labeled or bool(fs)
+                if placed_any:
+                    by_ph[ph] += 1
+                    total += 1
+        if taken:
+            page.apply_redactions()   # rimozione VERA dal content stream
+
+    _scrub_metadata(doc)
+    out = doc.tobytes(garbage=3, deflate=True)
+    doc.close()
+
+    checked = [(ph, v) for ph, v in items if ph in by_ph]
+    report = {
+        "occurrences": total,
+        "by_placeholder": by_ph,
+        "not_found": [ph for ph, n in by_ph.items() if n == 0],
+        "skipped": skipped,
+        "residual": _verify_residuals(out, checked),
+    }
+    return out, report
+
+
+def text_to_pdf(text, margin=56.0, fontsize=10.5, leading=15.5):
+    """Testo (gia' anonimizzato) -> PDF A4 solo testo, impaginato da zero.
+    Nessun contenuto del documento originale finisce nell'output."""
+    text = unicodedata.normalize("NFKC", text or "").translate(_TRANSLATE)
+    # helv copre Latin-1: sostituzione esplicita dei caratteri fuori codifica
+    text = text.encode("latin-1", "replace").decode("latin-1")
+    if not text.strip():
+        raise PdfError("Nessun testo da impaginare.")
+
+    a4 = fitz.paper_rect("a4")
+    width = a4.width - 2 * margin
+
+    def tl(s):
+        return fitz.get_text_length(s, fontname="helv", fontsize=fontsize)
+
+    def hard_split(line):
+        """Spezza le 'parole' piu' larghe della riga (IBAN, URL...)."""
+        out = []
+        while tl(line) > width and len(line) > 1:
+            k = max(1, int(len(line) * width / tl(line)))
+            while k > 1 and tl(line[:k]) > width:
+                k -= 1
+            while k < len(line) and tl(line[:k + 1]) <= width:
+                k += 1
+            out.append(line[:k])
+            line = line[k:]
+        out.append(line)
+        return out
+
+    def wrap(par):
+        if not par:
+            return [""]
+        lines, cur = [], ""
+        for w in par.split(" "):
+            cand = (cur + " " + w) if cur else w
+            if not cur or tl(cand) <= width:
+                cur = cand
+            else:
+                lines.append(cur)
+                cur = w
+        lines.append(cur)
+        out = []
+        for ln in lines:
+            out.extend(hard_split(ln))
+        return out
+
+    doc = fitz.open()
+    page = doc.new_page(width=a4.width, height=a4.height)
+    y = margin + fontsize
+    for par in text.split("\n"):
+        for ln in wrap(par.rstrip()):
+            if y > a4.height - margin:
+                page = doc.new_page(width=a4.width, height=a4.height)
+                y = margin + fontsize
+            if ln:
+                page.insert_text((margin, y), ln, fontname="helv",
+                                 fontsize=fontsize)
+            y += leading
+
+    _scrub_metadata(doc)
+    out = doc.tobytes(deflate=True)
+    doc.close()
+    return out


### PR DESCRIPTION
Implementa il punto 1 della proposta in #7: upload del PDF → anonimizzazione → creazione del PDF anonimizzato → download, per poter caricare su Claude/altri LLM molti documenti già anonimizzati e fare analisi in blocco con riferimenti coerenti al dizionario reversibile.
Cosa fa
Nuovo pulsante "📄 Scarica PDF anonimizzato" nel pannello Anonimizza (i18n IT/EN) e nuovo endpoint `POST /pdf` in `app.py` (funziona identico nell'app Tauri: `serve.py` importa `app`).
Due modalità:
PDF caricato → redazione vera del documento originale con `apply_redactions()` di PyMuPDF: il testo delle PII è rimosso dal content stream (non coperto da un rettangolo) e al suo posto compaiono i placeholder del dizionario reversibile; il layout resta quello del documento. Metadati e XMP azzerati (anche lì possono nascondersi PII).
Testo incollato → PDF ricostruito impaginando da zero il solo testo anonimizzato.
Matching char-preciso con confini di parola (indice per carattere da `get_text("rawdict")` + regex ancorate, whitespace flessibile, match multi-riga): niente redazioni di sottostringhe dentro altre parole; i valori troppo corti/ambigui (frammenti che il modello a volte produce su testi tabellari, es. referti) vengono saltati e dichiarati nel report invece di danneggiare il documento.
Verifica finale dei residui: se un valore del dizionario è ancora leggibile nel testo estraibile dell'output, l'UI mostra un avviso (header `X-PII-Residual`).
Emersi dai test su documenti reali, inclusi in questa PR:
detector regex per le date numeriche (gg/mm/aaaa, anche con `-` o `.` e ora opzionale), indipendenti dal modello;
aggiunta manuale delle PII sfuggite al modello: si seleziona il testo nell'editor, si sceglie il tipo e si clicca "➕ Aggiungi selezione come PII"; le entità manuali hanno priorità massima nella fusione, quindi correggono anche eventuali etichette errate del modello, e finiscono nel dizionario (e quindi nel PDF).
Note tecniche
Nuovo modulo `src/app/pdf_export.py` senza dipendenze dal modello (testabile in isolamento). Nessuna dipendenza nuova: PyMuPDF è già in `requirements.txt`. PyInstaller lo raccoglie automaticamente (import diretto da `app.py`).
Testato su PDF sintetici (nomi a cavallo di riga, IBAN spaziati, testo ruotato, punteggiatura attaccata, entità ripetute su più pagine) e su referti medici reali multi-pagina: redazioni complete, residui 0, valori clinici e layout intatti.
Limiti noti (fuori scope = punti 2-4 della #7)
Il testo dentro immagini raster (scansioni, loghi, blocchi firma) non esiste nel layer testuale: non può essere trovato né redatto, serve OCR. Se nel PDF non si trova alcuna occorrenza, l'endpoint risponde con un errore chiaro invece di produrre un PDF "anonimizzato" che non lo è.
Parole sillabate a cavallo di riga non riconosciute dal matcher → finiscono nei residui e l'UI avvisa.
Ref #7 (punto 1 — la issue resta aperta per i punti 2-4).
