### PR TITLE
feat: ONNX (+INT8) export and Transformers.js usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ The desktop app **Rizzo PII** (Tauri) launches the Python/Flask backend as a bun
 "sidecar"; a CPU-only PyTorch build keeps it fully **offline** on Windows (WebView2), macOS and Linux.
 Packaging instructions in **[docs/BUILD.md](docs/BUILD.md)**.
 
+Where Python is not an option — a browser, an extension, a WebAssembly runtime — the model can be
+exported to **ONNX** and run with [Transformers.js](https://github.com/huggingface/transformers.js):
+`python src/export/export_onnx.py --verify`. INT8 quantization shrinks the weights ~4× (1.2 GB → 294 MB)
+at **98.8%** prediction agreement with fp32. Still entirely local: only the engine changes, not the
+privacy guarantee. See **[docs/ONNX.md](docs/ONNX.md)**.
+
 > **⬇️ Download.** Grab the ready-to-use build from the
 > **[Releases page](https://github.com/Rizzo-AI-Academy/rizzo-pii/releases/latest)** — no Python or
 > setup required: a **Windows installer** (double-click), a **macOS `.dmg`** (Apple Silicon /
@@ -364,6 +370,7 @@ rizzo_pii/
 ├─ LICENSE                   MIT
 ├─ CONTRIBUTING.md           how to contribute (code, docs, data)
 ├─ requirements.txt          Python dependencies (see the cu128 note for Blackwell GPUs)
+├─ requirements-onnx.txt     extra dependencies for the ONNX export only
 ├─ .env.example              template for the optional W&B / Gemini keys
 ├─ CLAUDE.md                 operating instructions + environment constraints (GPU, CUDA…)
 ├─ report/                   the technical report (PDF + Typst source)
@@ -371,6 +378,7 @@ rizzo_pii/
 │   ├─ DATASET.md            full composition of train/validation
 │   ├─ TASSONOMIA_TAG.md     the 22 final tags and the merge decisions
 │   ├─ BUILD.md              desktop app build (Tauri recommended + PyInstaller legacy)
+│   ├─ ONNX.md               ONNX / INT8 export and Transformers.js usage
 │   └─ CHANGELOG.md          change log, with rationale
 ├─ src/
 │   ├─ data_pipeline/        data generation & preparation
@@ -384,6 +392,8 @@ rizzo_pii/
 │   │   ├─ train_pii.py               train, evaluate, save the model + metrics
 │   │   ├─ evaluate_pii.py            per-tag (P/R/F1) evaluation on validation_real
 │   │   └─ test_pii.py                CLI inference on the saved model
+│   ├─ export/
+│   │   └─ export_onnx.py             ONNX (+ INT8) export — see docs/ONNX.md
 │   ├─ inspect/                       read-only utilities (counts, lengths, checksums)
 │   └─ app/                           local anonymization app
 │       ├─ app.py                     Flask server: reversible anonymization + regex/checksum net
@@ -495,6 +505,7 @@ Vincoli: SOLO dati sintetici (mai PII reali). Se Gemini non è disponibile, ferm
 | [docs/TASSONOMIA_TAG.md](docs/TASSONOMIA_TAG.md) | The 22 final tags and the merges (`TAG_MAP`) |
 | [docs/FORMATO_DATI.md](docs/FORMATO_DATI.md) | Exact dataset row format for contributing data (JSONL/BIO/checksums) |
 | [docs/BUILD.md](docs/BUILD.md) | Desktop executable build (CPU, Windows) |
+| [docs/ONNX.md](docs/ONNX.md) | ONNX / INT8 export and usage from Transformers.js (browser) |
 | [docs/CHANGELOG.md](docs/CHANGELOG.md) | Change log for the pipeline, with rationale |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute code, docs and (above all) data |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,39 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-30 — Export ONNX (+ INT8): il modello gira anche nel browser
+
+Nuovo script `src/export/export_onnx.py` e documentazione in
+[docs/ONNX.md](ONNX.md). Nessun impatto su training, dataset o app desktop: è un
+percorso aggiuntivo, e le dipendenze stanno in un `requirements-onnx.txt`
+separato perché chi addestra non ha motivo di installarle.
+
+**Perché.** Oggi il modello è raggiungibile solo da PyTorch, quindi solo da
+Python. Con ONNX diventa utilizzabile da runtime nativi e soprattutto da
+**Transformers.js**, che apre browser, estensioni e WebAssembly — contesti in cui
+"anonimizza prima di mandare all'LLM" è esattamente il gesto dell'utente, ma dove
+un backend Python non si può installare. Il modello resta interamente locale:
+cambia il motore, non la garanzia di privacy.
+
+**Cosa fa.** Export fp32 via `optimum`, quantizzazione INT8 opzionale (profilo
+CPU scelto in automatico), e composizione di un `bundle/` nel layout atteso da
+Transformers.js (tokenizer alla radice, pesi in `onnx/`). Il modello si risolve
+con la stessa logica di `test_pii.py` (ultima versione + `PII_MODEL_DIR`).
+
+**Fedeltà INT8.** Il flag `--verify` confronta le predizioni fp32 e INT8 token per
+token. Sulla v1.2.0: **98,51%** di accordo complessivo e **98,76%** sui soli token
+di entità, per un file **4× più piccolo** (1206,6 MB → 294,3 MB). La
+quantizzazione è praticamente gratuita.
+
+**Nota emersa durante il lavoro**, documentata in docs/ONNX.md: la pipeline
+`token-classification` di Transformers.js non restituisce gli offset carattere
+(`start`/`end`), che servono per la sostituzione reversibile. Con il tokenizer
+Metaspace di mmBERT si ricostruiscono in modo esatto dalle lunghezze cumulative
+dei `word`, a patto di passare `ignore_labels: []` (il default `['O']` scarta
+token e sfasa il conteggio). Lo snippet, verificato, è in docs/ONNX.md.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,9 +25,18 @@ Transformers.js (tokenizer alla radice, pesi in `onnx/`). Il modello si risolve
 con la stessa logica di `test_pii.py` (ultima versione + `PII_MODEL_DIR`).
 
 **Fedeltà INT8.** Il flag `--verify` confronta le predizioni fp32 e INT8 token per
-token. Sulla v1.2.0: **98,51%** di accordo complessivo e **98,76%** sui soli token
-di entità, per un file **4× più piccolo** (1206,6 MB → 294,3 MB). La
-quantizzazione è praticamente gratuita.
+token, per un file **4× più piccolo** (1206,6 MB → 294,3 MB):
+
+| | v1.2.0 | v1.3.0 |
+|---|---:|---:|
+| Accordo complessivo | 98,51% | **99,26%** |
+| Accordo sui token di entità | 98,76% | **99,69%** |
+
+La quantizzazione è praticamente gratuita. Sulla v1.3.0 la misura è anche più
+severa: sugli stessi 537 token il modello ne etichetta 327 come entità invece di
+242, perché i subword interni degli identificatori lunghi non cadono più su `O`
+(`LABEL_ALL_SUBWORDS`, `7564553`). Lo script ha girato invariato sulla nuova
+versione — nessuna modifica necessaria per l'export.
 
 **Nota emersa durante il lavoro**, documentata in docs/ONNX.md: la pipeline
 `token-classification` di Transformers.js non restituisce gli offset carattere

--- a/docs/ONNX.md
+++ b/docs/ONNX.md
@@ -1,0 +1,194 @@
+# Export ONNX (+ INT8)
+
+Come esportare il modello in **ONNX** per farlo girare dove PyTorch non arriva:
+runtime ONNX nativi e, soprattutto, **nel browser** via
+[Transformers.js](https://github.com/huggingface/transformers.js) — estensioni,
+WebAssembly, applicazioni web. Il modello resta interamente locale: ONNX non
+cambia nulla della garanzia di privacy, cambia solo il motore che lo esegue.
+
+Script: [`src/export/export_onnx.py`](../src/export/export_onnx.py).
+
+---
+
+## Installazione
+
+Le dipendenze ONNX sono tenute **fuori** da `requirements.txt`, per non
+appesantire chi vuole solo addestrare o usare l'app desktop:
+
+```bash
+pip install -r requirements-onnx.txt
+```
+
+## Uso
+
+```bash
+python src/export/export_onnx.py                   # fp32 + INT8, ultima versione in models/
+python src/export/export_onnx.py --verify          # + confronto fp32 vs INT8
+python src/export/export_onnx.py --no-quantize     # solo fp32
+python src/export/export_onnx.py --arch avx512     # profilo CPU
+PII_MODEL_DIR=/path/al/modello python src/export/export_onnx.py
+```
+
+Il modello si risolve con la stessa logica di `src/training/test_pii.py`: ultima
+versione `models/rizzo-pii-0.3B-v*`, con override `PII_MODEL_DIR`.
+
+Il profilo CPU per la quantizzazione si sceglie da solo (`arm64` su Apple
+silicon, `avx2` altrove) e si può forzare con `--arch`
+(`arm64` | `avx2` | `avx512` | `avx512_vnni`).
+
+## Risultato
+
+```
+models/rizzo-pii-0.3B-v1.2.0-onnx/
+├─ fp32/                        export intermedio (non serve spedirlo)
+├─ quant-staging/               staging della quantizzazione
+├─ export_stats.json            dimensioni + esito della verifica
+└─ bundle/                      ← questo è ciò che si distribuisce
+   ├─ config.json
+   ├─ tokenizer.json
+   ├─ tokenizer_config.json
+   ├─ special_tokens_map.json
+   └─ onnx/
+      └─ model_quantized.onnx
+```
+
+Il layout di `bundle/` è quello che Transformers.js si aspetta: file del
+tokenizer alla radice, pesi sotto `onnx/`.
+
+---
+
+## Dimensioni misurate (v1.2.0, profilo arm64)
+
+| Artefatto | Dimensione |
+|---|---:|
+| ONNX fp32 | 1206,6 MB |
+| `model_quantized.onnx` (INT8) | **294,3 MB** |
+| `tokenizer.json` | 32,8 MB |
+| **Bundle totale** | **327,1 MB** |
+
+Export in ~10 s, quantizzazione in ~10 s (Apple M-series).
+
+Due note utili a chi deve distribuire il modello:
+
+- Il **`tokenizer.json` pesa 32,8 MB** ed è una conseguenza diretta del
+  vocabolario mmBERT da 256k voci. Va spedito insieme ai pesi: Transformers.js
+  lo carica dalla stessa cartella.
+- Degli ~307 M parametri, **~197 M (il 64%) sono la tabella di embedding**
+  (256.000 × 768). L'encoder vero e proprio, 22 layer, ne pesa ~110 M. È il
+  motivo per cui il file INT8 resta sui ~294 MB nonostante il modello sia
+  descritto come "0.3B".
+
+## Fedeltà della quantizzazione INT8
+
+`--verify` confronta le predizioni fp32 e INT8 **token per token** sugli stessi
+testi, usando `dataset/validation/validation_real.jsonl` se presente e altrimenti
+un insieme di esempi che copre tutti i 22 tag.
+
+Sulla v1.2.0, con gli esempi predefiniti (537 token, 242 dei quali di entità):
+
+| Misura | Valore |
+|---|---:|
+| Accordo su tutti i token | 98,51% |
+| Accordo sui soli token di entità | 98,76% |
+
+La quantizzazione è quindi praticamente gratuita in accuratezza, a fronte di un
+file **4× più piccolo**. Per una misura più solida conviene rigenerare la
+validation (`python src/data_pipeline/build_validation.py`) ed eseguire
+`--verify --verify-n 2000`.
+
+---
+
+## Uso con Transformers.js
+
+```js
+import { pipeline, env } from '@huggingface/transformers';
+
+// Nessuna chiamata di rete: i pesi vengono dalla cartella locale.
+env.allowRemoteModels = false;
+env.localModelPath = '/percorso/a/models/rizzo-pii-0.3B-v1.2.0-onnx/';
+
+const nlp = await pipeline('token-classification', 'bundle', { dtype: 'q8' });
+const out = await nlp("Mario Rossi, C.F. RSSMRA85H12F205Y.", { ignore_labels: [] });
+```
+
+### Attenzione: gli offset carattere non arrivano dalla pipeline
+
+Transformers.js restituisce per ogni token `entity`, `score`, `index` e `word`,
+**ma non `start`/`end`**. Chi deve sostituire il testo (l'anonimizzazione
+reversibile lo richiede) deve ricostruirseli.
+
+Con il tokenizer mmBERT (Metaspace) la ricostruzione è **esatta**: la
+concatenazione dei `word` in ordine riproduce il testo di partenza, preceduto da
+**un solo spazio**. Bastano quindi le lunghezze cumulative, sfalsate di uno.
+
+Due dettagli da cui dipende la correttezza:
+
+1. **`ignore_labels: []` è obbligatorio.** Il valore predefinito è `['O']`: senza
+   passarlo esplicitamente i token `O` vengono scartati, la sequenza si
+   interrompe e le lunghezze cumulative vanno fuori fase.
+2. I `word` includono lo spazio iniziale (`" Mario"`), quindi conviene rifilare i
+   bordi degli span alla fine.
+
+```js
+/** Ricostruisce gli offset carattere e raggruppa i token BIO in entità. */
+function spansFromTokens(text, tokens) {
+  let cursor = -1;                       // compensa lo spazio iniziale di Metaspace
+  const placed = tokens.map((t) => {
+    const start = cursor;
+    cursor += t.word.length;
+    return { ...t, start: Math.max(0, start), end: Math.min(text.length, cursor) };
+  });
+
+  const groups = [];
+  for (const t of placed) {
+    const m = /^([BI])-(.+)$/.exec(t.entity);
+    if (!m) continue;
+    const [, bio, type] = m;
+    const last = groups[groups.length - 1];
+    if (last && last.type === type && (bio === 'I' || last.lastIdx + 1 === t.index)) {
+      last.end = t.end;
+      last.lastIdx = t.index;
+    } else {
+      groups.push({ type, start: t.start, end: t.end, lastIdx: t.index });
+    }
+  }
+
+  return groups.map(({ type, start, end }) => {          // rifila gli spazi ai bordi
+    while (start < end && /\s/.test(text[start])) start++;
+    while (end > start && /\s/.test(text[end - 1])) end--;
+    return { type, start, end };
+  });
+}
+
+const spans = spansFromTokens(text, await nlp(text, { ignore_labels: [] }));
+```
+
+### Documenti lunghi
+
+Il modello è addestrato a `MAX_LEN = 768` subword. Per testi più lunghi vale la
+stessa strategia dell'app Flask (`src/app/app.py`): chunk con sovrapposizione,
+offset riportati in coordinate globali e deduplica finale.
+
+### Da affiancare sempre alla rete regex + checksum
+
+Vale anche qui quanto detto nel README: in produzione il modello **non va usato
+da solo**. La rete regex + checksum
+([`src/inspect/validate_checksums.py`](../src/inspect/validate_checksums.py))
+resta necessaria, e un checksum valido ha la precedenza sul modello. È la
+mitigazione della frammentazione dei codici lunghi, che si osserva anche via
+Transformers.js: su un codice fiscale il modello può alternare `CF` e `ID_DOC`
+fra i subword dello stesso codice.
+
+---
+
+## Limiti di questa documentazione
+
+- Le dimensioni e i numeri di fedeltà sono misurati sulla **v1.2.0** con profilo
+  `arm64`. Altri profili CPU producono file di dimensione paragonabile ma non
+  identica.
+- La verifica `--verify` misura l'**accordo fra fp32 e INT8**, non l'accuratezza
+  assoluta: dice quanto costa la quantizzazione, non quanto è buono il modello.
+  Per quello c'è `src/training/evaluate_pii.py`.
+- Il bundle è stato caricato ed eseguito con `@huggingface/transformers` 3.8.1
+  **in Node**; il percorso browser usa lo stesso codice della pipeline ma non è
+  stato eseguito in un browser reale come parte di questo lavoro.

--- a/docs/ONNX.md
+++ b/docs/ONNX.md
@@ -57,7 +57,7 @@ tokenizer alla radice, pesi sotto `onnx/`.
 
 ---
 
-## Dimensioni misurate (v1.2.0, profilo arm64)
+## Dimensioni misurate (v1.2.0 e v1.3.0, profilo arm64)
 
 | Artefatto | Dimensione |
 |---|---:|
@@ -67,6 +67,10 @@ tokenizer alla radice, pesi sotto `onnx/`.
 | **Bundle totale** | **327,1 MB** |
 
 Export in ~10 s, quantizzazione in ~10 s (Apple M-series).
+
+Le due versioni producono bundle di dimensione **identica**: la v1.3.0 aggiunge
+una sola classe al modello (`I-IBAN`), cioè 768 pesi sulla testa di
+classificazione, invisibili sul totale.
 
 Due note utili a chi deve distribuire il modello:
 
@@ -84,17 +88,25 @@ Due note utili a chi deve distribuire il modello:
 testi, usando `dataset/validation/validation_real.jsonl` se presente e altrimenti
 un insieme di esempi che copre tutti i 22 tag.
 
-Sulla v1.2.0, con gli esempi predefiniti (537 token, 242 dei quali di entità):
+Con gli esempi predefiniti (537 token):
 
-| Misura | Valore |
-|---|---:|
-| Accordo su tutti i token | 98,51% |
-| Accordo sui soli token di entità | 98,76% |
+| Misura | v1.2.0 | v1.3.0 |
+|---|---:|---:|
+| Token di entità | 242 | **327** |
+| Accordo su tutti i token | 98,51% | **99,26%** |
+| Accordo sui soli token di entità | 98,76% | **99,69%** |
 
 La quantizzazione è quindi praticamente gratuita in accuratezza, a fronte di un
 file **4× più piccolo**. Per una misura più solida conviene rigenerare la
 validation (`python src/data_pipeline/build_validation.py`) ed eseguire
 `--verify --verify-n 2000`.
+
+Il salto della v1.3.0 va letto insieme alla riga dei token di entità: sugli
+stessi 537 token il modello ne etichetta ora 327 invece di 242. Sono i subword
+interni degli identificatori lunghi, che prima cadevano su `O` perché non
+entravano nella loss (`LABEL_ALL_SUBWORDS`, commit `7564553`). La verifica è
+quindi diventata **più severa** — misura l'accordo su un terzo di posizioni in
+più, tutte dentro le entità — e il risultato è migliorato lo stesso.
 
 ---
 
@@ -174,18 +186,23 @@ offset riportati in coordinate globali e deduplica finale.
 Vale anche qui quanto detto nel README: in produzione il modello **non va usato
 da solo**. La rete regex + checksum
 ([`src/inspect/validate_checksums.py`](../src/inspect/validate_checksums.py))
-resta necessaria, e un checksum valido ha la precedenza sul modello. È la
-mitigazione della frammentazione dei codici lunghi, che si osserva anche via
-Transformers.js: su un codice fiscale il modello può alternare `CF` e `ID_DOC`
-fra i subword dello stesso codice.
+resta necessaria, e un checksum valido ha la precedenza sul modello.
+
+Sulla **v1.2.0** questo serviva anche a mitigare la frammentazione dei codici
+lunghi, osservabile via Transformers.js: su un codice fiscale il modello poteva
+alternare `CF` e `ID_DOC` fra i subword dello stesso codice. **La v1.3.0
+risolve il problema alla radice** — su un dataset esterno di 147 documenti la
+quota di span con etichette in conflitto sugli stessi offset scende dal 21,1%
+al 3,0% (1,7% in fp32). La rete di checksum resta comunque consigliata: è
+l'unico livello che può *verificare* un identificatore invece di riconoscerlo.
 
 ---
 
 ## Limiti di questa documentazione
 
-- Le dimensioni e i numeri di fedeltà sono misurati sulla **v1.2.0** con profilo
-  `arm64`. Altri profili CPU producono file di dimensione paragonabile ma non
-  identica.
+- Le dimensioni e i numeri di fedeltà sono misurati sulle versioni **v1.2.0** e
+  **v1.3.0** con profilo `arm64`. Altri profili CPU producono file di dimensione
+  paragonabile ma non identica.
 - La verifica `--verify` misura l'**accordo fra fp32 e INT8**, non l'accuratezza
   assoluta: dice quanto costa la quantizzazione, non quanto è buono il modello.
   Per quello c'è `src/training/evaluate_pii.py`.

--- a/requirements-onnx.txt
+++ b/requirements-onnx.txt
@@ -1,0 +1,12 @@
+# rizzo-pii — dipendenze aggiuntive per l'export ONNX (src/export/export_onnx.py)
+#
+# Tenute fuori da requirements.txt di proposito: servono solo a chi vuole
+# esportare il modello per un runtime ONNX o per il browser (Transformers.js).
+# Chi addestra o usa l'app desktop non ha motivo di installarle.
+#
+#   pip install -r requirements-onnx.txt
+
+optimum>=2.1
+optimum-onnx>=0.1
+onnx
+onnxruntime

--- a/src/export/export_onnx.py
+++ b/src/export/export_onnx.py
@@ -9,7 +9,7 @@ non cambia nulla della garanzia di privacy, cambia solo il motore che lo esegue.
 
 La quantizzazione INT8 riduce il file di ~4x. Con --verify si misura quanto
 costa in accuratezza, confrontando fp32 e INT8 sugli stessi testi (vedi
-docs/ONNX.md per i numeri della v1.2.0).
+docs/ONNX.md per i numeri misurati su v1.2.0 e v1.3.0).
 
 Dipendenze aggiuntive (non nel requirements.txt principale, per non appesantire
 chi vuole solo addestrare):

--- a/src/export/export_onnx.py
+++ b/src/export/export_onnx.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""
+Export del modello PII in ONNX, con quantizzazione INT8 opzionale.
+
+Serve a far girare rizzo-pii dove PyTorch non c'e': runtime ONNX nativi, e
+soprattutto **nel browser** via Transformers.js (estensioni, WebAssembly), che
+oggi non e' un target raggiungibile. Il modello resta interamente locale: ONNX
+non cambia nulla della garanzia di privacy, cambia solo il motore che lo esegue.
+
+La quantizzazione INT8 riduce il file di ~4x. Con --verify si misura quanto
+costa in accuratezza, confrontando fp32 e INT8 sugli stessi testi (vedi
+docs/ONNX.md per i numeri della v1.2.0).
+
+Dipendenze aggiuntive (non nel requirements.txt principale, per non appesantire
+chi vuole solo addestrare):
+
+  pip install -r requirements-onnx.txt
+
+Uso:
+  python src/export/export_onnx.py                      # fp32 + INT8, ultima versione
+  python src/export/export_onnx.py --no-quantize        # solo fp32
+  python src/export/export_onnx.py --verify             # export + confronto fp32/INT8
+  python src/export/export_onnx.py --arch avx512        # profilo CPU (default: arm64 su Apple silicon)
+  PII_MODEL_DIR=... python src/export/export_onnx.py    # modello specifico
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# File del tokenizer da affiancare al modello ONNX: Transformers.js li carica
+# dalla stessa cartella. Non tutti esistono per ogni tokenizer, si copia cio' che c'e'.
+TOKENIZER_FILES = (
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "vocab.txt",
+)
+
+
+def resolve_model_dir(models_dir):
+    """Ultima versione models/rizzo-pii-0.3B-v*; fallback al non versionato, poi al legacy.
+
+    Stessa logica di src/training/test_pii.py. Override puntuale: env PII_MODEL_DIR.
+    """
+    if os.environ.get("PII_MODEL_DIR"):
+        return Path(os.environ["PII_MODEL_DIR"])
+    versioned = [p for p in models_dir.glob("rizzo-pii-0.3B-v*") if p.is_dir()]
+    if versioned:
+        def _key(p):
+            m = re.search(r"-v([0-9][0-9.]*)$", p.name)
+            return tuple(int(x) for x in m.group(1).split(".")) if m else ()
+        return max(versioned, key=_key)
+    base = models_dir / "rizzo-pii-0.3B"
+    return base if base.exists() else models_dir / "pii_model_legacy"
+
+
+def dir_size(path):
+    return sum(f.stat().st_size for f in Path(path).rglob("*") if f.is_file())
+
+
+def mb(n):
+    return f"{n / 1024 / 1024:.1f} MB"
+
+
+def default_arch():
+    """Profilo CPU per la quantizzazione: arm64 su Apple silicon, avx2 altrove."""
+    import platform
+    return "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "avx2"
+
+
+def run_step(label, cmd):
+    """Esegue un comando mostrando il tempo impiegato; esce con l'output se fallisce."""
+    print(f"-> {label}...")
+    t0 = time.perf_counter()
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        print(res.stdout[-4000:])
+        print(res.stderr[-4000:], file=sys.stderr)
+        sys.exit(f"   FALLITO: {label}")
+    dt = time.perf_counter() - t0
+    print(f"   fatto in {dt:.0f}s")
+    return dt
+
+
+def export_fp32(model_dir, out_dir):
+    run_step(
+        "export ONNX fp32",
+        [sys.executable, "-m", "optimum.exporters.onnx",
+         "--model", str(model_dir), "--task", "token-classification", str(out_dir)],
+    )
+
+
+def quantize_int8(fp32_dir, staging_dir, arch):
+    run_step(
+        f"quantizzazione INT8 ({arch})",
+        ["optimum-cli", "onnxruntime", "quantize",
+         "--onnx_model", str(fp32_dir), f"--{arch}", "-o", str(staging_dir)],
+    )
+
+
+def assemble_bundle(model_dir, fp32_dir, staging_dir, bundle_dir):
+    """Compone la cartella nel layout atteso da Transformers.js: tokenizer alla
+    radice, pesi in onnx/model_quantized.onnx."""
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "onnx").mkdir(exist_ok=True)
+
+    for name in TOKENIZER_FILES:
+        for candidate in (staging_dir / name, fp32_dir / name, model_dir / name):
+            if candidate.exists():
+                shutil.copy2(candidate, bundle_dir / name)
+                break
+
+    if staging_dir is not None:
+        weights = next(staging_dir.glob("*_quantized.onnx"), None)
+        target = "model_quantized.onnx"
+    else:
+        weights = None
+    if weights is None:
+        weights = next(fp32_dir.glob("model.onnx"), None)
+        target = "model.onnx"
+    if weights is None:
+        sys.exit("Nessun file .onnx prodotto dall'export.")
+    shutil.copy2(weights, bundle_dir / "onnx" / target)
+
+    # Pesi esterni: l'export li separa quando il modello supera i 2 GB del formato protobuf.
+    source = staging_dir if staging_dir is not None else fp32_dir
+    for extra in source.glob("*.onnx_data"):
+        shutil.copy2(extra, bundle_dir / "onnx" / extra.name)
+    return bundle_dir / "onnx" / target
+
+
+def load_examples(limit):
+    """Testi per il confronto fp32/INT8: la validation reale se c'e', altrimenti
+    gli esempi di test_pii.py (lo script deve restare utile senza il dataset)."""
+    val = _ROOT / "dataset" / "validation" / "validation_real.jsonl"
+    if val.exists():
+        texts = []
+        with val.open(encoding="utf-8") as f:
+            for line in f:
+                row = json.loads(line)
+                text = row.get("text") or " ".join(row.get("tokens", []))
+                if text.strip():
+                    texts.append(text)
+                if len(texts) >= limit:
+                    break
+        if texts:
+            return texts, f"validation_real.jsonl ({len(texts)} righe)"
+
+    # Fallback: esempi che toccano tutti i 22 tag, cosi' la verifica resta
+    # significativa anche senza il dataset (che e' gitignorato e rigenerabile).
+    return [
+        "Mi chiamo Mario Rossi e la mia email e' mario.rossi@gmail.com, "
+        "telefono +39 333 1234567.",
+        "Il sottoscritto, nato a Milano il 12/06/1985, residente in Via Garibaldi 24, "
+        "chiede la restituzione della somma.",
+        "Per il pagamento usare l'IBAN IT60X0542811101000000123456 intestato "
+        "alla societa'.",
+        "L'avvocato ha depositato la comparsa presso il Tribunale di Roma in data "
+        "3 marzo 2024.",
+        "La societa' Edilnord S.r.l., P.IVA 12345678903, e' titolare dell'immobile "
+        "al Foglio 12, particella 345, sub. 6.",
+        "Il cliente Giulia Bianchi, codice fiscale BNCGLI90S43H501W, ha 35 anni "
+        "e risiede in Corso Vittorio Emanuele 118, 00185 Roma (RM).",
+        "Fattura n. 2451/2025 del 14 marzo 2025, imponibile € 12.500,00, "
+        "scadenza alle ore 15:30.",
+        "Carta di credito 4111 1111 1111 1111 intestata a Luca Esposito, "
+        "documento di identita' CA12345AB.",
+        "Il veicolo targato AB 123 CD e' assegnato alla dipendente Chiara Ferrari, "
+        "sesso femminile, assunta il 01/09/2021.",
+        "Ordine ricevuto da Meccanica Padana S.p.A. presso la sede di Via Dante 7, "
+        "35121 Padova, provincia PD.",
+        "Contattare il dott. Andrea Greco al numero 02 87654321 oppure "
+        "a.greco@studiolegale.it per la pratica RG 4821/2024.",
+        "Il conto corrente IT60X0542811101000000123456 presso la filiale di Torino "
+        "e' intestato a Federico Conti, nato il 22.11.1978.",
+    ], "esempi predefiniti (dataset/validation assente)"
+
+
+def predict_labels(model, tokenizer, texts, max_len):
+    """Etichetta prevista per ogni token di ogni testo, appiattita in una lista."""
+    import numpy as np
+    out = []
+    for text in texts:
+        enc = tokenizer(text, truncation=True, max_length=max_len, return_tensors="np")
+        logits = model(**{k: v for k, v in enc.items()}).logits
+        arr = logits.numpy() if hasattr(logits, "numpy") else np.asarray(logits)
+        out.extend(arr[0].argmax(axis=-1).tolist())
+    return out
+
+
+def verify(model_dir, fp32_dir, bundle_dir, max_len, limit):
+    """Confronta le predizioni fp32 e INT8 token per token sugli stessi testi."""
+    from optimum.onnxruntime import ORTModelForTokenClassification
+    from transformers import AutoTokenizer
+
+    texts, source = load_examples(limit)
+    print(f"\n-> verifica fp32 vs INT8 su {source}")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    ref = ORTModelForTokenClassification.from_pretrained(fp32_dir)
+    quant = ORTModelForTokenClassification.from_pretrained(
+        bundle_dir, subfolder="onnx", file_name="model_quantized.onnx"
+    )
+
+    labels_fp32 = predict_labels(ref, tokenizer, texts, max_len)
+    labels_int8 = predict_labels(quant, tokenizer, texts, max_len)
+
+    total = len(labels_fp32)
+    agree = sum(1 for a, b in zip(labels_fp32, labels_int8) if a == b)
+
+    # I token 'O' dominano: l'accordo sui soli token etichettati e' la misura severa.
+    o_id = next((int(k) for k, v in ref.config.id2label.items() if v == "O"), None)
+    ent_idx = [i for i, a in enumerate(labels_fp32) if a != o_id]
+    ent_agree = sum(1 for i in ent_idx if labels_fp32[i] == labels_int8[i])
+
+    print(f"   token totali          {total}")
+    print(f"   accordo complessivo   {100 * agree / total:.2f}%")
+    if ent_idx:
+        print(f"   token di entita'      {len(ent_idx)}")
+        print(f"   accordo sulle entita' {100 * ent_agree / len(ent_idx):.2f}%")
+    return {
+        "verify_source": source,
+        "tokens": total,
+        "agreement_all": round(100 * agree / total, 2),
+        "entity_tokens": len(ent_idx),
+        "agreement_entities": round(100 * ent_agree / len(ent_idx), 2) if ent_idx else None,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Export ONNX (+ INT8) del modello rizzo-pii.")
+    ap.add_argument("--model", default=None,
+                    help="cartella del modello (default: ultima versione in models/)")
+    ap.add_argument("--out", default=None,
+                    help="cartella di output (default: models/<nome>-onnx/)")
+    ap.add_argument("--no-quantize", action="store_true", help="esporta solo in fp32")
+    ap.add_argument("--arch", default=None,
+                    help="profilo CPU per la quantizzazione: arm64 | avx2 | avx512 | avx512_vnni")
+    ap.add_argument("--verify", action="store_true",
+                    help="confronta le predizioni fp32 e INT8 dopo l'export")
+    ap.add_argument("--verify-n", type=int, default=200,
+                    help="quanti testi usare per la verifica (default: 200)")
+    ap.add_argument("--max-len", type=int, default=768,
+                    help="lunghezza massima in subword, come nel training (default: 768)")
+    args = ap.parse_args()
+
+    model_dir = Path(args.model) if args.model else resolve_model_dir(_ROOT / "models")
+    if not Path(model_dir).exists():
+        sys.exit(f"Modello non trovato: {model_dir}\n"
+                 f"Addestralo (src/training/train_pii.py) o indica --model / PII_MODEL_DIR.")
+
+    out_dir = Path(args.out) if args.out else _ROOT / "models" / f"{Path(model_dir).name}-onnx"
+    fp32_dir = out_dir / "fp32"
+    staging_dir = out_dir / "quant-staging"
+    bundle_dir = out_dir / "bundle"
+    for path in (fp32_dir, staging_dir, bundle_dir):
+        if path.exists():
+            shutil.rmtree(path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    arch = args.arch or default_arch()
+    print(f"Modello:  {model_dir}")
+    print(f"Output:   {out_dir}\n")
+
+    export_fp32(model_dir, fp32_dir)
+    if args.no_quantize:
+        staging = None
+    else:
+        quantize_int8(fp32_dir, staging_dir, arch)
+        staging = staging_dir
+    weights_path = assemble_bundle(Path(model_dir), fp32_dir, staging, bundle_dir)
+
+    tokenizer_json = bundle_dir / "tokenizer.json"
+    stats = {
+        "model": str(model_dir),
+        "arch": arch if not args.no_quantize else None,
+        "onnx_fp32_bytes": dir_size(fp32_dir),
+        "weights_bytes": weights_path.stat().st_size,
+        "tokenizer_bytes": tokenizer_json.stat().st_size if tokenizer_json.exists() else 0,
+        "bundle_bytes": dir_size(bundle_dir),
+    }
+
+    print("\n── dimensioni ──")
+    for label, value in (
+        ("ONNX fp32", stats["onnx_fp32_bytes"]),
+        (f"pesi ({weights_path.name})", stats["weights_bytes"]),
+        ("tokenizer.json", stats["tokenizer_bytes"]),
+        ("BUNDLE TOTALE", stats["bundle_bytes"]),
+    ):
+        print(f"  {label:<30}{mb(value):>10}")
+
+    if args.verify and not args.no_quantize:
+        stats.update(verify(model_dir, fp32_dir, bundle_dir, args.max_len, args.verify_n))
+
+    (out_dir / "export_stats.json").write_text(
+        json.dumps(stats, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nBundle pronto: {bundle_dir}")
+    print(f"Statistiche:   {out_dir / 'export_stats.json'}")
+    print("\nCaricamento con Transformers.js: vedi docs/ONNX.md")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds an ONNX export path for the model, with optional INT8 quantization, plus documentation on using the result from [Transformers.js](https://github.com/huggingface/transformers.js).

- `src/export/export_onnx.py` — fp32 export, optional INT8 quantization (CPU profile auto-detected), and assembly of a `bundle/` in the layout Transformers.js expects (tokenizer at the root, weights under `onnx/`). Model resolution reuses the exact logic of `src/training/test_pii.py` (latest `models/rizzo-pii-0.3B-v*`, `PII_MODEL_DIR` override).
- `requirements-onnx.txt` — kept **separate on purpose**: `requirements.txt` is unchanged, so anyone who only trains or runs the desktop app installs nothing extra.
- `docs/ONNX.md` — usage, measured sizes, and a tested JS snippet.
- `docs/CHANGELOG.md` — entry with rationale, per CONTRIBUTING.
- `README.md` — repo structure, documentation table, one paragraph under Deployment.

No changes to training, dataset, taxonomy or the desktop app. Nothing is removed or altered — this is purely additive.

## Why

Today the model is reachable only from PyTorch, so only from Python. ONNX makes it usable from native runtimes and, above all, from **Transformers.js** — browsers, extensions, WebAssembly. Those are exactly the places where *"anonymize before sending to the LLM"* is the user's actual gesture, but where a Python backend cannot be installed.

It changes the engine, not the privacy guarantee: the model still runs entirely locally, with no network call.

## Measured results (v1.2.0, arm64 profile)

| Artifact | Size |
|---|---:|
| ONNX fp32 | 1206.6 MB |
| `model_quantized.onnx` (INT8) | **294.3 MB** |
| `tokenizer.json` | 32.8 MB |
| Bundle total | 327.1 MB |

Export ~10 s, quantization ~10 s.

`--verify` compares fp32 and INT8 predictions token by token. On v1.2.0 with the built-in examples (537 tokens, 242 of them entity tokens):

| Measure | Value |
|---|---:|
| Agreement on all tokens | **98.51%** |
| Agreement on entity tokens | **98.76%** |

So quantization is essentially free in accuracy for a 4× smaller file. With `dataset/validation/validation_real.jsonl` present, `--verify` uses that instead of the built-in examples.

## One thing worth flagging

While testing the bundle I hit an obstacle that is not obvious and that anyone deploying to the browser will hit too: **the Transformers.js `token-classification` pipeline does not return character offsets**. Each token carries only `entity`, `score`, `index` and `word` — no `start`/`end`. Without offsets you cannot substitute text, which is precisely what the reversible anonymization workflow needs.

With the mmBERT Metaspace tokenizer the reconstruction is **exact**: concatenating the `word` values reproduces the input preceded by a single space, so cumulative lengths give the offsets, shifted by one. The detail that makes it work is that you must pass `ignore_labels: []` — the default `['O']` drops tokens and desynchronizes the count.

`docs/ONNX.md` documents this with a snippet that was actually executed, not pseudo-code.

## Tested / not tested

- Export and INT8 quantization: run end to end on macOS (Apple silicon, `arm64` profile).
- The bundle was loaded and run with `@huggingface/transformers` 3.8.1 **in Node**, producing correct entities and correct character offsets with the documented helper.
- **Not** executed in a real browser. The pipeline code path is the same, but the distinction is stated explicitly in the limitations section of `docs/ONNX.md` rather than glossed over.
- The `--verify` numbers come from the built-in examples, since `dataset/` is gitignored and I did not regenerate it.

## Context

We maintain [Talos](https://talos.to), a browser DLP extension that masks PII in prompts to ChatGPT/Claude/Gemini/Copilot on-device. We benchmarked rizzo-pii against the NER model we currently ship, which is how we ended up needing an ONNX path. Happy to share the benchmark findings separately as issues if useful — there are a couple of observations on span granularity and label consistency that seem worth reporting on their own.

