### PR TITLE
Concordanza articolo/nome nei template dell'LLM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -412,6 +412,29 @@ Motivazione: consentono di **arricchire il pool offline da 25 a 85 template senz
 `MIXEDLIST` e `PROVINCE`) per mitigare l'overfit strutturale sui tag IT-legali rari
 (`CATASTO`/`DOCID`/`CF`/`TARGA`). Complementare al percorso Gemini raccomandato in
 `CONTRIBUTING.md`, non sostitutivo. Nessun impatto sul training.
+## 2026-07-30 — Concordanza articolo/nome nei template scritti dall'LLM
+
+Il `PROMPT` chiede all'LLM di scrivere `"il/la {LAWYER}"`, ma il modello scrive quasi sempre
+`"il {LAWYER}"`: con un nome femminile iniettato esce **"il Lara De Angelis"**. Misurato su una
+generazione reale da 5.000 esempi: **13,9%** delle entità persona ha l'articolo discordante,
+**26%** delle righe ne contiene almeno una. Le label restano esatte — è la prosa che non regge, e
+la plausibilità del contesto è il motivo per cui questi template esistono.
+
+`fix_concordanza()`, applicata da `clean_and_validate()`, riscrive il determinante davanti ai
+segnaposto di persona sfruttando una regola del linguaggio giuridico italiano: il **nome di ruolo**
+porta l'articolo maschile per entrambi i sessi. Così `"il {LAWYER}"` → `"l'avvocato {LAWYER}"`,
+`"del {JUDGE}"` → `"del giudice {JUDGE}"`, `"al {PLAINTIFF}"` → `"all'attore {PLAINTIFF}"`,
+`"dalla {DEFENDANT}"` → `"dal convenuto {DEFENDANT}"`. Per `{FULLNAME}`, che non ha un ruolo, il
+determinante si toglie: `"del {FULLNAME}"` → `"di {FULLNAME}"`, `"il {FULLNAME}"` → `"{FULLNAME}"`.
+
+Vale per qualsiasi backend (Gemini incluso): è l'LLM, non il modello locale, a produrre l'artefatto.
+
+**Resta noto e non risolto:** `"il Sig. {FULLNAME}"` — forma che il prompt suggerisce
+esplicitamente — con un nome femminile dà *"il Sig. Arianna Nardi"*. Non è correggibile a livello
+di template, perché il sesso si conosce solo quando il valore viene iniettato; servirebbe un
+titolo neutro nel prompt (`"il/la Sig."`) o un `{TITLE}` generato accanto al nome. Stessa natura
+il caso `"del {TRIBUNAL}"` → *"del Corte d'Appello di Sassari"*, dove `TRIBUNAL_TYPES` mescola
+generi (`Tribunale`, `Corte`, `Procura`).
 
 ---
 

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -281,6 +281,66 @@ def normalizza_escape(text):
     B-), inutilizzabile in training. Misurato: 1 template su 237 conteneva la
     sequenza e ha rotto 721 righe su 200.000."""
     return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "\t")
+# --- concordanza articolo/nome -------------------------------------------------------
+# Il PROMPT chiede "il/la {LAWYER}", ma l'LLM scrive quasi sempre "il {LAWYER}": con un
+# nome femminile esce "il Lara De Angelis" (13,9% delle persone in una generazione reale
+# da 5.000 esempi). Nel linguaggio giuridico italiano il NOME DI RUOLO porta l'articolo
+# maschile per entrambi i sessi ("il giudice Sara Rossi", "l'avvocato Lara Bianchi"):
+# inserirlo risolve la concordanza invece di aggirarla. Per {FULLNAME}, che non ha un
+# ruolo, si toglie l'articolo ("di Sara Rossi" invece di "del Sara Rossi").
+RUOLI = {"JUDGE": ("giudice", False), "LAWYER": ("avvocato", True),
+         "PLAINTIFF": ("attore", True), "DEFENDANT": ("convenuto", False),
+         "WITNESS": ("teste", False)}
+
+# determinante trovato -> (forma davanti a consonante, forma davanti a vocale)
+DETERMINANTI = {
+    "il": ("il", "l'"), "lo": ("il", "l'"), "la": ("il", "l'"), "l'": ("il", "l'"),
+    "un": ("un", "un"), "una": ("un", "un"), "uno": ("un", "un"),
+    "del": ("del", "dell'"), "dello": ("del", "dell'"), "della": ("del", "dell'"),
+    "dell'": ("del", "dell'"),
+    "al": ("al", "all'"), "allo": ("al", "all'"), "alla": ("al", "all'"),
+    "all'": ("al", "all'"),
+    "dal": ("dal", "dall'"), "dallo": ("dal", "dall'"), "dalla": ("dal", "dall'"),
+    "dall'": ("dal", "dall'"),
+}
+# per {FULLNAME}: l'articolo si toglie, la preposizione articolata diventa semplice
+SENZA_ARTICOLO = {"il": "", "lo": "", "la": "", "l'": "", "un": "", "una": "", "uno": "",
+                  "del": "di", "dello": "di", "della": "di", "dell'": "di",
+                  "al": "a", "allo": "a", "alla": "a", "all'": "a",
+                  "dal": "da", "dallo": "da", "dalla": "da", "dall'": "da"}
+
+_DET = "|".join(sorted((re.escape(d) for d in DETERMINANTI), key=len, reverse=True))
+_RE_RUOLO = re.compile(rf"\b({_DET})\s*\{{({'|'.join(RUOLI)})\}}", re.IGNORECASE)
+_RE_FULLNAME = re.compile(rf"\b({_DET})\s*\{{FULLNAME\}}", re.IGNORECASE)
+
+
+def fix_concordanza(text):
+    """Riscrive i determinanti davanti ai segnaposto di persona (vedi sopra).
+    Ritorna (testo, n_correzioni)."""
+    n = 0
+
+    def _ruolo(m):
+        nonlocal n
+        det, slot = m.group(1).lower(), m.group(2).upper()
+        noun, vocale = RUOLI[slot]
+        forma = DETERMINANTI[det][1 if vocale else 0]
+        n += 1
+        sep = "" if forma.endswith("'") else " "
+        out = f"{forma}{sep}{noun} {{{slot}}}"
+        return out[0].upper() + out[1:] if m.group(1)[0].isupper() else out
+
+    def _fullname(m):
+        nonlocal n
+        det = m.group(1).lower()
+        prep = SENZA_ARTICOLO[det]
+        n += 1
+        if not prep:
+            return "{FULLNAME}"
+        return f"{prep} {{FULLNAME}}"
+
+    text = _RE_RUOLO.sub(_ruolo, text)
+    text = _RE_FULLNAME.sub(_fullname, text)
+    return text, n
 
 
 def clean_and_validate(text):
@@ -304,6 +364,9 @@ def clean_and_validate(text):
     if bad:
         print(f"  scartato: carattere non latino {bad!r} (artefatto del modello)")
         return None
+    text, nfix = fix_concordanza(text)
+    if nfix:
+        print(f"  concordanza: {nfix} determinanti riscritti davanti ai nomi")
     return text
 
 


### PR DESCRIPTION
Concordanza articolo/nome nei template dell'LLM

Il prompt chiede 'il/la {LAWYER}' ma l'LLM scrive 'il {LAWYER}': con un nome
femminile esce 'il Lara De Angelis'. Misurato su 5000 esempi reali: 13,9% delle
persone ha l'articolo discordante, 26% delle righe.

fix_concordanza() sfrutta una regola del giuridico italiano: il nome di ruolo
porta l'articolo maschile per entrambi i sessi. 'il {LAWYER}' ->
'l'avvocato {LAWYER}', 'del {JUDGE}' -> 'del giudice {JUDGE}'. Per {FULLNAME},
che non ha ruolo, il determinante si toglie: 'del {FULLNAME}' -> 'di {FULLNAME}'.

Resta noto: 'il Sig. {FULLNAME}' e 'del {TRIBUNAL}' non sono correggibili a
livello di template (il genere si conosce solo all'iniezione).

