### PR TITLE
Contribuire dati senza chiave Gemini + iniettori per i 4 tag che il sintetico non poteva produrre

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,43 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-31 — Contribuire senza chiave Gemini + iniettori per i 4 tag scoperti
+
+Due modifiche alla pipeline dati, entrambe pensate per allargare chi e cosa può contribuire.
+
+**1. Template scritti da un agente di coding** (`contribute_dataset.py`). Nuove opzioni
+`--templates-file` e `--template-author`: la prosa con i segnaposto può arrivare da un file
+scritto da un agente (Claude Code, Cursor, …) invece che da Gemini. Il principio *"LLM autore,
+codice etichettatore"* non cambia — l'LLM scrive solo il testo, il codice inietta i valori e
+ricava le label BIO — quindi il ruolo dell'LLM esterno è sostituibile: **contribuire non
+richiede più una chiave API di terze parti**, che era il principale ostacolo pratico per un
+contributore occasionale.
+
+I template passano per la stessa guardia anti-PII-inline dei template Gemini
+(`valida_template_agente`), con due differenze: il set di segnaposto ammessi è quello degli
+**iniettori** (`gen.SLOTS`, che copre anche `PROVINCE` e gli elenchi, non solo i segnaposto
+proposti a Gemini), e vengono **scartati i template con due segnaposto separati da soli spazi**
+— caso in cui le entità iniettate risulterebbero adiacenti senza un token `O` fra loro e si
+fonderebbero in un'unica sequenza (cfr. `docs/FORMATO_DATI.md`). `meta.template_author`
+registra chi ha scritto il template **di ogni singola riga**: le righe che pescano dai template
+built-in restano marcate `built-in`, così il dato resta vero anche su un pool misto.
+
+**2. Iniettori per `CREDITCARDNUMBER`, `TIME`, `AGE`, `GENDER`** (`generate_synthetic_pii.py`).
+Erano quattro tag della tassonomia che **nessun template poteva produrre**, perché non
+esisteva un generatore: il sintetico non contribuiva a colmarli e restavano appesi alle sole
+fonti esterne — proprio mentre `CREDITCARDNUMBER` è il tag più raro del pool (~66× meno di
+`FULLNAME`), cioè il più esposto allo sbilanciamento di classe già annotato fra i limiti noti.
+
+Il numero di carta è generato con **checksum di Luhn valido**, coerentemente con CF/PIVA/IBAN:
+è la stessa condizione che la rete regex+checksum applica in produzione, quindi un valore senza
+checksum valido non sarebbe stato riconosciuto dal detector deterministico. `TIME` tagga il solo
+orario (`ore` resta contesto, come per il tribunale); `AGE` tagga il numero e lascia `anni` come
+contesto; `GENDER` copre sia le forme estese sia le sigle dei moduli anagrafici. I quattro
+segnaposto sono aggiunti anche ad `ALLOWED_SLOTS`/`SLOT_HINTS` di `llm_template_bank.py`, così
+il percorso Gemini li usa da subito.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -398,8 +398,12 @@ def write_local(rows, out_path):
     return out_path
 
 
-def upload_pr(local_path, path_in_repo, handle, n, seed, repo_id):
-    """Carica il file aprendo una Pull Request sul dataset HF."""
+def upload_pr(local_path, path_in_repo, handle, n, seed, repo_id, descrizione=None):
+    """Carica il file aprendo una Pull Request sul dataset HF.
+
+    'descrizione' e' il corpo della PR: serve a spiegare al maintainer cosa contiene
+    quel lotto (tipi di documento, tag rinforzati, come e' stato verificato). Senza,
+    si usa il testo generico."""
     try:
         from huggingface_hub import HfApi
     except ImportError:
@@ -424,7 +428,7 @@ def upload_pr(local_path, path_in_repo, handle, n, seed, repo_id):
         repo_id=repo_id,
         repo_type="dataset",
         commit_message=commit,
-        commit_description=(
+        commit_description=descrizione or (
             "Dati 100% sintetici generati con src/data_pipeline/contribute_dataset.py "
             "(principio 'LLM autore, codice etichettatore', checksum CF/PIVA/IBAN validi). "
             "Nessuna PII reale."),
@@ -461,7 +465,17 @@ def main():
     ap.add_argument("--upload-file", metavar="PATH",
                     help="non rigenerare: carica un .jsonl gia' prodotto (push veloce, niente Gemini)")
     ap.add_argument("--repo", default=REPO_ID, help="dataset di destinazione (override)")
+    ap.add_argument("--pr-description", metavar="PATH",
+                    help="file di testo con il corpo della Pull Request: spiega al "
+                         "maintainer cosa contiene il lotto")
     args = ap.parse_args()
+
+    descrizione = None
+    if args.pr_description:
+        p_desc = Path(args.pr_description)
+        if not p_desc.is_file():
+            sys.exit(f"ERRORE: file di descrizione inesistente: {p_desc}")
+        descrizione = p_desc.read_text(encoding="utf-8")
 
     # scorciatoia: ri-carica un file gia' generato (utile per ritentare il push)
     if args.upload_file:
@@ -472,7 +486,8 @@ def main():
         print(f"Carico file esistente ({n} righe): {p}")
         # se il contributore passa anche --handle, il commit porta il suo nome invece
         # del generico "upload" (il file e' gia' stato generato in un run precedente)
-        upload_pr(p, f"contributions/{p.name}", args.handle or "upload", n, "-", args.repo)
+        upload_pr(p, f"contributions/{p.name}", args.handle or "upload", n, "-", args.repo,
+                  descrizione)
         return
 
     if args.n < 1 or args.n > MAX_N:
@@ -518,7 +533,8 @@ def main():
         print("\n(--no-upload) Nessun caricamento. Rilancia senza --no-upload per aprire la PR.")
         return
 
-    upload_pr(local_path, f"contributions/{fname}", handle, len(rows), seed, args.repo)
+    upload_pr(local_path, f"contributions/{fname}", handle, len(rows), seed, args.repo,
+              descrizione)
 
 
 if __name__ == "__main__":

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -42,6 +42,11 @@ Uso
 
   # senza chiave Gemini: usa solo i template built-in (dati meno "nuovi")
   python src/data_pipeline/contribute_dataset.py --n 5000 --handle iltuonome --offline
+
+  # template scritti dal TUO agente di coding (Claude Code, Cursor, ...) invece che
+  # da Gemini: stesso principio "LLM autore, codice etichettatore", nessuna chiave API
+  python src/data_pipeline/contribute_dataset.py --n 5000 --handle iltuonome \
+      --templates-file dataset/synthetic/legal_templates_claude.json --template-author claude
 """
 
 import argparse
@@ -49,6 +54,7 @@ import io
 import json
 import os
 import random
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -239,19 +245,88 @@ def gen_new_templates(per_type, boost):
     return out
 
 
-def generate(n, seed, handle, per_type, offline, boost):
-    """Genera n esempi sintetici. Con Gemini usa template NUOVI scritti al volo.
+def valida_template_agente(text):
+    """Guardia sui template scritti da un agente di coding.
+
+    Stessa sostanza di tb.clean_and_validate (niente markdown, niente PII scritta
+    inline), ma il set di segnaposto ammessi e' quello degli INIETTORI
+    (gen.SLOTS): copre anche PROVINCE e i generatori di elenchi, che
+    build_example() sa espandere ma che non vengono proposti a Gemini.
+    In piu' scarta i template con due segnaposto separati da soli spazi: le entita'
+    iniettate risulterebbero adiacenti senza un token 'O' fra loro e si
+    fonderebbero (cfr. docs/FORMATO_DATI.md)."""
+    if not text:
+        return None
+    text = re.sub(r"^```.*?\n|```$", "", text.strip(), flags=re.MULTILINE).strip()
+    slots = set(gen.SLOT_RE.findall(text))
+    if not slots:
+        return None
+    ignoti = slots - set(gen.SLOTS)
+    if ignoti:
+        print(f"  scartato: segnaposto senza iniettore {sorted(ignoti)}")
+        return None
+    stray = tb.find_stray_names(text)
+    if stray:
+        print(f"  scartato: probabili nomi inline non taggati {sorted(set(stray))[:8]}")
+        return None
+    if re.search(r"\}\s*\{", text):
+        print("  scartato: due segnaposto senza testo in mezzo (entita' che si fondono)")
+        return None
+    return text
+
+
+def load_agent_templates(path):
+    """Carica i template scritti da un agente di coding al posto di Gemini.
+
+    Il file e' lo stesso formato prodotto da llm_template_bank.py
+    ([{"id", "doc_type", "text"}, ...] oppure una lista di stringhe). Serve a chi
+    ha un agente di coding ma non una chiave Gemini: il principio non cambia
+    (l'LLM scrive SOLO la prosa con i segnaposto, il codice inietta i dati e le
+    label), cambia solo quale modello ha scritto il testo."""
+    if not os.path.isfile(path):
+        sys.exit(f"ERRORE: file dei template inesistente: {path}")
+    try:
+        raw = json.load(open(path, encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        sys.exit(f"ERRORE: {path} non e' un JSON valido: {e}")
+    if not isinstance(raw, list):
+        sys.exit(f"ERRORE: {path} deve contenere una lista di template.")
+
+    out, scartati = [], 0
+    for item in raw:
+        text = item.get("text") if isinstance(item, dict) else item
+        clean = valida_template_agente(text)
+        if clean:
+            out.append(clean)
+        else:
+            scartati += 1
+    print(f"Template dal file {os.path.basename(path)}: {len(out)} validi, {scartati} scartati")
+    if not out:
+        sys.exit("ERRORE: nessun template valido nel file indicato.")
+    return out
+
+
+def generate(n, seed, handle, per_type, offline, boost,
+             templates_file=None, template_author=None):
+    """Genera n esempi sintetici. Con Gemini usa template NUOVI scritti al volo;
+    con --templates-file usa quelli scritti dall'agente di coding.
     Ritorna (righe, conteggi, n_template_nuovi)."""
     # IMPORTANTE: ri-seminiamo DOPO l'import (gen imposta seed(42) a import-time).
     # Seed diverso per contributore => valori diversi => no duplicati nel dataset.
     random.seed(seed)
 
-    new_templates = [] if offline else gen_new_templates(per_type, boost)
+    if templates_file:
+        new_templates = load_agent_templates(templates_file)
+    elif offline:
+        new_templates = []
+    else:
+        new_templates = gen_new_templates(per_type, boost)
     # i built-in garantiscono comunque la copertura dei tag rari (CATASTO/DOCID/CONTO...);
     # la NOVITA' del testo viene dai template freschi di Gemini.
     templates = new_templates + gen.TEMPLATES + gen.load_external_templates()
+    origine = f"scritti da {template_author}" if templates_file else "nuovi da Gemini"
     print(f"\nTemplate nel pool: {len(templates)} "
-          f"({len(new_templates)} nuovi da Gemini + {len(gen.TEMPLATES)} built-in + "
+          f"({len(new_templates)} {origine} + {len(gen.TEMPLATES)} built-in + "
           f"{len(templates) - len(new_templates) - len(gen.TEMPLATES)} locali)")
 
     # selezione pesata: i template che coprono i tag potenziati escono piu' spesso
@@ -261,6 +336,8 @@ def generate(n, seed, handle, per_type, offline, boost):
     idx_pool = list(range(len(templates)))
 
     n_new = len(new_templates)
+    # etichetta di provenienza dei template "nuovi" di questo run
+    autore_nuovi = template_author or ("built-in" if offline else "gemini")
     rows, label_counts, bad = [], {}, 0
     for _ in range(n):
         tid = random.choices(idx_pool, weights=weights, k=1)[0]
@@ -276,8 +353,12 @@ def generate(n, seed, handle, per_type, offline, boost):
             # provenienza: sopravvive a merge/split, ignorata dal loader di training
             "meta": {"contributor": handle, "seed": seed,
                      "generator_version": GENERATOR_VERSION, "synthetic": True,
-                     # True se la riga usa un template NUOVO scritto da Gemini in questo run
-                     "new_template": tid < n_new},
+                     # True se la riga usa un template NUOVO (scritto da Gemini in questo
+                     # run, oppure fornito con --templates-file)
+                     "new_template": tid < n_new,
+                     # chi ha scritto la prosa del template USATO DA QUESTA RIGA: le
+                     # righe che pescano dai template built-in restano "built-in"
+                     "template_author": (autore_nuovi if tid < n_new else "built-in")},
         }
         err = _validate_record(rec)
         if err:
@@ -352,6 +433,12 @@ def main():
                     help="rinforza i tag sotto-rappresentati, es. --boost ORG=6 IBAN=4 CF=4")
     ap.add_argument("--offline", action="store_true",
                     help="non usare Gemini: genera dai soli template built-in (dati meno nuovi)")
+    ap.add_argument("--templates-file", metavar="PATH",
+                    help="JSON di template scritti dal tuo agente di coding invece che da "
+                         "Gemini (stesso formato di llm_template_bank.py): nessuna chiave API")
+    ap.add_argument("--template-author", default=None, metavar="NOME",
+                    help="chi ha scritto i template di --templates-file (es. claude, cursor): "
+                         "finisce in meta.template_author per tracciabilita'")
     ap.add_argument("--no-upload", action="store_true",
                     help="genera solo in locale, non apre la PR")
     ap.add_argument("--upload-file", metavar="PATH",
@@ -384,13 +471,21 @@ def main():
     print("rizzo-pii — contribuzione dati sintetici al dataset community")
     print("⚠️  Solo dati SINTETICI: nessuna PII reale viene prodotta o caricata.")
     print("=" * 70)
-    mode = "built-in (offline)" if args.offline else f"Gemini (--per-type {args.per_type})"
+    if args.templates_file:
+        autore = args.template_author or "agente di coding"
+        mode = f"file ({os.path.basename(args.templates_file)}, autore: {autore})"
+    elif args.offline:
+        mode = "built-in (offline)"
+    else:
+        mode = f"Gemini (--per-type {args.per_type})"
     print(f"handle={handle}  n={args.n}  seed={seed}  template={mode}")
 
-    rows, counts, n_new = generate(args.n, seed, handle, args.per_type, args.offline, boost)
+    rows, counts, n_new = generate(args.n, seed, handle, args.per_type, args.offline, boost,
+                                   args.templates_file, args.template_author)
     if n_new:
         from_new = sum(1 for r in rows if r["meta"]["new_template"])
-        print(f"\n{from_new}/{len(rows)} esempi da template NUOVI di Gemini.")
+        origine = args.template_author or "agente di coding" if args.templates_file else "Gemini"
+        print(f"\n{from_new}/{len(rows)} esempi da template NUOVI di {origine}.")
     print(f"Generati {len(rows)} esempi validi. Entita' per label:")
     for label, c in sorted(counts.items(), key=lambda x: -x[1]):
         print(f"  {label:18s} {c}")

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -453,7 +453,9 @@ def main():
             sys.exit(f"ERRORE: file inesistente: {p}")
         n = sum(1 for _ in open(p, encoding="utf-8"))
         print(f"Carico file esistente ({n} righe): {p}")
-        upload_pr(p, f"contributions/{p.name}", "upload", n, "-", args.repo)
+        # se il contributore passa anche --handle, il commit porta il suo nome invece
+        # del generico "upload" (il file e' gia' stato generato in un run precedente)
+        upload_pr(p, f"contributions/{p.name}", args.handle or "upload", n, "-", args.repo)
         return
 
     if args.n < 1 or args.n > MAX_N:

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -109,6 +109,21 @@ def piva_ok(p):
     return (10 - t % 10) % 10 == int(p[10])
 
 
+def luhn_ok(c):
+    """Checksum di Luhn: vale per le carte di credito (spazi ignorati)."""
+    cifre = [int(x) for x in c if x.isdigit()]
+    if len(cifre) < 13:
+        return False
+    tot = 0
+    for i, d in enumerate(reversed(cifre)):
+        if i % 2 == 1:
+            d *= 2
+            if d > 9:
+                d -= 9
+        tot += d
+    return tot % 10 == 0
+
+
 def cf_ok(c):
     if len(c) != 16:
         return False
@@ -199,6 +214,8 @@ def _validate_record(rec):
             return f"PIVA con checksum non valido: {e['value']}"
         if e["label"] == "IBAN" and not iban_ok(e["value"]):
             return f"IBAN con checksum non valido: {e['value']}"
+        if e["label"] == "CREDITCARDNUMBER" and not luhn_ok(e["value"]):
+            return f"carta di credito con checksum non valido: {e['value']}"
     return None
 
 

--- a/src/data_pipeline/generate_synthetic_pii.py
+++ b/src/data_pipeline/generate_synthetic_pii.py
@@ -339,6 +339,50 @@ def piva_piece():
 def iban_piece():
     return [(iban_it(), "IBAN")]
 
+def _luhn_check_digit(parziale):
+    """Cifra di controllo di Luhn per un numero privo dell'ultima cifra."""
+    tot = 0
+    for i, c in enumerate(reversed(parziale)):
+        d = int(c)
+        if i % 2 == 0:            # nel numero completo finira' in posizione da raddoppiare
+            d *= 2
+            if d > 9:
+                d -= 9
+        tot += d
+    return (10 - tot % 10) % 10
+
+def creditcard_piece():
+    """Numero di carta con checksum di Luhn VALIDO.
+
+    Stessa logica di CF/PIVA/IBAN: il valore deve superare il proprio controllo
+    matematico, cosi' la rete regex+checksum in produzione lo riconosce davvero.
+    Le cifre sono casuali: nessun numero reale viene mai prodotto."""
+    prefisso = random.choice(["4", "51", "52", "53", "54", "55"])   # circuiti piu' comuni
+    corpo = prefisso + "".join(str(random.randint(0, 9)) for _ in range(15 - len(prefisso)))
+    numero = corpo + str(_luhn_check_digit(corpo))
+    if random.random() < 0.7:                      # come compare su estratti conto e atti
+        numero = " ".join(numero[i:i + 4] for i in range(0, 16, 4))
+    return [(numero, "CREDITCARDNUMBER")]
+
+def time_piece():
+    """Ora del giorno. Si tagga il solo orario: 'ore' resta contesto, come per il
+    tribunale (il termine non e' il dato personale)."""
+    h = random.randint(6, 21)
+    m = random.choice([0, 5, 10, 15, 20, 30, 40, 45, 50])
+    return [(random.choice([f"{h:02d}:{m:02d}", f"{h}:{m:02d}", f"{h}.{m:02d}"]), "TIME")]
+
+def age_piece():
+    """Eta'. Il numero e' l'entita', 'anni' e' il contesto che la introduce o la segue."""
+    n = str(random.randint(18, 92))
+    if random.random() < 0.7:
+        return [(n, "AGE"), (" anni", None)]
+    return [("anni ", None), (n, "AGE")]
+
+def gender_piece():
+    """Sesso/genere come compare negli atti e nei moduli anagrafici."""
+    return [(random.choice(["maschile", "femminile", "M", "F", "uomo", "donna",
+                            "maschio", "femmina"]), "GENDER")]
+
 # stem per ragioni sociali (nomi di fantasia, nessun riferimento reale)
 COMPANY_STEMS = ["Adriatica", "Meridionale", "Lombarda", "Tirrenica", "Alfa", "Beta",
                  "Costruzioni Moderne", "Logistica Veloce", "Tecnoimpianti",
@@ -522,6 +566,8 @@ SLOTS = {
     "DRIVING": driving_piece, "CITY": city_piece, "DATE": date_piece,
     "ORG": org_piece, "DOCID": docid_piece, "CATASTO": catasto_piece,
     "CONTO": conto_piece, "PROVINCE": province_piece,
+    "CREDITCARD": creditcard_piece, "TIME": time_piece, "AGE": age_piece,
+    "GENDER": gender_piece,
     "NAMELIST": name_list, "ORGLIST": org_list, "MIXEDLIST": mixed_list,
 }
 

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -41,7 +41,7 @@ ALLOWED_SLOTS = {
     "FULLNAME", "JUDGE", "LAWYER", "PLAINTIFF", "DEFENDANT", "WITNESS",
     "CF", "PIVA", "IBAN", "ADDRESS", "EMAIL", "PEC", "PHONE", "AMOUNT",
     "RG", "TRIBUNAL", "TARGA", "IDCARD", "DRIVING", "CITY", "DATE",
-    "ORG", "DOCID", "CATASTO", "CONTO",
+    "ORG", "DOCID", "CATASTO", "CONTO", "CREDITCARD", "TIME", "AGE", "GENDER",
 }
 
 # breve legenda per i segnaposto il cui uso non e' ovvio dal nome (guida l'LLM a
@@ -49,7 +49,11 @@ ALLOWED_SLOTS = {
 SLOT_HINTS = """  {ORG}     = ragione sociale di una societa'/studio legale/banca (la PARTE, non il tribunale)
   {DOCID}   = codice identificativo di un atto: n. protocollo, n. repertorio/raccolta, n. sentenza
   {CATASTO} = dati catastali di un immobile (foglio, particella, subalterno)
-  {CONTO}   = numero di conto corrente (diverso dall'IBAN)"""
+  {CONTO}   = numero di conto corrente (diverso dall'IBAN)
+  {CREDITCARD} = numero di carta di credito (verbali di frode, contratti con pagamento a mezzo carta)
+  {TIME}    = orario, da usare dopo la parola "ore" (es. "alle ore {TIME}") nei verbali
+  {AGE}     = eta' di una persona; il segnaposto porta gia' con se' la parola "anni"
+  {GENDER}  = sesso/genere come compare nei moduli anagrafici e nei verbali di identificazione"""
 
 DOC_TYPES = [
     "atto di citazione", "comparsa di costituzione e risposta", "sentenza civile",


### PR DESCRIPTION
Ciao, complimenti per il progetto: l'idea di tenere le PII in locale e mandare al modello solo i segnaposto è esattamente ciò che serve a chi lavora con documenti legali italiani, e la copertura di CF/P.IVA/catasto non la offre nessun altro modello aperto.

Ho provato a contribuire dati e, facendolo, sono emerse quattro modifiche che propongo qui. Sono già state usate sul campo: hanno prodotto le due PR di dati [#478](https://huggingface.co/datasets/rizzoaiacademy/anonimizzazione-testi-italiano/discussions/478) e [#487](https://huggingface.co/datasets/rizzoaiacademy/anonimizzazione-testi-italiano/discussions/487) sul dataset (22.000 esempi, 637.180 entità).

## 1. Contribuire senza una chiave API di terze parti

`contribute_dataset.py` guadagna `--templates-file` e `--template-author`: la prosa con i segnaposto può arrivare da un file scritto da un agente di coding (Claude Code, Cursor, …) invece che da Gemini.

Il principio *"LLM autore, codice etichettatore"* non cambia — l'LLM scrive solo il testo, il codice inietta i valori e ricava le label BIO — quindi il ruolo dell'LLM esterno è sostituibile. Il README propone già di far fare tutto a un agente di coding: questa patch elimina l'ultimo prerequisito, cioè procurarsi una chiave Gemini, che per un contributore occasionale è l'ostacolo pratico più grosso.

I template passano per la stessa guardia anti-PII-inline dei template Gemini, con due differenze:

- il set di segnaposto ammessi è quello degli **iniettori** (`gen.SLOTS`), non solo quelli proposti a Gemini: include `PROVINCE` e i generatori di elenchi, che `build_example()` sa già espandere;
- vengono scartati i template con **due segnaposto separati da soli spazi**. È il caso in cui le entità iniettate risultano adiacenti senza un token `O` fra loro e si fondono in un'unica sequenza (`docs/FORMATO_DATI.md` lo vieta, ma nulla lo controllava). Mi ci sono imbattuto scrivendo un template con `{LAWYER}` a fine riga e `{ADDRESS}` a inizio della successiva.

`meta.template_author` registra chi ha scritto il template **di ogni singola riga**: su un pool misto le righe che pescano dai template built-in restano marcate `built-in`, così il campo resta vero e il revisore vede la composizione reale del lotto.

## 2. Iniettori per `CREDITCARDNUMBER`, `TIME`, `AGE`, `GENDER`

Questi quattro tag della tassonomia non avevano un generatore in `generate_synthetic_pii.py`: **nessun template poteva produrli**, quindi il sintetico non contribuiva a colmarli e restavano appesi alle sole fonti esterne. È un peccato soprattutto per `CREDITCARDNUMBER`, che nel `CLAUDE.md` è indicato come il tag più raro del pool (~66× meno di `FULLNAME`), cioè il più esposto allo sbilanciamento di classe fra i limiti noti.

Il numero di carta è generato con **checksum di Luhn valido**, coerentemente con CF/P.IVA/IBAN: è la stessa condizione che la rete regex+checksum applica in produzione, quindi un valore senza checksum valido non verrebbe nemmeno riconosciuto dal detector deterministico. `_validate_record()` verifica il Luhn sulle righe prodotte.

Sulle scelte di etichettatura, sono aperto a correzioni:

- `TIME` tagga il **solo orario**, lasciando `ore` come contesto — stessa logica con cui `TRIBUNAL` non è PII;
- `AGE` tagga il **numero** e lascia `anni` come contesto, in entrambe le posizioni;
- `GENDER` copre sia le forme estese sia le sigle dei moduli anagrafici.

I quattro segnaposto sono aggiunti anche ad `ALLOWED_SLOTS`/`SLOT_HINTS`, così il percorso Gemini li usa da subito.

## 3. `--pr-description`

Permette di allegare alla Pull Request sul dataset un corpo scritto dal contributore, che spieghi cosa contiene quel lotto. Con lotti da decine di migliaia di righe, una descrizione fa la differenza fra una PR revisionabile e una scatola chiusa.

## 4. `--upload-file` rispetta `--handle`

Ricaricando un file già generato, il commit veniva firmato `handle=upload` invece che con l'handle del contributore.

## Verifica

Le modifiche sono state esercitate generando 22.000 esempi su 115 template e 110 tipi di documento. Ogni lotto è stato ricontrollato da uno script indipendente che non si fida del generatore e ricalcola tutto dal solo `source_text`: tokenizzazione secondo la regex della specifica, offset di ogni entità, coerenza BIO (`I-` solo dopo `B-`/`I-` dello stesso tag), numero di `B-` pari al numero di entità, checksum CF/P.IVA/IBAN/Luhn, e controllo che le e-mail restino su domini di test. Zero errori.

Nessun comportamento esistente cambia: senza le nuove opzioni lo script si comporta esattamente come prima. `docs/CHANGELOG.md` riporta la voce con il razionale.

Se preferisci un taglio diverso su qualsiasi punto — nomi delle opzioni, confini dei tag `TIME`/`AGE`, o separare la PR in due — dimmi pure come procedere.
