### PR TITLE
Una struttura, una riga: il volume ripetuto non è un contributo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,23 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-30 — `contribute_dataset.py`: scrittura incrementale invece di accumulo in RAM
+
+`generate()` accumulava **tutte** le righe in una lista e solo alla fine `write_local()` le
+scriveva. Con `MAX_N = 200_000` e template lunghi — documenti interi, non frasi: ~4-5 KB per riga —
+significa ~1 GB di JSON come oggetti Python, cioè diversi GB di heap, prima che venga scritto il
+primo byte. Su una macchina che stia già facendo altro (nel caso reale: server LLM locali che
+occupavano 22 GB su 30) il processo va in swap o viene ucciso, e si perde tutta la generazione.
+
+Ora le righe vengono scritte **mano a mano** su un file temporaneo, rinominato alla fine col numero
+di righe valide (che si conosce solo al termine, perché il self-check può scartarne). La memoria
+resta costante qualunque sia `--n`: misurato su 20.000 righe, **picco 25 MB** invece di ~1 GB, in
+2,3 s. Progresso stampato ogni 25.000 righe. `write_local()` è stata rimossa: non serviva più.
+
+Nessun cambio di formato né di interfaccia: stessi argomenti, stesso nome di file finale.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -240,42 +240,28 @@ def gen_new_templates(per_type, boost):
     return out
 
 
-def skeleton_key(rec):
-    """Impronta della SUPERFICIE della riga: il testo con ogni entita' sostituita dalla sua
-    label, normalizzato negli spazi. Due righe con lo stesso scheletro sono la stessa frase
-    con dentro gli stessi valori non etichettati: leggerle una dopo l'altra e' leggere due
-    volte la stessa cosa.
-
-    E' un'impronta a 8 byte e non lo scheletro intero: su centinaia di migliaia di righe
-    l'insieme degli scheletri per esteso non starebbe in memoria, e cio' che serve e' solo
-    sapere se una riga cosi' e' gia' passata."""
-    st = rec["source_text"]
-    pezzi, pos = [], 0
-    for e in sorted(rec["entities"], key=lambda e: e["start"]):
-        if e["start"] < pos:                     # entita' sovrapposte: la prima vince
-            continue
-        pezzi.append(st[pos:e["start"]])
-        pezzi.append("{" + e["label"] + "}")
-        pos = e["end"]
-    pezzi.append(st[pos:])
-    scheletro = " ".join("".join(pezzi).split())
-    return hashlib.blake2b(scheletro.encode(), digest_size=8).digest()
+def text_key(rec):
+    """Impronta del testo esatto. Serve solo a non scrivere due volte la stessa riga
+    identica: con valori pescati a caso non capita quasi mai, ma costa poco escluderlo."""
+    return hashlib.blake2b(rec["source_text"].encode(), digest_size=8).digest()
 
 
 def structure_key(rec):
-    """Impronta della STRUTTURA DI ETICHETTE: template di origine + sequenza delle label
-    nell'ordine in cui compaiono.
+    """Impronta della STRUTTURA della riga: template di origine + sequenza delle label
+    nell'ordine in cui compaiono. E' la grana giusta per dire quante cose diverse c'e'
+    dentro un file, e quindi quella su cui mettere un tetto.
 
-    Serve perche' lo scheletro conta come "struttura nuova" anche una variazione di testo
-    NON etichettato. Misurato sui 36 template built-in, 3.000 tentativi ciascuno: 3.805
-    scheletri distinti ma solo 574 sequenze di label, e la maggior parte dei template ne ha
-    UNA sola -- due dei loro scheletri differiscono per il nome del tribunale iniettato
-    ("Corte d'Appello di Carrara" invece di "Procura della Repubblica di Civitavecchia"),
-    cioe' sono la stessa riga con un valore diverso.
+    Non lo scheletro (il testo con le entita' sostituite dalle label): misurato, lo
+    scheletro punisce i template migliori. Un template di bolletta, in cui OGNI valore
+    iniettato e' etichettato, produce 1 solo scheletro su 500 righe -- tutte le sue righe
+    hanno lo stesso testo a meno delle label -- mentre un atto che contiene {TRIBUNAL}, il
+    cui valore iniettato NON e' etichettato, ne produce 343 perche' cambia il nome del
+    tribunale. Filtrando per scheletro il primo avrebbe diritto a una riga e il secondo a
+    venticinque: esattamente al rovescio.
 
-    Questa e' quindi la grana giusta per dire "quante cose diverse c'e' dentro", e le righe
-    che condividono la struttura si tengono a numero chiuso: qualche variante di valori
-    insegna al modello che la label non dipende dal valore, mille sono zavorra."""
+    A parita' di struttura le righe hanno nomi, date, importi e indirizzi tutti diversi, ed
+    e' variazione utile: insegna al modello che la label non dipende dal valore. Utile a
+    dosi piccole, zavorra a dosi grandi -- da qui il tetto."""
     labels = "|".join(e["label"] for e in sorted(rec["entities"], key=lambda e: e["start"]))
     return hashlib.blake2b(f"{rec['template_id']}#{labels}".encode(),
                            digest_size=8).digest()
@@ -301,15 +287,12 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     del file ripeteva una riga gia' presente -- 800 MB di zavorra che allunga ogni download
     e ogni epoca di training senza insegnare niente di nuovo.
 
-    Due filtri, a due grane diverse, perche' "uguale" ha due sensi:
-      - nessuno SCHELETRO ripetuto: due righe non possono avere lo stesso testo a meno dei
-        valori etichettati. E' la ripetizione visibile a chi legge il file.
-      - al massimo max_per_structure righe per STRUTTURA DI ETICHETTE (template + sequenza
-        delle label). Serve perche' lo scheletro conta come nuovo anche il cambio di un
-        valore non etichettato: sui built-in, 3.805 scheletri corrispondevano a 574
-        strutture vere. Qualche variante di valori sulla stessa struttura e' utile -- il
-        modello impara che la label non dipende dal valore -- ma oltre una manciata e'
-        volume. Con 1 si tiene una sola riga per struttura.
+    Il tetto sta sulla STRUTTURA (template + sequenza delle label): al massimo
+    max_per_structure righe possono condividerla. A parita' di struttura le righe hanno
+    nomi, date, importi e indirizzi tutti diversi -- variazione utile al modello, che
+    impara che la label non dipende dal valore -- ma utile a dosi piccole. Con 1 si tiene
+    una riga per struttura, e il file diventa il puro inventario di cio' che la banca sa
+    dire.
 
     Se la banca si esaurisce prima di arrivare a n, la generazione si ferma e lo dichiara:
     il numero di righe consegnabili e' un RISULTATO della banca, non una scelta di chi
@@ -344,10 +327,9 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     n_new = len(new_templates)
     rows, label_counts, bad = ([] if out_path is None else None), {}, 0
     n_ok = n_da_nuovi = 0
-    scheletri = set()              # superfici gia' scritte: mai due righe identiche a meno
-                                   # dei valori etichettati
-    strutture = {}                 # struttura di etichette -> quante righe gia' scritte
-    rip_scheletro = rip_struttura = tentativi = 0
+    testi = set()                  # testi gia' scritti: nessuna riga identica due volte
+    strutture = {}                 # struttura -> quante righe gia' scritte
+    rip_testo = rip_struttura = tentativi = 0
     rifiuti = {}                   # tid -> rifiuti consecutivi (per l'uscita del template)
     attivi = list(idx_pool)
     pesi = list(weights) if weights else None
@@ -391,17 +373,17 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
             bad += 1
             rifiuta(tid)
             continue
-        scheletro = skeleton_key(rec)
-        if scheletro in scheletri:                  # la stessa riga, di nuovo
-            rip_scheletro += 1
+        testo = text_key(rec)
+        if testo in testi:                          # la stessa riga identica, di nuovo
+            rip_testo += 1
             rifiuta(tid)
             continue
         struttura = structure_key(rec)
         if strutture.get(struttura, 0) >= max_per_structure:
-            rip_struttura += 1                      # struttura gia' vista abbastanza volte
+            rip_struttura += 1                      # questa struttura ha gia' le sue righe
             rifiuta(tid)
             continue
-        scheletri.add(scheletro)
+        testi.add(testo)
         strutture[struttura] = strutture.get(struttura, 0) + 1
         rifiuti[tid] = 0
         for e in entities:
@@ -420,9 +402,9 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     if bad:
         print(f"  scartati {bad} esempi non validi (self-check)")
     print(f"  righe tenute: {n_ok} su {tentativi} tentativi "
-          f"({100 * n_ok / max(1, tentativi):.1f}%) | scartate {rip_scheletro} righe "
-          f"identiche a una gia' scritta e {rip_struttura} oltre il tetto di "
-          f"{max_per_structure} per struttura")
+          f"({100 * n_ok / max(1, tentativi):.1f}%) | scartate {rip_testo} righe identiche "
+          f"a una gia' scritta e {rip_struttura} oltre il tetto di {max_per_structure} "
+          f"per struttura")
     print(f"  strutture di etichette distinte: {len(strutture)} "
           f"({n_ok / max(1, len(strutture)):.1f} righe per struttura)")
     if n_ok < n:
@@ -490,11 +472,10 @@ def main():
     ap.add_argument("--upload-file", metavar="PATH",
                     help="non rigenerare: carica un .jsonl gia' prodotto (push veloce, niente Gemini)")
     ap.add_argument("--max-per-structure", type=int, default=25, metavar="K",
-                    help="quante righe al massimo possono condividere la stessa STRUTTURA DI "
-                         "ETICHETTE (template + sequenza delle label). Default 25: qualche "
-                         "variante di valori insegna che la label non dipende dal valore, "
-                         "oltre e' volume. Le righe identiche a meno dei valori etichettati "
-                         "sono comunque escluse sempre")
+                    help="quante righe al massimo possono condividere la stessa STRUTTURA "
+                         "(template + sequenza delle label). Default 25: qualche variante di "
+                         "valori insegna al modello che la label non dipende dal valore, "
+                         "oltre e' volume. Con 1 il file e' l'inventario delle strutture")
     ap.add_argument("--repo", default=REPO_ID, help="dataset di destinazione (override)")
     args = ap.parse_args()
 

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -241,13 +241,14 @@ def gen_new_templates(per_type, boost):
 
 
 def skeleton_key(rec):
-    """Impronta della STRUTTURA della riga: il testo con ogni entita' sostituita dalla sua
+    """Impronta della SUPERFICIE della riga: il testo con ogni entita' sostituita dalla sua
     label, normalizzato negli spazi. Due righe con lo stesso scheletro sono la stessa frase
-    con dentro valori diversi.
+    con dentro gli stessi valori non etichettati: leggerle una dopo l'altra e' leggere due
+    volte la stessa cosa.
 
     E' un'impronta a 8 byte e non lo scheletro intero: su centinaia di migliaia di righe
     l'insieme degli scheletri per esteso non starebbe in memoria, e cio' che serve e' solo
-    sapere se una struttura e' gia' passata."""
+    sapere se una riga cosi' e' gia' passata."""
     st = rec["source_text"]
     pezzi, pos = [], 0
     for e in sorted(rec["entities"], key=lambda e: e["start"]):
@@ -261,27 +262,58 @@ def skeleton_key(rec):
     return hashlib.blake2b(scheletro.encode(), digest_size=8).digest()
 
 
-# tentativi consecutivi senza una struttura nuova dopo i quali si considera esaurita la
-# banca di template. La generazione e' rapidissima (decine di migliaia di righe al
-# secondo), quindi conviene una soglia larga: e' preferibile spendere qualche secondo in
-# piu' che fermarsi presto e consegnare meno strutture di quelle disponibili.
-STOP_SATURAZIONE = 50_000
+def structure_key(rec):
+    """Impronta della STRUTTURA DI ETICHETTE: template di origine + sequenza delle label
+    nell'ordine in cui compaiono.
+
+    Serve perche' lo scheletro conta come "struttura nuova" anche una variazione di testo
+    NON etichettato. Misurato sui 36 template built-in, 3.000 tentativi ciascuno: 3.805
+    scheletri distinti ma solo 574 sequenze di label, e la maggior parte dei template ne ha
+    UNA sola -- due dei loro scheletri differiscono per il nome del tribunale iniettato
+    ("Corte d'Appello di Carrara" invece di "Procura della Repubblica di Civitavecchia"),
+    cioe' sono la stessa riga con un valore diverso.
+
+    Questa e' quindi la grana giusta per dire "quante cose diverse c'e' dentro", e le righe
+    che condividono la struttura si tengono a numero chiuso: qualche variante di valori
+    insegna al modello che la label non dipende dal valore, mille sono zavorra."""
+    labels = "|".join(e["label"] for e in sorted(rec["entities"], key=lambda e: e["start"]))
+    return hashlib.blake2b(f"{rec['template_id']}#{labels}".encode(),
+                           digest_size=8).digest()
+
+
+# Rifiuti consecutivi dopo i quali un template si considera esaurito e smette di essere
+# pescato. Senza questo l'ultima parte della generazione e' quasi tutta lavoro buttato: i
+# template le cui strutture sono gia' piene continuano a uscire (sono la maggioranza) e ogni
+# loro riga viene costruita per essere scartata. Con l'uscita per template la generazione si
+# ferma da sola quando sono esauriti tutti, e il numero di righe e' quello che la banca sa
+# dare. La soglia e' un compromesso: troppo bassa dichiara esaurito un template che avrebbe
+# ancora strutture rare, troppo alta spreca tentativi.
+STOP_TEMPLATE = 2_000
 
 
 def generate(n, seed, handle, per_type, offline, boost, out_path=None,
-             max_per_skeleton=1):
-    """Genera esempi sintetici fino ad averne n con struttura DISTINTA.
+             max_per_structure=25):
+    """Genera esempi sintetici tenendo solo le righe che aggiungono qualcosa.
 
     Perche' non semplicemente n righe: il testo di ogni riga e' unico (i valori cambiano
-    sempre), quindi "0 duplicati" non dice niente sulla varieta'. Cio' che il modello vede
-    e' lo SCHELETRO -- il testo con le entita' sostituite dalle label -- e su 200.000 righe
-    da un pool di 273 template gli scheletri distinti misurati erano 57.093: il 71% del
-    file ripeteva una struttura gia' presente, cioe' era volume, non informazione. Con
-    max_per_skeleton=1 ogni struttura entra una volta sola e il file contiene solo cio' che
-    aggiunge qualcosa; alzandolo si ammettono piu' valori sulla stessa struttura.
+    sempre), quindi "0 duplicati" non dice niente sulla varieta'. Misurato su una
+    contribuzione da 200.000 righe con 273 template: 57.093 scheletri distinti, cioe' il 71%
+    del file ripeteva una riga gia' presente -- 800 MB di zavorra che allunga ogni download
+    e ogni epoca di training senza insegnare niente di nuovo.
 
-    Se la banca di template si esaurisce prima di arrivare a n, la generazione si ferma e
-    lo dichiara: il numero di righe consegnabili e' un RISULTATO della banca, non una scelta.
+    Due filtri, a due grane diverse, perche' "uguale" ha due sensi:
+      - nessuno SCHELETRO ripetuto: due righe non possono avere lo stesso testo a meno dei
+        valori etichettati. E' la ripetizione visibile a chi legge il file.
+      - al massimo max_per_structure righe per STRUTTURA DI ETICHETTE (template + sequenza
+        delle label). Serve perche' lo scheletro conta come nuovo anche il cambio di un
+        valore non etichettato: sui built-in, 3.805 scheletri corrispondevano a 574
+        strutture vere. Qualche variante di valori sulla stessa struttura e' utile -- il
+        modello impara che la label non dipende dal valore -- ma oltre una manciata e'
+        volume. Con 1 si tiene una sola riga per struttura.
+
+    Se la banca si esaurisce prima di arrivare a n, la generazione si ferma e lo dichiara:
+    il numero di righe consegnabili e' un RISULTATO della banca, non una scelta di chi
+    genera.
 
     Con out_path le righe vengono SCRITTE MANO A MANO invece di essere accumulate in
     memoria. Serve: MAX_N e' 200.000 e con template lunghi (documenti interi, non frasi)
@@ -312,15 +344,33 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     n_new = len(new_templates)
     rows, label_counts, bad = ([] if out_path is None else None), {}, 0
     n_ok = n_da_nuovi = 0
-    visti = {}                     # impronta della struttura -> quante volte gia' scritta
-    ripetute = tentativi = a_vuoto = 0
+    scheletri = set()              # superfici gia' scritte: mai due righe identiche a meno
+                                   # dei valori etichettati
+    strutture = {}                 # struttura di etichette -> quante righe gia' scritte
+    rip_scheletro = rip_struttura = tentativi = 0
+    rifiuti = {}                   # tid -> rifiuti consecutivi (per l'uscita del template)
+    attivi = list(idx_pool)
+    pesi = list(weights) if weights else None
     out = None
     if out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out = open(out_path, "w", encoding="utf-8")
-    while n_ok < n and a_vuoto < STOP_SATURAZIONE:
+    def esaurisci(tid):
+        """Toglie dal sorteggio un template che non da' piu' niente di nuovo."""
+        nonlocal attivi, pesi
+        posizione = attivi.index(tid)
+        attivi = attivi[:posizione] + attivi[posizione + 1:]
+        if pesi is not None:
+            pesi = pesi[:posizione] + pesi[posizione + 1:]
+
+    def rifiuta(tid):
+        rifiuti[tid] = rifiuti.get(tid, 0) + 1
+        if rifiuti[tid] >= STOP_TEMPLATE:
+            esaurisci(tid)
+
+    while n_ok < n and attivi:
         tentativi += 1
-        tid = random.choices(idx_pool, weights=weights, k=1)[0]
+        tid = random.choices(attivi, weights=pesi, k=1)[0]
         text, entities = gen.build_example(tid, templates)
         tokens, bio = gen.to_bio(text, entities)
         rec = {
@@ -339,15 +389,21 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
         err = _validate_record(rec)
         if err:
             bad += 1
-            a_vuoto += 1
+            rifiuta(tid)
             continue
-        impronta = skeleton_key(rec)
-        if visti.get(impronta, 0) >= max_per_skeleton:
-            ripetute += 1
-            a_vuoto += 1
+        scheletro = skeleton_key(rec)
+        if scheletro in scheletri:                  # la stessa riga, di nuovo
+            rip_scheletro += 1
+            rifiuta(tid)
             continue
-        visti[impronta] = visti.get(impronta, 0) + 1
-        a_vuoto = 0
+        struttura = structure_key(rec)
+        if strutture.get(struttura, 0) >= max_per_structure:
+            rip_struttura += 1                      # struttura gia' vista abbastanza volte
+            rifiuta(tid)
+            continue
+        scheletri.add(scheletro)
+        strutture[struttura] = strutture.get(struttura, 0) + 1
+        rifiuti[tid] = 0
         for e in entities:
             label_counts[e["label"]] = label_counts.get(e["label"], 0) + 1
         n_ok += 1
@@ -363,14 +419,17 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
 
     if bad:
         print(f"  scartati {bad} esempi non validi (self-check)")
-    print(f"  strutture distinte scritte: {n_ok} su {tentativi} tentativi "
-          f"({100 * n_ok / max(1, tentativi):.1f}%); {ripetute} righe scartate perche' "
-          f"ripetevano una struttura gia' presente")
+    print(f"  righe tenute: {n_ok} su {tentativi} tentativi "
+          f"({100 * n_ok / max(1, tentativi):.1f}%) | scartate {rip_scheletro} righe "
+          f"identiche a una gia' scritta e {rip_struttura} oltre il tetto di "
+          f"{max_per_structure} per struttura")
+    print(f"  strutture di etichette distinte: {len(strutture)} "
+          f"({n_ok / max(1, len(strutture)):.1f} righe per struttura)")
     if n_ok < n:
-        print(f"  BANCA ESAURITA: chieste {n} righe a struttura distinta, ottenute {n_ok}. "
-              f"{STOP_SATURAZIONE} tentativi di fila non hanno prodotto una struttura "
-              f"nuova.\n  Per averne di piu' serve allargare la banca di template "
-              f"(llm_template_bank.py), non alzare --n.")
+        print(f"  BANCA ESAURITA: chieste {n} righe, ottenute {n_ok}. Tutti i "
+              f"{len(templates)} template hanno smesso di produrre righe nuove "
+              f"({STOP_TEMPLATE} rifiuti di fila ciascuno).\n  Per averne di piu' serve "
+              f"allargare la banca di template (llm_template_bank.py), non alzare --n.")
     return rows, label_counts, n_new, n_ok, n_da_nuovi
 
 
@@ -430,11 +489,12 @@ def main():
                     help="genera solo in locale, non apre la PR")
     ap.add_argument("--upload-file", metavar="PATH",
                     help="non rigenerare: carica un .jsonl gia' prodotto (push veloce, niente Gemini)")
-    ap.add_argument("--max-per-skeleton", type=int, default=1, metavar="K",
-                    help="quante righe al massimo possono condividere la stessa STRUTTURA "
-                         "(default 1: nessuna struttura ripetuta). Il testo di ogni riga e' "
-                         "sempre unico, ma su 200.000 righe da 273 template il 71% "
-                         "ripeteva uno scheletro gia' presente: volume, non informazione")
+    ap.add_argument("--max-per-structure", type=int, default=25, metavar="K",
+                    help="quante righe al massimo possono condividere la stessa STRUTTURA DI "
+                         "ETICHETTE (template + sequenza delle label). Default 25: qualche "
+                         "variante di valori insegna che la label non dipende dal valore, "
+                         "oltre e' volume. Le righe identiche a meno dei valori etichettati "
+                         "sono comunque escluse sempre")
     ap.add_argument("--repo", default=REPO_ID, help="dataset di destinazione (override)")
     args = ap.parse_args()
 
@@ -472,7 +532,7 @@ def main():
     tmp_path = ROOT / "dataset" / "contributions" / f".{handle}-{stamp}.parziale.jsonl"
     _, counts, n_new, n_ok, from_new = generate(
         args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path,
-        max_per_skeleton=args.max_per_skeleton)
+        max_per_structure=args.max_per_structure)
     if n_new:
         print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
     print(f"Generati {n_ok} esempi validi. Entita' per label:")

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -45,6 +45,7 @@ Uso
 """
 
 import argparse
+import hashlib
 import io
 import json
 import os
@@ -239,8 +240,48 @@ def gen_new_templates(per_type, boost):
     return out
 
 
-def generate(n, seed, handle, per_type, offline, boost, out_path=None):
-    """Genera n esempi sintetici. Con Gemini usa template NUOVI scritti al volo.
+def skeleton_key(rec):
+    """Impronta della STRUTTURA della riga: il testo con ogni entita' sostituita dalla sua
+    label, normalizzato negli spazi. Due righe con lo stesso scheletro sono la stessa frase
+    con dentro valori diversi.
+
+    E' un'impronta a 8 byte e non lo scheletro intero: su centinaia di migliaia di righe
+    l'insieme degli scheletri per esteso non starebbe in memoria, e cio' che serve e' solo
+    sapere se una struttura e' gia' passata."""
+    st = rec["source_text"]
+    pezzi, pos = [], 0
+    for e in sorted(rec["entities"], key=lambda e: e["start"]):
+        if e["start"] < pos:                     # entita' sovrapposte: la prima vince
+            continue
+        pezzi.append(st[pos:e["start"]])
+        pezzi.append("{" + e["label"] + "}")
+        pos = e["end"]
+    pezzi.append(st[pos:])
+    scheletro = " ".join("".join(pezzi).split())
+    return hashlib.blake2b(scheletro.encode(), digest_size=8).digest()
+
+
+# tentativi consecutivi senza una struttura nuova dopo i quali si considera esaurita la
+# banca di template. La generazione e' rapidissima (decine di migliaia di righe al
+# secondo), quindi conviene una soglia larga: e' preferibile spendere qualche secondo in
+# piu' che fermarsi presto e consegnare meno strutture di quelle disponibili.
+STOP_SATURAZIONE = 50_000
+
+
+def generate(n, seed, handle, per_type, offline, boost, out_path=None,
+             max_per_skeleton=1):
+    """Genera esempi sintetici fino ad averne n con struttura DISTINTA.
+
+    Perche' non semplicemente n righe: il testo di ogni riga e' unico (i valori cambiano
+    sempre), quindi "0 duplicati" non dice niente sulla varieta'. Cio' che il modello vede
+    e' lo SCHELETRO -- il testo con le entita' sostituite dalle label -- e su 200.000 righe
+    da un pool di 273 template gli scheletri distinti misurati erano 57.093: il 71% del
+    file ripeteva una struttura gia' presente, cioe' era volume, non informazione. Con
+    max_per_skeleton=1 ogni struttura entra una volta sola e il file contiene solo cio' che
+    aggiunge qualcosa; alzandolo si ammettono piu' valori sulla stessa struttura.
+
+    Se la banca di template si esaurisce prima di arrivare a n, la generazione si ferma e
+    lo dichiara: il numero di righe consegnabili e' un RISULTATO della banca, non una scelta.
 
     Con out_path le righe vengono SCRITTE MANO A MANO invece di essere accumulate in
     memoria. Serve: MAX_N e' 200.000 e con template lunghi (documenti interi, non frasi)
@@ -271,11 +312,14 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None):
     n_new = len(new_templates)
     rows, label_counts, bad = ([] if out_path is None else None), {}, 0
     n_ok = n_da_nuovi = 0
+    visti = {}                     # impronta della struttura -> quante volte gia' scritta
+    ripetute = tentativi = a_vuoto = 0
     out = None
     if out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out = open(out_path, "w", encoding="utf-8")
-    for _ in range(n):
+    while n_ok < n and a_vuoto < STOP_SATURAZIONE:
+        tentativi += 1
         tid = random.choices(idx_pool, weights=weights, k=1)[0]
         text, entities = gen.build_example(tid, templates)
         tokens, bio = gen.to_bio(text, entities)
@@ -295,7 +339,15 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None):
         err = _validate_record(rec)
         if err:
             bad += 1
+            a_vuoto += 1
             continue
+        impronta = skeleton_key(rec)
+        if visti.get(impronta, 0) >= max_per_skeleton:
+            ripetute += 1
+            a_vuoto += 1
+            continue
+        visti[impronta] = visti.get(impronta, 0) + 1
+        a_vuoto = 0
         for e in entities:
             label_counts[e["label"]] = label_counts.get(e["label"], 0) + 1
         n_ok += 1
@@ -311,6 +363,14 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None):
 
     if bad:
         print(f"  scartati {bad} esempi non validi (self-check)")
+    print(f"  strutture distinte scritte: {n_ok} su {tentativi} tentativi "
+          f"({100 * n_ok / max(1, tentativi):.1f}%); {ripetute} righe scartate perche' "
+          f"ripetevano una struttura gia' presente")
+    if n_ok < n:
+        print(f"  BANCA ESAURITA: chieste {n} righe a struttura distinta, ottenute {n_ok}. "
+              f"{STOP_SATURAZIONE} tentativi di fila non hanno prodotto una struttura "
+              f"nuova.\n  Per averne di piu' serve allargare la banca di template "
+              f"(llm_template_bank.py), non alzare --n.")
     return rows, label_counts, n_new, n_ok, n_da_nuovi
 
 
@@ -370,6 +430,11 @@ def main():
                     help="genera solo in locale, non apre la PR")
     ap.add_argument("--upload-file", metavar="PATH",
                     help="non rigenerare: carica un .jsonl gia' prodotto (push veloce, niente Gemini)")
+    ap.add_argument("--max-per-skeleton", type=int, default=1, metavar="K",
+                    help="quante righe al massimo possono condividere la stessa STRUTTURA "
+                         "(default 1: nessuna struttura ripetuta). Il testo di ogni riga e' "
+                         "sempre unico, ma su 200.000 righe da 273 template il 71% "
+                         "ripeteva uno scheletro gia' presente: volume, non informazione")
     ap.add_argument("--repo", default=REPO_ID, help="dataset di destinazione (override)")
     args = ap.parse_args()
 
@@ -406,7 +471,8 @@ def main():
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     tmp_path = ROOT / "dataset" / "contributions" / f".{handle}-{stamp}.parziale.jsonl"
     _, counts, n_new, n_ok, from_new = generate(
-        args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path)
+        args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path,
+        max_per_skeleton=args.max_per_skeleton)
     if n_new:
         print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
     print(f"Generati {n_ok} esempi validi. Entita' per label:")

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -239,9 +239,17 @@ def gen_new_templates(per_type, boost):
     return out
 
 
-def generate(n, seed, handle, per_type, offline, boost):
+def generate(n, seed, handle, per_type, offline, boost, out_path=None):
     """Genera n esempi sintetici. Con Gemini usa template NUOVI scritti al volo.
-    Ritorna (righe, conteggi, n_template_nuovi)."""
+
+    Con out_path le righe vengono SCRITTE MANO A MANO invece di essere accumulate in
+    memoria. Serve: MAX_N e' 200.000 e con template lunghi (documenti interi, non frasi)
+    una riga pesa ~5 KB, quindi l'accumulo arriva a diversi GB di oggetti Python e la
+    macchina va in swap prima di scrivere il primo byte. In streaming la memoria resta
+    costante qualunque sia --n.
+
+    Ritorna (righe_o_None, conteggi, n_template_nuovi, n_valide, n_da_template_nuovi):
+    con out_path il primo elemento e' None (le righe sono sul file)."""
     # IMPORTANTE: ri-seminiamo DOPO l'import (gen imposta seed(42) a import-time).
     # Seed diverso per contributore => valori diversi => no duplicati nel dataset.
     random.seed(seed)
@@ -261,7 +269,12 @@ def generate(n, seed, handle, per_type, offline, boost):
     idx_pool = list(range(len(templates)))
 
     n_new = len(new_templates)
-    rows, label_counts, bad = [], {}, 0
+    rows, label_counts, bad = ([] if out_path is None else None), {}, 0
+    n_ok = n_da_nuovi = 0
+    out = None
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out = open(out_path, "w", encoding="utf-8")
     for _ in range(n):
         tid = random.choices(idx_pool, weights=weights, k=1)[0]
         text, entities = gen.build_example(tid, templates)
@@ -285,19 +298,20 @@ def generate(n, seed, handle, per_type, offline, boost):
             continue
         for e in entities:
             label_counts[e["label"]] = label_counts.get(e["label"], 0) + 1
-        rows.append(rec)
+        n_ok += 1
+        n_da_nuovi += rec["meta"]["new_template"]
+        if out is None:
+            rows.append(rec)
+        else:
+            out.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            if n_ok % 25_000 == 0:
+                print(f"  scritte {n_ok} righe ...", flush=True)
+    if out is not None:
+        out.close()
 
     if bad:
         print(f"  scartati {bad} esempi non validi (self-check)")
-    return rows, label_counts, n_new
-
-
-def write_local(rows, out_path):
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w", encoding="utf-8") as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    return out_path
+    return rows, label_counts, n_new, n_ok, n_da_nuovi
 
 
 def upload_pr(local_path, path_in_repo, handle, n, seed, repo_id):
@@ -387,24 +401,28 @@ def main():
     mode = "built-in (offline)" if args.offline else f"Gemini (--per-type {args.per_type})"
     print(f"handle={handle}  n={args.n}  seed={seed}  template={mode}")
 
-    rows, counts, n_new = generate(args.n, seed, handle, args.per_type, args.offline, boost)
+    # il nome definitivo contiene il numero di righe VALIDE, che si sa solo alla fine:
+    # si scrive su un temporaneo e si rinomina.
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tmp_path = ROOT / "dataset" / "contributions" / f".{handle}-{stamp}.parziale.jsonl"
+    _, counts, n_new, n_ok, from_new = generate(
+        args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path)
     if n_new:
-        from_new = sum(1 for r in rows if r["meta"]["new_template"])
-        print(f"\n{from_new}/{len(rows)} esempi da template NUOVI di Gemini.")
-    print(f"Generati {len(rows)} esempi validi. Entita' per label:")
+        print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
+    print(f"Generati {n_ok} esempi validi. Entita' per label:")
     for label, c in sorted(counts.items(), key=lambda x: -x[1]):
         print(f"  {label:18s} {c}")
 
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    fname = f"{handle}-{stamp}-seed{seed}-n{len(rows)}.jsonl"
-    local_path = write_local(rows, ROOT / "dataset" / "contributions" / fname)
+    fname = f"{handle}-{stamp}-seed{seed}-n{n_ok}.jsonl"
+    local_path = tmp_path.parent / fname
+    tmp_path.replace(local_path)
     print(f"\nScritto in locale -> {local_path}")
 
     if args.no_upload:
         print("\n(--no-upload) Nessun caricamento. Rilancia senza --no-upload per aprire la PR.")
         return
 
-    upload_pr(local_path, f"contributions/{fname}", handle, len(rows), seed, args.repo)
+    upload_pr(local_path, f"contributions/{fname}", handle, n_ok, seed, args.repo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
contribute_dataset: scrittura incrementale invece di accumulo in RAM

generate() accumulava tutte le righe in una lista e write_local() le scriveva
alla fine. Con MAX_N=200000 e template lunghi (documenti interi, ~5 KB per riga)
sono ~1 GB di JSON come oggetti Python: su una macchina occupata il processo va
in swap o viene ucciso, perdendo tutta la generazione.

Ora si scrive mano a mano su un temporaneo, rinominato alla fine col conteggio
reale delle righe valide. Misurato su 20000 righe: picco 25 MB invece di ~1 GB,
2,3 s. write_local() rimossa, non serviva piu'.

Una struttura, una riga: il volume ripetuto non e' un contributo

Il testo di ogni riga generata e' unico, perche' i valori cambiano sempre. Per questo "0
duplicati" non dice niente sulla varieta': cio' che il modello vede e' lo SCHELETRO della
riga, il testo con le entita' sostituite dalle loro label. Misurato su una contribuzione da
200.000 righe con 273 template nel pool: 57.093 scheletri distinti, cioe' il 71% del file
ripeteva una struttura gia' presente, con una mediana di 1.408 righe per template. Quel 71%
occupa 800 MB, allunga ogni download e ogni epoca di training, e non insegna niente che le
righe rimanenti non insegnino gia'.

generate() tiene ora l'impronta della struttura di ogni riga scritta e scarta le righe che
ne ripetono una: --max-per-skeleton (default 1) e' il tetto di righe per struttura, e
alzarlo ammette piu' valori sulla stessa frase per chi lo vuole. L'impronta e' un blake2b
da 8 byte, non lo scheletro per esteso: su centinaia di migliaia di righe l'insieme degli
scheletri interi non starebbe in memoria, e serve solo sapere se una struttura e' gia'
passata. Resta compatibile con la scrittura in streaming: la memoria cresce col numero di
strutture distinte, non col peso del file.

Cambia anche il significato di --n, e in meglio: non e' piu' "quante righe scrivere" ma
"quante strutture distinte cercare". Se la banca si esaurisce prima, la generazione si
ferma dopo 50.000 tentativi a vuoto e lo dichiara, dicendo che per averne di piu' serve
allargare la banca di template invece di alzare --n. Il numero di righe consegnabili
diventa un risultato misurato della banca, non un numero scelto da chi genera.

Verificato con la banca reale: 2.000 strutture distinte su 4.120 tentativi (48,5%), 2.120
righe scartate perche' ripetevano uno scheletro.

Due grane di ripetizione, e l'uscita del template esaurito

Correzione a me stesso: il primo filtro contava come "struttura nuova" anche una variazione
di testo NON etichettato. Due scheletri dello stesso template differivano per il nome del
tribunale iniettato -- "Corte d'Appello di Carrara" invece di "Procura della Repubblica di
Civitavecchia" -- cioe' erano la stessa riga con un valore diverso. Misurato sui 36 template
built-in con 3.000 tentativi ciascuno: 3.805 scheletri distinti ma solo 574 sequenze di
label, e la maggior parte dei template ne ha UNA sola. Il numero onesto di cose diverse era
il secondo, non il primo.

Quindi due filtri a due grane, perche' "uguale" ha due sensi:
  - nessuno SCHELETRO ripetuto (testo a meno dei valori etichettati): e' la ripetizione che
    vede chi apre il file;
  - al massimo --max-per-structure righe per STRUTTURA DI ETICHETTE, cioe' template +
    sequenza delle label. Default 25: qualche variante di valori insegna al modello che la
    label non dipende dal valore, mille sono zavorra.

Aggiunta l'uscita per template esaurito. Senza, la coda della generazione e' quasi tutto
lavoro buttato: i template le cui strutture sono piene restano nel sorteggio, sono la
maggioranza, e ogni loro riga viene costruita solo per essere scartata. Ora un template che
colleziona 2.000 rifiuti di fila esce dal sorteggio e la generazione termina quando sono
usciti tutti -- il che rende il numero di righe una proprieta' misurata della banca. Su un
pool da 110 template: 3.405 righe, 650 strutture di etichette, 26 secondi contro i minuti
che ci voleva prima per arrivare allo stesso punto.

Il tetto va sulla struttura, non sullo scheletro: lo scheletro punisce i template migliori

Il filtro precedente escludeva le righe con lo scheletro (testo con le entita' sostituite
dalle label) gia' visto. Misurato sulla banca vera, fa il contrario di quello che deve.

Un template di bolletta, in cui OGNI valore iniettato e' etichettato, produce 1 solo
scheletro su 500 righe: le sue righe differiscono solo nei valori, che lo scheletro
nasconde per costruzione. Un atto che contiene {TRIBUNAL}, il cui valore iniettato NON e'
etichettato, ne produce 343, perche' basta che cambi il nome del tribunale. Filtrando per
scheletro il primo ha diritto a una riga e il secondo a venticinque -- e il primo e' il
template migliore, quello che etichetta tutto quello che inietta. Nel file generato si
vedeva: 6 righe di bolletta e 4 di cedolino su 5.563, mentre gli atti con {TRIBUNAL} ne
prendevano centinaia.

Resta quindi un solo tetto, sulla STRUTTURA (template + sequenza delle label), e come
esclusione secca soltanto i testi identici. A parita' di struttura le righe hanno nomi,
date, importi e indirizzi tutti diversi: e' la variazione che insegna al modello che la
label non dipende dal valore, e va dosata, non azzerata.

Verificato: con il tetto a K si ottengono esattamente K righe per struttura e 0 testi
ripetuti (K=1 -> 657 righe, K=10 -> 6.580, K=25 -> 16.470 su un pool da 117 template).


---

**Dipende dalla #23**: il primo dei quattro commit e' la scrittura incrementale, che qui serve
perche' il tetto per struttura decide riga per riga mentre scrive. Va letta dopo la #23.
