### PR TITLE
Guardia: riconoscere i nomi di persona, non il lessico dei tribunali

### DIFF
--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -434,6 +434,14 @@ DATA_INLINE_RE = re.compile(r"\b\d{1,2}[/.\-]\d{1,2}[/.\-]\d{2,4}\b")
 # nessuno dei pattern sopra le prende (due soli gruppi, cifre sotto la soglia).
 
 
+# Due segnaposto separati da soli spazi: iniettando i valori le due entita' finiscono
+# adiacenti senza un token 'O' fra loro, e in BIO si fondono in una sola. L'idea e' della
+# PR #15 di @Darkfog81, che la applica ai template scritti da un agente di coding; vale
+# identica per quelli scritti da un LLM, che questa forma la produce spesso negli
+# elenchi ("{CITY} {DATE}", "{FULLNAME} {CF}").
+SLOT_ADIACENTI_RE = re.compile(r"\}[ \t]*\{")
+
+
 def inline_code(text):
     """Primo codice o data scritto inline, se presente."""
     masked = re.sub(r"\{\w+\}", " ", text)
@@ -469,6 +477,9 @@ def clean_and_validate(text):
     if codice:
         print(f"  scartato: codice o data scritti inline invece che come segnaposto "
               f"({codice!r})")
+        return None
+    if SLOT_ADIACENTI_RE.search(text):
+        print("  scartato: due segnaposto senza testo in mezzo (le entita' si fondono)")
         return None
     return text
 

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -220,6 +220,16 @@ CONTESTO_RUOLO = {
     "beneficiaria", "dipendente", "lavoratore", "lavoratrice", "paziente", "alunno",
     "alunna", "studente", "studentessa", "cliente", "contraente", "assicurato",
     "assicurata", "delegato", "delegata", "richiedente", "denunciante", "querelante",
+    # gli altri modi italiani di dire "la persona che fa X". Stanno qui e non fra i
+    # contesti forti perche' sono seguiti spesso da un qualificatore maiuscolo ("il
+    # sottoscritto Agente accertatore", "il Venditore"), e perche' una corsa fatta solo
+    # di queste parole e' vocabolario di ruolo, non un nome
+    "agente", "operatore", "funzionario", "responsabile", "incaricato", "accertatore",
+    "verbalizzante", "conducente", "proprietario", "trasgressore", "socio", "abbonato",
+    "utente", "assegnatario", "candidato", "conduttore", "locatore", "locatrice",
+    "venditore", "venditrice", "acquirente", "mandante", "mandatario", "cancelliere",
+    "segretario", "presidente", "amministratore", "custode", "tutore", "genitore",
+    "committente", "appaltatore", "fornitore", "debitore", "creditore", "passeggero",
 }
 TITLES_L = {t.lower() for t in TITLES}
 # le ABBREVIAZIONI di titolo ("Sig.", "Avv.", "Dott.") stanno solo davanti a un nome, e
@@ -227,17 +237,10 @@ TITLES_L = {t.lower() for t in TITLES}
 # un qualificatore ("il Dottore Commercialista"), quindi valgono come ruolo
 CONTESTO_FORTE = (CONTESTO_FORTE | TITLES_L) - CONTESTO_RUOLO
 
-# teste di denominazione istituzionale: "<istituzione> di <Maiuscola>" e' il nome
-# dell'UFFICIO, non una persona -- "Giudice di Pace", "Corte dei Conti", "Corte di
-# Cassazione". Serve perche' diversi cognomi italiani sono anche parole comuni (Pace,
-# Conti, Costa, Villa, Monti) e il solo lessico li leggerebbe come persone: "Giudice di
-# Pace" era 11 dei 12 falsi positivi rimasti su 237 template. Restano invece segnalati
-# "l'avvocato di Bianchi" e "la firma di Rossi": chi introduce non e' un'istituzione.
-ISTITUZIONI = {
-    "giudice", "corte", "tribunale", "procura", "ministero", "agenzia", "commissione",
-    "sezione", "ufficio", "camera", "consiglio", "collegio", "autorita", "direzione",
-    "servizio", "istituto", "azienda", "comune", "provincia", "regione", "prefettura",
-}
+# preposizioni della famiglia di "di": davanti a una maiuscola la rendono un complemento
+# ("Giudice di Pace", "Corte dei Conti") e non un nome. Sostituiscono una lista di
+# istituzioni scritta a mano: la relazione grammaticale vale per qualunque ufficio, la
+# lista sarebbe rimasta indietro al primo dominio nuovo.
 PREPOSIZIONI = {"di", "del", "dello", "della", "dei", "degli", "delle", "d"}
 
 # I segnaposto vanno TOLTI prima di cercare i nomi, ma non lasciando un buco: se al loro
@@ -261,11 +264,18 @@ _LESSICO_PERSONE = None
 
 
 def _lessico_persone():
-    """Nomi propri e cognomi noti al progetto (minuscoli).
+    """(nomi propri, cognomi) noti al progetto, minuscoli e tenuti SEPARATI.
 
     Sono le stesse liste con cui generate_synthetic_pii INIETTA le persone: se il modello
     scrive un nome inline, quasi sempre pesca da questo stesso repertorio di nomi comuni
     italiani. Riusarle qui evita di mantenere un secondo elenco a mano.
+
+    Separati perche' non valgono lo stesso. Un nome proprio ("Giulia", "Aldo") in un
+    documento e' quasi sempre una persona. Un cognome italiano e' spessissimo anche una
+    parola comune -- Gentile, Pace, Costa, Conte, Villa, Monti, Fiore, Guerra, Bianco --
+    e nei documenti amministrativi quelle parole compaiono con la maiuscola per motivi
+    loro: "Gentile Cliente" apre ogni lettera commerciale, "Giudice di Pace" e' un
+    ufficio. Un cognome vale quindi solo se qualcosa lo introduce come persona.
 
     Import pigro e stato del generatore casuale ripristinato: importare
     generate_synthetic_pii esegue random.seed(42) a import-time, e questo script pesca a
@@ -277,11 +287,11 @@ def _lessico_persone():
         try:
             sys.path.insert(0, str(Path(__file__).resolve().parent))
             import generate_synthetic_pii as _g
-            _LESSICO_PERSONE = {w.lower() for w in
-                                _g.MALE_NAMES + _g.FEMALE_NAMES + _g.SURNAMES}
+            _LESSICO_PERSONE = ({w.lower() for w in _g.MALE_NAMES + _g.FEMALE_NAMES},
+                                {w.lower() for w in _g.SURNAMES})
         except Exception as e:                       # pragma: no cover
             print(f"  (lessico dei nomi non caricato: {e}) -> guardia solo per contesto")
-            _LESSICO_PERSONE = set()
+            _LESSICO_PERSONE = (set(), set())
         finally:
             _r.setstate(stato)
     return _LESSICO_PERSONE
@@ -337,7 +347,7 @@ def find_stray_names(text):
     le sue parole."""
     masked = re.sub(r"\{\w+\}", f" {SEGNO_SLOT} ", text)      # i segnaposto fanno barriera
     words = re.findall(r"[A-Za-zÀ-ÿ][A-Za-zÀ-ÿ'.]*", masked)
-    lessico = _lessico_persone()
+    nomi, cognomi = _lessico_persone()
     stray = []
     i = 0
     while i < len(words):
@@ -357,12 +367,21 @@ def find_stray_names(text):
         if all(_cap(w).lower() in CONTESTO_FORTE | CONTESTO_RUOLO for w in corsa):
             i = j + 1
             continue
-        # denominazione di un ufficio: "Giudice di Pace", non una persona di nome Pace
+        # Una preposizione appena prima della corsa la rende un COMPLEMENTO di cio' che
+        # viene prima, non un nome in apposizione: "Giudice di Pace", "agente di Polizia
+        # Locale", "Responsabile del Procedimento" sono denominazioni di uffici, mentre una
+        # persona segue il proprio ruolo senza preposizione in mezzo ("il paziente
+        # Bianchi", "l'intestatario Ludovico Marinetti"). Il nome proprio resta valido
+        # comunque: "la firma di Giulia" e' una persona anche da complemento.
         prec = _confrontabile(words[i - 1])[0] if i else ""
-        if len(corsa) == 1 and prec in PREPOSIZIONI and intro in ISTITUZIONI:
-            i = j + 1
-            continue
-        if any(_cap(w).lower() in lessico for w in corsa):        # "Mario Rossi"
+        complemento = prec in PREPOSIZIONI
+        parole = [_cap(w).lower() for w in corsa]
+        introdotta = intro in CONTESTO_FORTE or intro in CONTESTO_RUOLO
+        if any(p in nomi for p in parole):                        # "Mario Rossi", "Giulia"
+            stray.append(" ".join(corsa))
+        elif complemento:
+            pass
+        elif any(p in cognomi for p in parole) and introdotta:    # "il paziente Bianchi"
             stray.append(" ".join(corsa))
         # il nome di una persona sta in 2-3 parole: una corsa piu' lunga e' la
         # denominazione di qualcos'altro (un'offerta commerciale, un ufficio, un titolo di

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -364,9 +364,13 @@ def find_stray_names(text):
             continue
         if any(_cap(w).lower() in lessico for w in corsa):        # "Mario Rossi"
             stray.append(" ".join(corsa))
-        elif intro in CONTESTO_FORTE:                             # "sottoscritto Sferrazza"
+        # il nome di una persona sta in 2-3 parole: una corsa piu' lunga e' la
+        # denominazione di qualcos'altro (un'offerta commerciale, un ufficio, un titolo di
+        # sezione), e chi la introduce puo' avere un altro senso -- in "l'offerta
+        # sottoscritta Mobile Plan Pro" il participio non introduce nessun sottoscritto
+        elif intro in CONTESTO_FORTE and len(corsa) <= 3:         # "sottoscritto Sferrazza"
             stray.append(f"{intro} {' '.join(corsa)}")
-        elif intro in CONTESTO_RUOLO and len(corsa) >= 2:         # "intestatario L. Marinetti"
+        elif intro in CONTESTO_RUOLO and 2 <= len(corsa) <= 3:    # "intestatario L. Marinetti"
             stray.append(f"{intro} {' '.join(corsa)}")
         i = j + 1
     return stray

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -192,68 +192,183 @@ def call_gemini(prompt, retries=3):
     return None
 
 
-# vocabolario di parole con la maiuscola LEGITTIME nei testi legali italiani:
-# se resta una maiuscola fuori da questo set (e fuori dai segnaposto), e' un nome
-# proprio "sciolto" scritto inline dall'LLM -> PII non taggata -> template da scartare.
-LEGAL_CAPITALIZED = set("""
-Il La Lo Gli Le Un Una Uno Con Per Si Che Chi In Da Del Della Dei Delle Dello Al Alla
-Ai Alle Allo Nel Nella Nei Sul Sulla Tra Fra A Ad E Ed O Od Ma Se Come Quando Dove
-Mentre Inoltre Pertanto Quindi Tutto Tutti Tutte Questa Questo Questi Queste Tale Tali
-Detto Detta Predetto Suddetto Premesso Considerato Visto Vista Visti Viste Letto Letti
-Letta Rilevato Ritenuto Dichiara Dichiarano Chiede Chiedono Voglia Vogliano Cosi Così
-Ciò Essendo Avendo Ove Salvo Fermo Nonche Nonché Ovvero Stante Affinche Affinché
-Tribunale Corte Appello Cassazione Giudice Giudici Giudicante Avvocato Avvocati
-Procuratore Procura Pubblico Ministero Repubblica Italiana Italia Stato Regione
-Provincia Comune Codice Civile Penale Procedura Costituzione Legge Leggi Decreto Decreti
-Articolo Art Comma Commi Capo Sezione Sez Ruolo Generale Causa Cause Sentenza Sentenze
-Ordinanza Ordinanze Ricorso Ricorrente Comparsa Atto Atti Citazione Liti Foro Udienza
-Cancelleria Cancelliere Spettabile Spett Egregio Egr Signor Signora Sig Sigg Dottor
-Dottore Dott Avv Ill Illustrissimo Onorevole Oggetto Premessa Fatto Diritto Conclusioni
-Motivi Domanda Eccezione Memoria Verbale Notaio Repertorio Raccolta Parte Parti Attore
-Convenuto Resistente Testimone Teste Perito Curatore Fallimento Societa Società
-Gennaio Febbraio Marzo Aprile Maggio Giugno Luglio Agosto Settembre Ottobre Novembre
-Dicembre Lunedi Lunedì Martedi Martedì Mercoledi Mercoledì Giovedi Giovedì Venerdi
-Venerdì Sabato Domenica Euro
-Costituzionale Ufficiale Gazzetta Ordinario Ordinaria Suprema Supremo Amministrativo
-Amministrativa Regionale Nazionale Europea Europeo Unione Agenzia Entrate Comunale
-Provinciale Locatore Locatrice Conduttore Conduttrice Venditore Venditrice Acquirente
-Promittente Promissario Canone Deposito Cauzione Cauzionale Durata Oneri Onere Catasto
-Catastale Particella Foglio Subalterno Mappale Rendita Fabbricati Fabbricato Terreni
-Immobile Immobili Bene Beni Prezzo Acconto Saldo Designato Designata Condanna Condannato
-Deciso Decisa Firma Firme Regolamento Mandato Delega Comparente Comparenti Contraenti
-Contraente Contrattuale Mensile Annuale Banca Filiale Bonifico Pagamento Pagamenti
-Scadenza Interessi Interesse Capitale Allegato Allegati Documento Documenti Conto
-Corrente Vi Voi Vostra Vostro Vostri Vostre Tanto Nondimeno
-""".split())
+
+# titoli che, seguiti da una maiuscola, segnalano un nome scritto inline. Solo le forme
+# che introducono una PERSONA: "Spett." e "Spettabile" si rivolgono a un'organizzazione
+# ("Spett.le Azienda ...") e da soli non dicono nulla su un nome.
+TITLES = {"Sig", "Sig.ra", "Sigg", "Signor", "Signora", "Dott", "Dottor",
+          "Dssa", "Avv", "Egr", "Egregio", "Ill", "Onorevole"}
+
+# Parole che in italiano INTRODUCONO una persona. Due livelli, perche' non danno la stessa
+# certezza:
+#  - FORTI: dopo di queste una maiuscola e' un nome anche da sola ("il sottoscritto
+#    Sferrazza"). Non introducono altro.
+#  - RUOLI: possono essere seguite da un QUALIFICATORE maiuscolo che non e' una persona
+#    ("il Giudice Unico", "di seguito denominato Locatore"). Qui serve una maiuscola in
+#    piu' -- Nome + Cognome -- per parlare di nome inline.
+# Sono classi chiuse che parlano di persone, non di domini: non vanno allungate quando si
+# aggiunge un tipo di documento.
+CONTESTO_FORTE = {
+    "nato", "nata", "nati", "nate", "sottoscritto", "sottoscritta", "sottoscritti",
+    "signor", "signora", "signori", "nome", "cognome",
+}
+CONTESTO_RUOLO = {
+    "avvocato", "avvocatessa", "dottore", "dottoressa", "difeso", "difesa",
+    "rappresentato", "rappresentata", "assistito", "assistita", "teste", "testimone",
+    "giudice", "notaio", "perito", "curatore", "erede", "coniuge", "figlio", "figlia",
+    "padre", "madre", "intestatario", "intestataria", "titolare", "beneficiario",
+    "beneficiaria", "dipendente", "lavoratore", "lavoratrice", "paziente", "alunno",
+    "alunna", "studente", "studentessa", "cliente", "contraente", "assicurato",
+    "assicurata", "delegato", "delegata", "richiedente", "denunciante", "querelante",
+}
+TITLES_L = {t.lower() for t in TITLES}
+# le ABBREVIAZIONI di titolo ("Sig.", "Avv.", "Dott.") stanno solo davanti a un nome, e
+# restano forti; le stesse parole per esteso sono nomi di ruolo e possono essere seguite da
+# un qualificatore ("il Dottore Commercialista"), quindi valgono come ruolo
+CONTESTO_FORTE = (CONTESTO_FORTE | TITLES_L) - CONTESTO_RUOLO
+
+# teste di denominazione istituzionale: "<istituzione> di <Maiuscola>" e' il nome
+# dell'UFFICIO, non una persona -- "Giudice di Pace", "Corte dei Conti", "Corte di
+# Cassazione". Serve perche' diversi cognomi italiani sono anche parole comuni (Pace,
+# Conti, Costa, Villa, Monti) e il solo lessico li leggerebbe come persone: "Giudice di
+# Pace" era 11 dei 12 falsi positivi rimasti su 237 template. Restano invece segnalati
+# "l'avvocato di Bianchi" e "la firma di Rossi": chi introduce non e' un'istituzione.
+ISTITUZIONI = {
+    "giudice", "corte", "tribunale", "procura", "ministero", "agenzia", "commissione",
+    "sezione", "ufficio", "camera", "consiglio", "collegio", "autorita", "direzione",
+    "servizio", "istituto", "azienda", "comune", "provincia", "regione", "prefettura",
+}
+PREPOSIZIONI = {"di", "del", "dello", "della", "dei", "degli", "delle", "d"}
+
+# I segnaposto vanno TOLTI prima di cercare i nomi, ma non lasciando un buco: se al loro
+# posto resta uno spazio, chi introduce scavalca il segnaposto e si attacca alla parola
+# dopo -- in "corrisposta dal Sig. {FULLNAME} al Venditore" il titolo "Sig." finisce a
+# introdurre "Venditore" e il template viene scartato per un nome che invece era gia' un
+# segnaposto. Un segno tutto maiuscolo al loro posto fa da barriera (e _cap lo ignora,
+# perche' gli acronimi non sono nomi).
+SEGNO_SLOT = "SEGNAPOSTO"
+
+# parole di servizio che stanno fra chi introduce e il nome ("nato a", "difeso dal"):
+# vanno saltate quando si cerca chi introduce, altrimenti la ricerca si ferma su di loro
+FUNZIONALI = {
+    "a", "ad", "al", "allo", "alla", "ai", "agli", "alle", "da", "dal", "dallo", "dalla",
+    "dai", "dagli", "dalle", "di", "del", "dello", "della", "dei", "degli", "delle",
+    "in", "nel", "nello", "nella", "nei", "negli", "nelle", "con", "e", "ed", "il", "lo",
+    "la", "i", "gli", "le", "un", "una", "uno", "sig", "sigra", "che", "il/la",
+} - CONTESTO_FORTE
+
+_LESSICO_PERSONE = None
 
 
-# titoli che, seguiti da una maiuscola, segnalano un nome scritto inline
-TITLES = {"Sig", "Sig.ra", "Sigg", "Signor", "Signora", "Dott", "Dottor", "Dottore",
-          "Dssa", "Avv", "Egr", "Egregio", "Spett", "Ill", "Onorevole", "Spettabile"}
+def _lessico_persone():
+    """Nomi propri e cognomi noti al progetto (minuscoli).
+
+    Sono le stesse liste con cui generate_synthetic_pii INIETTA le persone: se il modello
+    scrive un nome inline, quasi sempre pesca da questo stesso repertorio di nomi comuni
+    italiani. Riusarle qui evita di mantenere un secondo elenco a mano.
+
+    Import pigro e stato del generatore casuale ripristinato: importare
+    generate_synthetic_pii esegue random.seed(42) a import-time, e questo script pesca a
+    caso i tipi di documento -- l'import non deve rendere deterministica quella scelta."""
+    global _LESSICO_PERSONE
+    if _LESSICO_PERSONE is None:
+        import random as _r
+        stato = _r.getstate()
+        try:
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            import generate_synthetic_pii as _g
+            _LESSICO_PERSONE = {w.lower() for w in
+                                _g.MALE_NAMES + _g.FEMALE_NAMES + _g.SURNAMES}
+        except Exception as e:                       # pragma: no cover
+            print(f"  (lessico dei nomi non caricato: {e}) -> guardia solo per contesto")
+            _LESSICO_PERSONE = set()
+        finally:
+            _r.setstate(stato)
+    return _LESSICO_PERSONE
 
 
-def _is_name_cap(w):
-    """True se la parola e' una maiuscola 'da nome': iniziale maiuscola, non tutta
-    maiuscola (no acronimi), e non un termine giuridico noto. Gestisce le elisioni
-    (es. 'dell'Avv' -> valuta 'Avv')."""
+def _cap(w):
+    """La parola senza punto/elisione se ha l'iniziale maiuscola e non e' tutta maiuscola
+    (gli acronimi non sono nomi di persona), altrimenti None. 'dell'Avv.' -> 'Avv'."""
     seg = w.split("'")[-1].strip(".")
-    return bool(seg) and seg[0].isupper() and not seg.isupper() and seg not in LEGAL_CAPITALIZED
+    return seg if seg and seg[0].isupper() and not seg.isupper() else None
+
+
+def _confrontabile(w):
+    """(parola confrontabile, chiude_la_frase). Toglie l'elisione ("L'intestatario" ->
+    "intestatario", altrimenti chi introduce non si riconosce) e la punteggiatura finale.
+    Un punto finale e' un confine di frase, tranne nelle abbreviazioni di titolo: dopo un
+    confine la maiuscola e' solo l'inizio della frase nuova ("assistito. Nonostante")."""
+    seg = w.split("'")[-1]
+    nudo = seg.rstrip(".:;!?,").lower()
+    chiude = seg[-1:] in ".:;!?" and nudo not in TITLES_L
+    return nudo, chiude
+
+
+def _introduce(words, i):
+    """Chi introduce la maiuscola in posizione i: la prima parola non funzionale nelle 3
+    precedenti ("nato a X" -> "nato", "difeso dal X" -> "difeso"). None se prima c'e' un
+    confine di frase, un segnaposto, o non si trova nulla."""
+    for k in range(i - 1, max(-1, i - 4), -1):
+        nudo, chiude = _confrontabile(words[k])
+        if chiude or nudo == SEGNO_SLOT.lower():
+            return None
+        if nudo and nudo not in FUNZIONALI:
+            return nudo
+    return None
 
 
 def find_stray_names(text):
-    """Segnala SOLO i pattern che indicano un vero nome proprio scritto inline:
-    due maiuscole 'da nome' consecutive (Nome Cognome) o titolo + maiuscola (Sig. Rossi).
-    Le singole parole giuridiche maiuscole sono testo normale e NON vengono toccate."""
-    masked = re.sub(r"\{\w+\}", " ", text)          # togli i segnaposto
+    """Segnala i nomi di PERSONA scritti inline (PII non taggata -> template da scartare).
+
+    La versione precedente considerava nome proprio qualunque coppia di maiuscole assente
+    da un lessico giuridico scritto a mano (LEGAL_CAPITALIZED). Regge dentro il tribunale
+    e crolla fuori: "Risorse Umane", "Ufficio Protocollo", "Servizio Clienti" vengono
+    scartati come se fossero persone, cioe' si perdono i template buoni proprio nei domini
+    nuovi -- e allungare quella lista a ogni dominio e' una rincorsa senza fine.
+
+    Qui i segnali sono due, entrambi indipendenti dal dominio:
+      1. LESSICO -- una delle parole e' un nome o un cognome noto al progetto;
+      2. CONTESTO -- la corsa di maiuscole sta dove va una persona: da sola se la introduce
+         un contesto forte, in coppia (Nome + Cognome) se la introduce un nome di ruolo.
+
+    Si ragiona su CORSE di maiuscole consecutive, non su coppie: e' la corsa intera a
+    essere un nome o una denominazione, e chi la introduce sta prima della corsa -- non fra
+    le sue parole."""
+    masked = re.sub(r"\{\w+\}", f" {SEGNO_SLOT} ", text)      # i segnaposto fanno barriera
     words = re.findall(r"[A-Za-zÀ-ÿ][A-Za-zÀ-ÿ'.]*", masked)
+    lessico = _lessico_persone()
     stray = []
-    for a, b in zip(words, words[1:]):
-        if a and a[-1] in ".:;!?":                              # confine di frase: non e' un nome
+    i = 0
+    while i < len(words):
+        if not _cap(words[i]):
+            i += 1
             continue
-        if _is_name_cap(a) and _is_name_cap(b):                 # "Mario Rossi"
-            stray.append(f"{a} {b}")
-        elif a.rstrip(".") in TITLES and _is_name_cap(b):       # "Sig. Bianchi"
-            stray.append(f"{a} {b}")
+        j = i
+        # la corsa non attraversa un confine di frase: in "assistito dal Cancelliere. La
+        # causa..." Cancelliere e La sono due frasi diverse, non un nome di due parole
+        while (j + 1 < len(words) and _cap(words[j + 1])
+                and not _confrontabile(words[j])[1]):
+            j += 1
+        corsa = words[i:j + 1]
+        intro = _introduce(words, i)
+        # una corsa fatta solo di titoli e nomi di ruolo e' vocabolario, non un nome: in
+        # "il sottoscritto Sig. {FULLNAME}" il nome e' il segnaposto, non "Sig."
+        if all(_cap(w).lower() in CONTESTO_FORTE | CONTESTO_RUOLO for w in corsa):
+            i = j + 1
+            continue
+        # denominazione di un ufficio: "Giudice di Pace", non una persona di nome Pace
+        prec = _confrontabile(words[i - 1])[0] if i else ""
+        if len(corsa) == 1 and prec in PREPOSIZIONI and intro in ISTITUZIONI:
+            i = j + 1
+            continue
+        if any(_cap(w).lower() in lessico for w in corsa):        # "Mario Rossi"
+            stray.append(" ".join(corsa))
+        elif intro in CONTESTO_FORTE:                             # "sottoscritto Sferrazza"
+            stray.append(f"{intro} {' '.join(corsa)}")
+        elif intro in CONTESTO_RUOLO and len(corsa) >= 2:         # "intestatario L. Marinetti"
+            stray.append(f"{intro} {' '.join(corsa)}")
+        i = j + 1
     return stray
 
 
@@ -283,6 +398,29 @@ def normalizza_escape(text):
     return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "\t")
 
 
+# --- codici e date scritti inline -----------------------------------------------------
+# Un CF/IBAN/telefono/data scritto nel testo invece che come segnaposto e' un'entita' che
+# esiste nel testo ma NON nelle label: il modello impara a NON taggarla. La guardia sui
+# nomi non lo vede (non sono parole). Serve soprattutto nei domini fuori dal tribunale,
+# dove la prosa e' piena di numeri (bollette, referti, cedolini) e il modello e' piu'
+# tentato di inventare un codice.
+CIFRE_LUNGHE_RE = re.compile(r"\d{9,}")                       # telefoni, IBAN, carte
+CODICE_MISTO_RE = re.compile(r"\b(?=[A-Z0-9]*\d)(?=[A-Z0-9]*[A-Z])[A-Z0-9]{11,}\b")
+DATA_INLINE_RE = re.compile(r"\b\d{1,2}[/.\-]\d{1,2}[/.\-]\d{2,4}\b")
+# Le citazioni di norme ("196/2003", "art. 2043 c.c.") sono numeri legittimi, non PII:
+# nessuno dei pattern sopra le prende (due soli gruppi, cifre sotto la soglia).
+
+
+def inline_code(text):
+    """Primo codice o data scritto inline, se presente."""
+    masked = re.sub(r"\{\w+\}", " ", text)
+    for rx in (CIFRE_LUNGHE_RE, CODICE_MISTO_RE, DATA_INLINE_RE):
+        m = rx.search(masked)
+        if m:
+            return m.group(0)
+    return None
+
+
 def clean_and_validate(text):
     """Pulisce il markdown, verifica i segnaposto e scarta i template con PII inline
     o con caratteri non latini."""
@@ -303,6 +441,11 @@ def clean_and_validate(text):
     bad = non_latin_char(text)
     if bad:
         print(f"  scartato: carattere non latino {bad!r} (artefatto del modello)")
+        return None
+    codice = inline_code(text)
+    if codice:
+        print(f"  scartato: codice o data scritti inline invece che come segnaposto "
+              f"({codice!r})")
         return None
     return text
 

--- a/src/data_pipeline/selfcheck_guards.py
+++ b/src/data_pipeline/selfcheck_guards.py
@@ -47,6 +47,7 @@ NON_SONO_NOMI = [
     "Somma corrisposta dal Sig. {FULLNAME} al Venditore tramite bonifico.",
     "Consumo rilevato pari a 3.450 kWh nel periodo di riferimento.",
     "Valutazione finale: Ottimo. Media dei voti 8,5 su 10.",
+    "L'offerta sottoscritta Mobile Plan Pro Canone prevede minuti illimitati.",
 ]
 
 # codici e date scritti inline: entita' presenti nel testo ma assenti dalle label

--- a/src/data_pipeline/selfcheck_guards.py
+++ b/src/data_pipeline/selfcheck_guards.py
@@ -48,6 +48,11 @@ NON_SONO_NOMI = [
     "Consumo rilevato pari a 3.450 kWh nel periodo di riferimento.",
     "Valutazione finale: Ottimo. Media dei voti 8,5 su 10.",
     "L'offerta sottoscritta Mobile Plan Pro Canone prevede minuti illimitati.",
+    "Gentile Servizio Clienti, chiedo il rimborso del titolo di viaggio.",
+    "Gentile Cliente, la informiamo che la fattura e' disponibile.",
+    "Il presente verbale e' redatto dal sottoscritto Agente accertatore.",
+    "Il Venditore consegna il bene entro il {DATE}.",
+    "La pratica passa al Responsabile del Procedimento entro 10 giorni.",
 ]
 
 # codici e date scritti inline: entita' presenti nel testo ma assenti dalle label

--- a/src/data_pipeline/selfcheck_guards.py
+++ b/src/data_pipeline/selfcheck_guards.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Autoverifica delle guardie che tengono la PII fuori dai template.
+
+Le guardie di llm_template_bank decidono quali template dell'LLM entrano nella banca:
+se sono troppo larghe entra PII non taggata (il modello impara a NON taggarla), se sono
+troppo strette si perdono template buoni -- e si perdono soprattutto nei domini nuovi,
+dove il lessico non e' quello dei tribunali. Un caso per ogni modo di sbagliare, cosi'
+la prossima modifica alle guardie si accorge subito di quale dei due lati ha rotto.
+
+Uso:  python selfcheck_guards.py [--templates FILE.json]
+Esce con codice 1 se un caso non si comporta come atteso.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import llm_template_bank as tb  # noqa: E402
+
+# nomi di persona scritti nel testo invece che come segnaposto: DEVONO essere presi
+NOMI_DA_PRENDERE = [
+    "Il Sig. Mario Rossi, nato a {CITY}, dichiara quanto segue.",
+    "Comparso il sottoscritto Sferrazza, difeso dal {LAWYER}.",
+    "L'intestatario Ludovico Marinetti chiede il rimborso di {AMOUNT}.",
+    "Il paziente Bianchi si e' presentato alle ore {TIME}.",
+    "La lettura e' stata comunicata da Giulia al numero {PHONE}.",
+    "Il teste Aldo Verdi ha riferito i fatti.",
+]
+
+# lessico amministrativo e istituzionale: NON sono nomi di persona. Sono i casi su cui la
+# guardia basata su un vocabolario giuridico scritto a mano scartava template buoni.
+NON_SONO_NOMI = [
+    "L'Ufficio Protocollo ha registrato l'istanza al n. {DOCID}.",
+    "La pratica e' assegnata alle Risorse Umane di {ORG}.",
+    "Il Servizio Clienti di {ORG} risponde entro 30 giorni.",
+    "Visti gli artt. 2043 e 1218 del Codice Civile e il D.Lgs. 196/2003.",
+    "L'Azienda Sanitaria Locale ha trasmesso il referto al {FULLNAME}.",
+    "Istituto Comprensivo Statale, classe frequentata da {FULLNAME}.",
+    "Il Tribunale di {CITY}, Sezione Prima Civile, ha pronunciato la {DOCID}.",
+    "Al Giudice di Pace di {CITY}, ricorso in opposizione.",
+    "La Corte di Giustizia Tributaria di Secondo Grado respinge il ricorso.",
+    "Il presente atto e' rogato dal sottoscritto Notaio in {CITY}.",
+    "Presente all'udienza, assistito dal Cancelliere. La causa prosegue.",
+    "Il {FULLNAME}, di seguito denominato Locatore, e il {FULLNAME}, Conduttore.",
+    "Somma corrisposta dal Sig. {FULLNAME} al Venditore tramite bonifico.",
+    "Consumo rilevato pari a 3.450 kWh nel periodo di riferimento.",
+    "Valutazione finale: Ottimo. Media dei voti 8,5 su 10.",
+]
+
+# codici e date scritti inline: entita' presenti nel testo ma assenti dalle label
+CODICI_DA_PRENDERE = [
+    "Codice fiscale RSSMRA85M01H501Z del richiedente.",
+    "Accredito su IT60X0542811101000000123456 entro il termine.",
+    "Recapito telefonico 3331234567 per comunicazioni.",
+    "Nato il 12/03/1985 a {CITY}.",
+]
+
+# numeri legittimi della prosa: norme, importi con segnaposto, unita' di misura
+NON_SONO_CODICI = [
+    "Ai sensi del D.Lgs. 196/2003 e del Regolamento UE 679/2016.",
+    "Importo di {AMOUNT} da versare entro il {DATE}.",
+    "Consumo di 3.450 kWh, potenza impegnata 4,5 kW.",
+    "Visto l'art. 2043 c.c. e la legge n. 241/1990.",
+]
+
+
+def _riga(atteso_ok, testo, esito):
+    print(f"  [{'ok  ' if atteso_ok else 'ERRORE'}] {testo[:58]:<58} -> {esito}")
+
+
+def controlla():
+    errori = 0
+    print("nomi inline che devono essere presi:")
+    for t in NOMI_DA_PRENDERE:
+        got = sorted(set(tb.find_stray_names(t)))
+        errori += not got
+        _riga(bool(got), t, got[:2])
+
+    print("\nlessico amministrativo che non deve essere preso:")
+    for t in NON_SONO_NOMI:
+        got = sorted(set(tb.find_stray_names(t)))
+        errori += bool(got)
+        _riga(not got, t, got[:2])
+
+    print("\ncodici e date inline che devono essere presi:")
+    for t in CODICI_DA_PRENDERE:
+        got = tb.inline_code(t)
+        errori += not got
+        _riga(bool(got), t, repr(got))
+
+    print("\nnumeri legittimi che non devono essere presi:")
+    for t in NON_SONO_CODICI:
+        got = tb.inline_code(t)
+        errori += bool(got)
+        _riga(not got, t, repr(got))
+    return errori
+
+
+def sulla_banca(percorso):
+    """Ripassa le guardie sui template GIA' accettati: quelli segnalati contengono PII
+    entrata quando le guardie erano piu' larghe, e va tolta dalla banca."""
+    if not os.path.exists(percorso):
+        print(f"\n(banca non trovata in {percorso}: salto il controllo sui template)")
+        return 0
+    banca = json.load(open(percorso, encoding="utf-8"))
+    print(f"\nle guardie sui {len(banca)} template della banca:")
+    segnalati = 0
+    for t in banca:
+        nomi = sorted(set(tb.find_stray_names(t["text"])))
+        cod = tb.inline_code(t["text"])
+        if nomi or cod:
+            segnalati += 1
+            print(f"  #{t.get('id', '?'):<4} {t.get('doc_type', '')[:32]:<32} "
+                  f"{'nomi ' + str(nomi[:2]) if nomi else ''} "
+                  f"{'codice ' + repr(cod) if cod else ''}")
+    print(f"  -> {segnalati}/{len(banca)} da rivedere")
+    return 0                              # informativo: non fa fallire l'autoverifica
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--templates",
+                    default=str(tb.ROOT / "dataset" / "synthetic" / "legal_templates.json"),
+                    help="banca di template su cui ripassare le guardie")
+    args = ap.parse_args()
+    errori = controlla()
+    sulla_banca(args.templates)
+    print(f"\n{'tutti i casi corretti' if not errori else str(errori) + ' CASI SBAGLIATI'}")
+    return 1 if errori else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Guardia: riconoscere i nomi di persona, non il lessico dei tribunali

find_stray_names considerava nome proprio qualunque coppia di maiuscole assente da
LEGAL_CAPITALIZED, un vocabolario giuridico scritto a mano. Regge dentro il tribunale e
crolla fuori: "Ufficio Protocollo", "Risorse Umane", "Servizio Clienti", "Azienda
Sanitaria Locale" vengono scartati come se fossero persone. Si perdono cioe' i template
buoni proprio nei domini che il dataset non copre, e allungare la lista a ogni dominio
nuovo e' una rincorsa senza fine.

Il discriminante non e' "questa parola e' giuridica?" ma "questa parola e' una persona?".
Due segnali, entrambi indipendenti dal dominio:

1. LESSICO -- i nomi e i cognomi che il progetto usa GIA' per iniettare le persone
   (MALE_NAMES/FEMALE_NAMES/SURNAMES di generate_synthetic_pii). Sono gli stessi che il
   modello tende a scrivere inline, e non c'e' un secondo elenco da mantenere.
2. CONTESTO -- le parole che in italiano introducono una persona, a due livelli: dopo
   "nato", "il sottoscritto", "Sig." una maiuscola e' un nome anche da sola; dopo un nome
   di RUOLO ("giudice", "intestatario") serve Nome + Cognome, perche' i ruoli possono
   essere seguiti da un qualificatore ("il Giudice Unico", "denominato Locatore").

Si ragiona su corse di maiuscole consecutive invece che su coppie, e la corsa non
attraversa un confine di frase ("assistito dal Cancelliere. La causa..." non e' un nome
di due parole). I segnaposto lasciano un segno al proprio posto invece di un buco: senza
di esso, in "corrisposta dal Sig. {FULLNAME} al Venditore" il titolo scavalca il
segnaposto e scarta il template per un nome che era gia' al suo posto. "<istituzione> di
<Maiuscola>" e' il nome di un ufficio, non una persona: e' l'unico modo per non leggere
"Giudice di Pace" come il cognome Pace, che nel lessico c'e' per davvero.

Aggiunta una seconda guardia, inline_code: un CF/IBAN/telefono/data scritto nel testo
invece che come segnaposto e' un'entita' che esiste nel testo ma non nelle label -- il
modello impara a NON taggarla. La guardia sui nomi non lo vede (non sono parole) e serve
soprattutto fuori dal tribunale, dove la prosa e' piena di numeri. Le citazioni di norme
("196/2003", "art. 2043") restano numeri legittimi e non vengono toccate.

selfcheck_guards.py verifica entrambi i lati dell'errore: 29 casi, sia PII che deve
essere presa sia lessico amministrativo che non deve esserlo. Sui 237 template di una
banca costruita con la guardia vecchia: 0 falsi positivi con la nuova, e un template
segnalato per una data scritta a mano (PII vera, entrata quando la guardia non guardava
i numeri).

Guardia: un nome di persona non e' fatto di quattro parole maiuscole

Un contratto di telefonia e' stato scartato per "l'offerta sottoscritta Mobile Plan Pro
Canone": "sottoscritta" vale come contesto forte, ma qui e' il participio ("l'offerta che
si sottoscrive"), non il sostantivo ("la sottoscritta dichiara"). Distinguere i due sensi
richiederebbe di guardare la frase; guardare la LUNGHEZZA basta. Un nome di persona sta in
due o tre parole, quindi una corsa piu' lunga e' la denominazione di qualcos'altro -- un
prodotto commerciale, un ufficio, un titolo di sezione -- e in quel caso chi introduce non
va creduto. Fuori dal tribunale i nomi commerciali di questa forma sono ovunque.

Guardia: nomi e cognomi non valgono lo stesso, e il complemento non e' un'apposizione

Provata sui 14 domini nuovi, la guardia ha scartato 6 template su 42 e tutti e 6 erano
buoni. I motivi sono due, e vengono da fuori il tribunale.

1. "Gentile Servizio Clienti" e "Gentile Cliente" scartati perche' GENTILE E' UN COGNOME
   nel lessico del progetto. Non e' un caso isolato: mezza lista di cognomi italiani e'
   fatta di parole comuni -- Pace, Costa, Conte, Villa, Monti, Fiore, Guerra, Bianco,
   Neri, Leone -- e nei documenti amministrativi quelle parole prendono la maiuscola per
   motivi loro. I nomi PROPRI ("Giulia", "Aldo") non hanno questo problema. Percio' il
   lessico ora e' diviso: un nome proprio vale da solo, un cognome vale solo se qualcosa
   lo introduce come persona.

2. "agente di Polizia Locale" e "Responsabile del Procedimento" scartati come nomi di
   persona introdotti da un ruolo. La differenza con "il paziente Bianchi" e'
   grammaticale, non lessicale: una PREPOSIZIONE prima della maiuscola rende quel pezzo un
   complemento di cio' che precede, mentre il nome di una persona segue il proprio ruolo in
   apposizione, senza preposizione in mezzo. Il nome proprio resta valido anche da
   complemento ("la firma di Giulia").

La seconda regola ha sostituito la lista ISTITUZIONI introdotta poco prima per non leggere
"Giudice di Pace" come il cognome Pace: la relazione grammaticale copre qualunque ufficio,
la lista sarebbe rimasta indietro al primo dominio nuovo -- lo stesso difetto del
vocabolario giuridico che questa serie di patch sta smontando.

Aggiunti a CONTESTO_RUOLO gli altri modi italiani di dire "la persona che fa X" (agente,
funzionario, conducente, socio, venditore, passeggero...): fuori dal tribunale sono i ruoli
piu' frequenti, e senza di loro "il sottoscritto Agente accertatore" veniva letto come un
nome.

Autoverifica a 34 casi. Sui 272 template della banca (14 domini nuovi inclusi): 0 falsi
positivi.

Guardia: due segnaposto attaccati fondono le entita'

L'idea e' della PR #15 di @Darkfog81, che la applica ai template scritti da un agente di
coding. Vale identica per quelli scritti da un LLM, e li' serve di piu': il modello produce
spesso questa forma negli elenchi ("{CITY} {DATE}", "{FULLNAME} {CF}", "{AGE} {GENDER}").

Con due segnaposto separati da soli spazi le entita' iniettate finiscono adiacenti senza un
token 'O' fra loro. In BIO diventano indistinguibili da una sola entita' piu' lunga quando
la label e' la stessa, e in ogni caso la prosa che ne esce non e' italiano: "di anni 45
maschile".

Trovato applicandola: 1 template su 478 nella banca locale conteneva "{AGE} {GENDER}".

