### PR TITLE
Template scrivibili da un LLM locale (endpoint OpenAI-compatibile)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,9 @@ Contributions of code, documentation and (above all) data are all welcome.
   ```bash
   pip install huggingface_hub                                     # the data script needs no torch
   export GEMINI_API_KEY=...      # https://aistudio.google.com/apikey   (PowerShell: $env:GEMINI_API_KEY=...)
+  # …or write the templates with a LOCAL model instead — no API key, nothing leaves the machine:
+  export LLM_BASE_URL=http://127.0.0.1:8080/v1   # llama.cpp / Ollama / vLLM / LM Studio
+  export LLM_MODEL=your-model-name
   hf auth login                  # or: export HF_TOKEN=hf_xxx
   # dry run (no upload), then the real batch boosting the weak tags:
   python src/data_pipeline/contribute_dataset.py --n 300  --handle yourname --no-upload

--- a/README.md
+++ b/README.md
@@ -452,7 +452,12 @@ the code injects valid values (CF/PIVA/IBAN checksums) and exact BIO labels — 
 **Pull Request** on the dataset for a maintainer to review. You can let your coding agent
 (Claude Code, Cursor, …) do everything: get a [Gemini API key](https://aistudio.google.com/apikey)
 and a [Hugging Face token](https://huggingface.co/settings/tokens), then **copy-paste the prompt
-below** (fill in the two keys and your handle):
+below** (fill in the two keys and your handle).
+
+> 🖥️ **No API key? Use your own local model.** Set `LLM_BASE_URL` (any OpenAI-compatible
+> endpoint — llama.cpp server, Ollama, vLLM, LM Studio) and `LLM_MODEL` instead of
+> `GEMINI_API_KEY`, and the templates are written **on your machine**: no key, no prompt
+> leaving the device. Fitting, for a privacy project.
 
 ```text
 Sei nel repository rizzo-pii. Voglio CONTRIBUIRE dati sintetici NUOVI al dataset Hugging Face

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,28 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-30 — I template si possono scrivere con un LLM **locale** (senza chiave Gemini)
+
+Per contribuire dati serviva una chiave Google, e i prompt uscivano dalla macchina: attrito
+d'ingresso per chi vuole aiutare, e una stonatura in un progetto il cui punto è **non mandare
+niente a terzi**. `llm_template_bank.py` ha ora un secondo backend: se è impostata
+**`LLM_BASE_URL`** (endpoint OpenAI-compatibile — llama.cpp server, Ollama, vLLM, LM Studio) i
+template li scrive quel modello, in locale. Senza la variabile nulla cambia: si usa Gemini
+esattamente come prima.
+
+`call_llm()` smista tra i due backend; `backend_name()` lo stampa nei log; `have_backend()`
+sostituisce il controllo della sola `GEMINI_API_KEY` in `contribute_dataset.py`, che ora spiega
+entrambe le strade. Le guardie sui template (segnaposto ammessi, nomi inline) sono le stesse:
+il testo di un modello locale passa gli stessi controlli.
+
+**Dettaglio non ovvio, costato una diagnosi:** un modello *reasoning* servito in locale può
+mettere **tutto** l'output in `reasoning_content` e restituire `content` **vuoto** (visto con
+gemma-4-12B su llama.cpp: 175 s di pensiero, zero testo). La richiesta manda quindi
+`chat_template_kwargs: {enable_thinking: false}` e, per sicurezza, accetta `reasoning_content`
+come ripiego.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,13 @@ gemma-4-12B su llama.cpp: 175 s di pensiero, zero testo). La richiesta manda qui
 `chat_template_kwargs: {enable_thinking: false}` e, per sicurezza, accetta `reasoning_content`
 come ripiego.
 
+**Nuova guardia `non_latin_char()`** in `clean_and_validate()`: un modello locale quantizzato può
+infilare un **ideogramma** in mezzo alla prosa italiana (`"oltre a槽 interessi"`), e il template
+passava tutti i controlli esistenti — il carattere finiva poi in **ogni** esempio generato da quel
+template (visto: 87 righe su 5.000 da un solo template). Ora un template con caratteri non latini
+viene scartato. La guardia è utile anche col backend Gemini, ma è coi modelli locali che il caso
+si presenta davvero.
+
 ---
 
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -204,9 +204,12 @@ def gen_new_templates(per_type, boost):
     PII inline o segnaposto non gestiti (stessa validazione di llm_template_bank).
     Se 'boost' e' presente, chiede a Gemini di usare spesso i segnaposto dei tag
     potenziati -> piu' esempi per i tag sotto-rappresentati."""
-    if not (os.environ.get("GEMINI_API_KEY") or tb.API_KEY):
-        sys.exit("ERRORE: GEMINI_API_KEY non impostata.\n"
-                 "  Ottieni una chiave su https://aistudio.google.com/apikey e poi:\n"
+    if not tb.have_backend():
+        sys.exit("ERRORE: nessun backend LLM configurato.\n"
+                 "  (a) LLM LOCALE, senza chiave e senza far uscire nulla dalla macchina:\n"
+                 "    export LLM_BASE_URL=http://127.0.0.1:8080/v1   # llama.cpp / Ollama / vLLM\n"
+                 "    export LLM_MODEL=nome-del-modello\n"
+                 "  (b) Gemini: chiave su https://aistudio.google.com/apikey e poi:\n"
                  "    export GEMINI_API_KEY=...        (PowerShell: $env:GEMINI_API_KEY=...)\n"
                  "  Oppure usa --offline per generare dai soli template built-in.")
 
@@ -219,7 +222,7 @@ def gen_new_templates(per_type, boost):
                 "i seguenti segnaposto: " + " ".join(f"{{{s}}}" for s in boost_slots) + ".")
 
     total = len(tb.DOC_TYPES) * per_type
-    print(f"Scrivo {total} NUOVI template con Gemini [{tb.MODEL}] "
+    print(f"Scrivo {total} NUOVI template con [{tb.backend_name()}] "
           f"({len(tb.DOC_TYPES)} tipi x {per_type}) ...")
 
     out, done, ok = [], 0, 0
@@ -228,14 +231,14 @@ def gen_new_templates(per_type, boost):
             done += 1
             prompt = tb.PROMPT.format(doc_type=doc_type, slot_list=slot_list,
                                       slot_hints=tb.SLOT_HINTS) + hint
-            text = tb.clean_and_validate(tb.call_gemini(prompt))
+            text = tb.clean_and_validate(tb.call_llm(prompt))
             if text:
                 out.append(text)
                 ok += 1
             print(f"  [{done:>3}/{total}] {doc_type:42s} {'OK' if text else 'scartato'}")
     print(f"Template nuovi validi: {ok}/{total}")
     if not out:
-        sys.exit("ERRORE: nessun template valido da Gemini. Riprova o usa --offline.")
+        sys.exit("ERRORE: nessun template valido dal modello. Riprova o usa --offline.")
     return out
 
 
@@ -384,7 +387,8 @@ def main():
     print("rizzo-pii — contribuzione dati sintetici al dataset community")
     print("⚠️  Solo dati SINTETICI: nessuna PII reale viene prodotta o caricata.")
     print("=" * 70)
-    mode = "built-in (offline)" if args.offline else f"Gemini (--per-type {args.per_type})"
+    mode = ("built-in (offline)" if args.offline
+            else f"{tb.backend_name()} (--per-type {args.per_type})")
     print(f"handle={handle}  n={args.n}  seed={seed}  template={mode}")
 
     rows, counts, n_new = generate(args.n, seed, handle, args.per_type, args.offline, boost)

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -17,6 +17,11 @@ Sicurezza chiave API: NON si incolla in chiaro. Si legge da variabile d'ambiente
 
 Modello: default gemini-3.5-flash (override con la env var GEMINI_MODEL).
 
+BACKEND LOCALE (nessuna chiave, niente esce dalla macchina): se e' impostata
+LLM_BASE_URL i template li scrive un LLM locale via endpoint OpenAI-compatibile.
+  export LLM_BASE_URL=http://127.0.0.1:8080/v1   # llama.cpp / Ollama / vLLM / LM Studio
+  export LLM_MODEL=nome-del-modello
+
 Uso:  python llm_template_bank.py --per-type 3
 Output: legal_templates.json  (lista di {"id", "doc_type", "text"})
 """
@@ -66,6 +71,16 @@ SLOT_RE = re.compile(r"\{(\w+)\}")
 MODEL = os.environ.get("GEMINI_MODEL", "gemini-3.5-flash")
 ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 
+# --- backend alternativo: un LLM LOCALE (endpoint OpenAI-compatibile) ------------------
+# Se LLM_BASE_URL e' impostata, i template vengono scritti da quel modello invece che da
+# Gemini: nessuna chiave API, nessun prompt che esce dalla macchina. Coerente con lo scopo
+# del progetto (e chi non ha una chiave Google puo' comunque contribuire dati).
+#   export LLM_BASE_URL=http://127.0.0.1:8080/v1   # llama.cpp / Ollama / vLLM / LM Studio
+#   export LLM_MODEL=nome-del-modello
+LLM_BASE_URL = os.environ.get("LLM_BASE_URL")
+LLM_MODEL = os.environ.get("LLM_MODEL", "local-model")
+LLM_API_KEY = os.environ.get("LLM_API_KEY", "sk-no-key-required")
+
 PROMPT = """Sei un giurista italiano. Scrivi un {doc_type} REALISTICO e completo (da 8 a 18 righe),
 nel linguaggio tecnico-giuridico autentico usato nei tribunali italiani.
 
@@ -87,11 +102,66 @@ un titolo seguito da un nome (es. "Sig. Bianchi", "avv. Verdi"): scrivi "il/la {
 Restituisci SOLO il testo del documento, senza titoli di contorno, senza commenti, senza markdown."""
 
 
+def backend_name():
+    """Descrizione del backend in uso, per i log."""
+    return f"locale {LLM_MODEL} @ {LLM_BASE_URL}" if LLM_BASE_URL else f"Gemini {MODEL}"
+
+
+def have_backend():
+    """True se c'e' un modo per far scrivere i template (locale o Gemini)."""
+    return bool(LLM_BASE_URL or API_KEY or os.environ.get("GEMINI_API_KEY"))
+
+
+def call_llm(prompt, retries=3):
+    """Fa scrivere un template al backend configurato: LLM locale se LLM_BASE_URL
+    e' impostata, altrimenti Gemini."""
+    if LLM_BASE_URL:
+        return call_local_openai(prompt, retries)
+    return call_gemini(prompt, retries)
+
+
+def call_local_openai(prompt, retries=3):
+    """Endpoint OpenAI-compatibile (llama.cpp server, Ollama, vLLM, LM Studio...)."""
+    url = LLM_BASE_URL.rstrip("/")
+    if not url.endswith("/chat/completions"):
+        url += "/chat/completions"
+    body = json.dumps({
+        "model": LLM_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.9,
+        "max_tokens": 1400,
+        # Sui modelli "reasoning" serviti in locale l'intero output puo' finire nel campo
+        # reasoning_content lasciando 'content' VUOTO (visto con gemma-4-12B su llama.cpp:
+        # 175 s di pensiero e zero testo). Qui il pensiero si disattiva e, per sicurezza,
+        # sotto si accetta reasoning_content come ripiego.
+        "chat_template_kwargs": {"enable_thinking": False},
+    }).encode()
+    headers = {"Content-Type": "application/json",
+               "Authorization": f"Bearer {LLM_API_KEY}"}
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers)
+            with urllib.request.urlopen(req, timeout=600) as r:
+                data = json.load(r)
+            msg = data["choices"][0]["message"]
+            text = (msg.get("content") or msg.get("reasoning_content") or "").strip()
+            if text:
+                return text
+            print("  risposta vuota dal modello locale")
+        except urllib.error.HTTPError as e:
+            print(f"  HTTP {e.code}: {e.read().decode()[:200]}")
+        except (urllib.error.URLError, KeyError, IndexError) as e:
+            print(f"  errore: {e}")
+        time.sleep(2 * (attempt + 1))
+    return None
+
+
 def call_gemini(prompt, retries=3):
     key = API_KEY or os.environ.get("GEMINI_API_KEY")
     if not key:
         sys.exit("ERRORE: imposta API_KEY nel file oppure la variabile d'ambiente "
-                 "GEMINI_API_KEY (chiave NUOVA, non quella incollata in chat).")
+                 "GEMINI_API_KEY (chiave NUOVA, non quella incollata in chat).\n"
+                 "  Oppure usa un LLM locale: export LLM_BASE_URL=http://127.0.0.1:8080/v1")
     url = ENDPOINT.format(model=MODEL, key=key)
     body = json.dumps({
         "contents": [{"parts": [{"text": prompt}]}],
@@ -215,7 +285,7 @@ def main():
     done = ok = skip = 0
     t0 = time.time()
     print(f"Genero {total} template ({len(DOC_TYPES)} tipi x {args.per_type}) "
-          f"con Gemini [{MODEL}]\n")
+          f"con [{backend_name()}]\n")
 
     def save():
         with open(args.out, "w", encoding="utf-8") as f:
@@ -229,8 +299,8 @@ def main():
             pct = 100 * done // total
             print(f"[{done:>3}/{total} | {pct:>3}%] OK={ok} scartati={skip} | "
                   f"trascorso {elapsed:>4.0f}s | ETA {eta:>4.0f}s | {doc_type} ...")
-            raw = call_gemini(PROMPT.format(doc_type=doc_type, slot_list=slot_list,
-                                            slot_hints=SLOT_HINTS))
+            raw = call_llm(PROMPT.format(doc_type=doc_type, slot_list=slot_list,
+                                         slot_hints=SLOT_HINTS))
             text = clean_and_validate(raw)
             if text:
                 templates.append({"id": tid, "doc_type": doc_type, "text": text})

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -33,6 +33,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import urllib.request
 import urllib.error
 from pathlib import Path
@@ -248,8 +249,23 @@ def find_stray_names(text):
     return stray
 
 
+def non_latin_char(text):
+    """Primo carattere alfabetico NON latino, se presente. Un modello locale (piccolo o
+    molto quantizzato) puo' infilare un ideogramma in mezzo alla prosa italiana; se il
+    template passa, quel carattere finisce in ogni esempio che lo usa."""
+    for ch in text:
+        if ch.isalpha():
+            try:
+                if "LATIN" not in unicodedata.name(ch):
+                    return ch
+            except ValueError:
+                return ch
+    return None
+
+
 def clean_and_validate(text):
-    """Pulisce il markdown, verifica i segnaposto e scarta i template con PII inline."""
+    """Pulisce il markdown, verifica i segnaposto e scarta i template con PII inline
+    o con caratteri non latini."""
     if not text:
         return None
     text = re.sub(r"^```.*?\n|```$", "", text.strip(), flags=re.MULTILINE).strip()
@@ -262,6 +278,10 @@ def clean_and_validate(text):
     stray = find_stray_names(text)
     if stray:
         print(f"  scartato: probabili nomi inline non taggati {sorted(set(stray))[:8]}")
+        return None
+    bad = non_latin_char(text)
+    if bad:
+        print(f"  scartato: carattere non latino {bad!r} (artefatto del modello)")
         return None
     return text
 

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -263,12 +263,25 @@ def non_latin_char(text):
     return None
 
 
+def normalizza_escape(text):
+    r"""Converte gli escape LETTERALI (i due caratteri '\' + 'n') in veri a capo.
+
+    Il modello a volte scrive la sequenza invece dell'a capo. Non e' un problema
+    estetico: iniettando un valore subito dopo, il tokenizzatore incolla la 'n'
+    all'inizio dell'entita' ('\n09/06/1965' -> token 'n09'), che resta O mentre il
+    resto dell'entita' diventa I-DATE. Ne esce una riga con BIO malformato (I- senza
+    B-), inutilizzabile in training. Misurato: 1 template su 237 conteneva la
+    sequenza e ha rotto 721 righe su 200.000."""
+    return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "\t")
+
+
 def clean_and_validate(text):
     """Pulisce il markdown, verifica i segnaposto e scarta i template con PII inline
     o con caratteri non latini."""
     if not text:
         return None
     text = re.sub(r"^```.*?\n|```$", "", text.strip(), flags=re.MULTILINE).strip()
+    text = normalizza_escape(text)
     slots = set(SLOT_RE.findall(text))
     if not slots:
         return None                       # nessun segnaposto -> inutile


### PR DESCRIPTION
Template scrivibili da un LLM locale (endpoint OpenAI-compatibile)

Contribuire dati richiedeva una chiave Gemini e mandava i prompt a un terzo:
attrito d'ingresso, e una stonatura per un progetto il cui punto e' non far
uscire nulla dalla macchina.

Con LLM_BASE_URL impostata i template li scrive un modello locale (llama.cpp,
Ollama, vLLM, LM Studio); senza la variabile il comportamento e' identico a
prima (Gemini). Stesse guardie sui template.

Nota: un modello reasoning locale puo' mettere tutto l'output in
reasoning_content e lasciare 'content' vuoto -> si disattiva il pensiero e si
accetta reasoning_content come ripiego.

Guardia: scarta i template con caratteri non latini

Un modello locale quantizzato puo' infilare un ideogramma in mezzo alla prosa
italiana ('oltre a槽 interessi'). Il template passava tutte le guardie e il
carattere finiva in OGNI esempio generato da quel template: 87 righe su 5000
da un solo template, viste in una generazione reale.

clean_and_validate() ora scarta i template con caratteri alfabetici non latini.

Guardia: gli escape letterali del modello rompono le label BIO

Il modello a volte scrive i due caratteri '\' + 'n' invece di un a capo. Iniettando
un valore subito dopo, il tokenizzatore incolla la 'n' all'inizio dell'entita'
('\n09/06/1965' -> token 'n09'): quel token resta O e il resto dell'entita' diventa
I-DATE, cioe' una riga con BIO malformato (I- senza B-) che il training scarta.

Misurato su una banca da 237 template: 1 template conteneva la sequenza e ha prodotto
721 righe rotte su 200.000. Si normalizza invece di scartare, perche' il template e'
per il resto valido.

