### PR TITLE
20 tipi di documento oltre il tribunale, a costo invariato

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -412,6 +412,33 @@ Motivazione: consentono di **arricchire il pool offline da 25 a 85 template senz
 `MIXEDLIST` e `PROVINCE`) per mitigare l'overfit strutturale sui tag IT-legali rari
 (`CATASTO`/`DOCID`/`CF`/`TARGA`). Complementare al percorso Gemini raccomandato in
 `CONTRIBUTING.md`, non sostitutivo. Nessun impatto sul training.
+## 2026-07-30 — 20 tipi di documento oltre il tribunale (a costo invariato)
+
+`DOC_TYPES` conteneva **10** tipi, tutti atti giudiziari civili. Ma gli identificativi italiani
+compaiono anche fuori da un'aula, e il modello è debole proprio sulle **classi aperte**: `ORG` è il
+tag peggiore (F1 .983 su 145 esempi di validazione), seguito da `ZIPCODE`/`STREET`/`CITY`. Restare
+sugli atti civili significa non mostrare mai `ORG` nei contesti dove è il soggetto naturale.
+
+Aggiunti **20 tipi**: appalti pubblici, perizia di stima, successioni, lavoro subordinato,
+contestazione disciplinare, assemblea condominiale, sinistro assicurativo, mutuo ipotecario,
+informativa GDPR, ricorso tributario, atto notarile di S.r.l., accesso agli atti, denuncia per uso
+fraudolento di carta, reclamo all'ABF, sommarie informazioni testimoniali, sinistro stradale,
+opposizione a sanzione, consenso informato sanitario, verbale di identificazione, prestazione
+previdenziale. Portano anche **strutture** che gli atti civili non hanno: moduli, informative,
+capitolati.
+
+**Il costo non aumenta.** Scrivere un template per ognuno dei 30 tipi a ogni run triplicherebbe le
+chiamate all'LLM — e per chi usa Gemini il costo è in euro. `sample_doc_types()` ne campiona **10
+per run** (`--doc-types N`, `0` = tutti): stesso numero di chiamate di prima, e contributori diversi
+coprono domini diversi. Due run consecutive differiscono di ~7 tipi su 10, quindi **l'unione delle
+contribuzioni copre tutto senza che nessuno paghi per tutto** — che è il modo giusto di far crescere
+un dataset comunitario.
+
+Nota per chi rivede: `find_stray_names()` è tarata sul lessico dei tribunali
+(`LEGAL_CAPITALIZED`) e nei domini nuovi scarta template validi perché legge come nomi di persona
+espressioni come *"Risorse Umane"*, *"Ufficio Protocollo"*, *"Sala Udienze"*. È perdita di recall,
+non un rischio di sicurezza (misurata: 8 template scartati su 44 in una banca di prova), ma conviene
+estendere il vocabolario insieme ai domini.
 
 ---
 

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -228,7 +228,7 @@ def _validate_record(rec):
     return None
 
 
-def gen_new_templates(per_type, boost):
+def gen_new_templates(per_type, boost, n_doc_types=None):
     """Fa scrivere a Gemini NUOVI template legali (prosa con soli segnaposto).
 
     Ritorna la lista dei testi-template validi. Ogni esecuzione produce prosa
@@ -253,12 +253,14 @@ def gen_new_templates(per_type, boost):
         hint = ("\n\nIMPORTANTE: in questo documento usa PIU' VOLTE, in modo naturale, "
                 "i seguenti segnaposto: " + " ".join(f"{{{s}}}" for s in boost_slots) + ".")
 
-    total = len(tb.DOC_TYPES) * per_type
+    doc_types = tb.sample_doc_types(
+        tb.DEFAULT_DOC_TYPES if n_doc_types is None else n_doc_types)
+    total = len(doc_types) * per_type
     print(f"Scrivo {total} NUOVI template con [{tb.backend_name()}] "
-          f"({len(tb.DOC_TYPES)} tipi x {per_type}) ...")
+          f"({len(doc_types)} tipi su {len(tb.DOC_TYPES)} x {per_type}) ...")
 
     out, done, ok = [], 0, 0
-    for doc_type in tb.DOC_TYPES:
+    for doc_type in doc_types:
         for _ in range(per_type):
             done += 1
             prompt = tb.PROMPT.format(doc_type=doc_type, slot_list=slot_list,
@@ -312,7 +314,7 @@ STOP_TEMPLATE = 2_000
 
 
 def generate(n, seed, handle, per_type, offline, boost, out_path=None,
-             max_per_structure=25):
+             max_per_structure=25, n_doc_types=None):
     """Genera esempi sintetici tenendo solo le righe che aggiungono qualcosa.
 
     Perche' non semplicemente n righe: il testo di ogni riga e' unico (i valori cambiano
@@ -344,7 +346,7 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     # Seed diverso per contributore => valori diversi => no duplicati nel dataset.
     random.seed(seed)
 
-    new_templates = [] if offline else gen_new_templates(per_type, boost)
+    new_templates = [] if offline else gen_new_templates(per_type, boost, n_doc_types)
     # i built-in garantiscono comunque la copertura dei tag rari (CATASTO/DOCID/CONTO...);
     # la NOVITA' del testo viene dai template freschi di Gemini.
     templates = new_templates + gen.TEMPLATES + gen.load_external_templates()
@@ -499,6 +501,8 @@ def main():
                     help="quanti NUOVI template per tipo documento far scrivere a Gemini (default 2)")
     ap.add_argument("--boost", nargs="*", metavar="TAG=PESO",
                     help="rinforza i tag sotto-rappresentati, es. --boost ORG=6 IBAN=4 CF=4")
+    ap.add_argument("--doc-types", type=int, default=None,
+                    help="quanti tipi di documento campionare per run (0 = tutti)")
     ap.add_argument("--offline", action="store_true",
                     help="non usare Gemini: genera dai soli template built-in (dati meno nuovi)")
     ap.add_argument("--no-upload", action="store_true",
@@ -548,7 +552,7 @@ def main():
     tmp_path = ROOT / "dataset" / "contributions" / f".{handle}-{stamp}.parziale.jsonl"
     _, counts, n_new, n_ok, from_new = generate(
         args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path,
-        max_per_structure=args.max_per_structure)
+        max_per_structure=args.max_per_structure, n_doc_types=args.doc_types)
     if n_new:
         print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
     print(f"Generati {n_ok} esempi validi. Entita' per label:")

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -30,6 +30,7 @@ import argparse
 import io
 import json
 import os
+import random
 import re
 import sys
 import time
@@ -66,11 +67,53 @@ SLOT_HINTS = """  {ORG}     = ragione sociale di una societa'/studio legale/banc
   {MATRICOLA} = matricola aziendale INPS/INAIL del datore di lavoro"""
 
 DOC_TYPES = [
+    # --- atti giudiziari civili ---
     "atto di citazione", "comparsa di costituzione e risposta", "sentenza civile",
     "decreto ingiuntivo", "contratto di locazione", "procura alle liti",
     "ricorso per decreto ingiuntivo", "verbale di udienza", "atto di diffida",
     "contratto di compravendita immobiliare",
+    # --- oltre il tribunale ---------------------------------------------------------
+    # Gli identificativi italiani (CF, P.IVA, catasto, IBAN, carta) compaiono anche fuori
+    # dagli atti civili, e il modello e' debole proprio sulle classi aperte -- ORG in testa
+    # (F1 .983 su 145 esempi di validazione), poi ZIPCODE/STREET/CITY. Questi domini portano
+    # ORG in contesti dove e' il soggetto naturale (appalti, banche, assicurazioni, condominio)
+    # e strutture di documento che gli atti civili non hanno (moduli, informative, capitolati).
+    "capitolato di appalto pubblico di lavori",
+    "perizia tecnica di stima immobiliare",
+    "atto di successione e dichiarazione di eredita'",
+    "contratto di lavoro subordinato a tempo indeterminato",
+    "lettera di contestazione disciplinare a un dipendente",
+    "verbale di assemblea condominiale",
+    "denuncia di sinistro assicurativo con controparte",
+    "contratto di mutuo ipotecario bancario",
+    "informativa privacy e consenso al trattamento dei dati (GDPR)",
+    "ricorso tributario alla Corte di Giustizia Tributaria",
+    "atto notarile di costituzione di societa' a responsabilita' limitata",
+    "istanza di accesso agli atti amministrativi",
+    "denuncia-querela per uso fraudolento di una carta di credito",
+    "reclamo all'Arbitro Bancario Finanziario per operazione non autorizzata su carta",
+    "verbale di sommarie informazioni testimoniali",
+    "atto di citazione per risarcimento danni da sinistro stradale",
+    "ricorso al Giudice di Pace in opposizione a sanzione amministrativa",
+    "consenso informato al trattamento sanitario",
+    "verbale di identificazione di persona sottoposta a controllo",
+    "domanda di ammissione a prestazione previdenziale",
 ]
+
+# quanti tipi campionare per run, quando non specificato
+DEFAULT_DOC_TYPES = 10
+
+
+def sample_doc_types(n=DEFAULT_DOC_TYPES):
+    """Sottoinsieme casuale dei tipi di documento (n=0 -> tutti).
+
+    Con 30 tipi, scrivere un template per OGNI tipo a ogni run triplicherebbe il costo
+    rispetto a prima -- e per chi usa Gemini il costo e' in euro. Campionarne 10 per run
+    tiene il costo invariato e fa si' che contributori diversi coprano domini diversi:
+    l'unione delle contribuzioni copre tutto senza che nessuno paghi per tutto."""
+    if not n or n >= len(DOC_TYPES):
+        return list(DOC_TYPES)
+    return random.sample(DOC_TYPES, n)
 
 # >>> incolla qui la tua chiave NUOVA (solo locale: non committare / non condividere questo file).
 # Lasciala "" per usare invece la variabile d'ambiente GEMINI_API_KEY.
@@ -310,6 +353,9 @@ def clean_and_validate(text):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--per-type", type=int, default=3, help="template per tipo documento")
+    ap.add_argument("--doc-types", type=int, default=DEFAULT_DOC_TYPES,
+                    help=f"quanti tipi di documento campionare per run "
+                         f"(0 = tutti i {len(DOC_TYPES)})")
     ap.add_argument("--out", default=str(ROOT / "dataset" / "synthetic" / "legal_templates.json"))
     ap.add_argument("--append", action="store_true", help="accoda al file esistente")
     args = ap.parse_args()
@@ -322,17 +368,18 @@ def main():
     base = len(templates)            # quanti c'erano gia'
     tid = len(templates)
 
-    total = len(DOC_TYPES) * args.per_type
+    doc_types = sample_doc_types(args.doc_types)
+    total = len(doc_types) * args.per_type
     done = ok = skip = 0
     t0 = time.time()
-    print(f"Genero {total} template ({len(DOC_TYPES)} tipi x {args.per_type}) "
-          f"con [{backend_name()}]\n")
+    print(f"Genero {total} template ({len(doc_types)} tipi su {len(DOC_TYPES)} "
+          f"x {args.per_type}) con [{backend_name()}]\n")
 
     def save():
         with open(args.out, "w", encoding="utf-8") as f:
             json.dump(templates, f, ensure_ascii=False, indent=2)
 
-    for doc_type in DOC_TYPES:
+    for doc_type in doc_types:
         for _ in range(args.per_type):
             done += 1
             elapsed = time.time() - t0


### PR DESCRIPTION
20 tipi di documento oltre il tribunale, a costo invariato

DOC_TYPES aveva 10 tipi, tutti atti giudiziari civili. Ma ORG e' il tag piu'
debole del modello (F1 .983) e resta invisibile nei contesti dove e' il soggetto
naturale: appalti, banche, assicurazioni, condominio.

Aggiunti 20 tipi (appalti, perizie, successioni, lavoro, condominio, sinistri,
mutui, GDPR, tributario, notarile, amministrativo, carte di credito, sanitario,
previdenziale), che portano anche strutture non giudiziarie: moduli, informative,
capitolati.

Il costo resta invariato: sample_doc_types() campiona 10 tipi per run
(--doc-types N, 0 = tutti). Contributori diversi coprono domini diversi ->
l'unione delle contribuzioni copre tutto senza che nessuno paghi per tutto.

