### PR TITLE
Rifiuta le label fuori tassonomia nei contributi

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,28 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-30 — Una label sconosciuta in un contributo aggiunge una classe al modello, in silenzio
+
+`train_pii.py` costruisce la tassonomia **dai dati**: `label_set` è l'unione delle label presenti
+in train + validation e `num_labels = len(label_list)` (righe 315-319). `normalize_labels()` lascia
+passare invariata ogni label che non sia in `TAG_MAP` (`TAG_MAP.get(l[2:], l[2:])`).
+
+Conseguenza: un file contribuito che contenga una label non prevista — anche solo un errore di
+battitura, `CREDITCARD` invece di `CREDITCARDNUMBER`, `FULLNAM` invece di `FULLNAME` — **non produce
+alcun errore**. Diventa una classe nuova della testa di classificazione, con dati di training e zero
+support in validation: invisibile nelle metriche, e le percentuali per-tag pubblicate non sono più
+confrontabili coi run precedenti. Un cambio di tassonomia può quindi avvenire come effetto
+collaterale di un upload, mentre `docs/TASSONOMIA_TAG.md` e `CONTRIBUTING.md` lo descrivono
+giustamente come una decisione deliberata (si edita solo `TAG_MAP`/`DROP_TYPES`).
+
+`contribute_dataset.py` ora rifiuta le righe con label fuori dai **22 tag finali** o dai tag grezzi
+che `TAG_MAP` sa rimappare, controllando sia `entities` sia `bio_labels`. Il messaggio d'errore
+rimanda a `docs/TASSONOMIA_TAG.md`. Chi vuole davvero proporre un tag nuovo apre una PR sul codice,
+che è dove la decisione va discussa: cambia la dimensione della testa, impone un riaddestramento e
+invalida il confronto con le metriche pubblicate.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -179,14 +179,43 @@ def parse_boost(items):
     return boost
 
 
+# --- tassonomia ammessa -------------------------------------------------------------
+# ATTENZIONE, non ovvio: train_pii.py costruisce l'elenco delle label DAI DATI
+# (`label_set` dall'unione train+validation, `num_labels=len(label_list)`), e
+# normalize_labels() lascia passare invariata qualsiasi label che non sia in TAG_MAP.
+# Conseguenza: una label sconosciuta in un file contribuito -- anche solo un errore di
+# battitura come "CREDITCARD" o "FULLNAM" -- NON da' errore: diventa silenziosamente una
+# CLASSE NUOVA del modello, con dati di training e zero support in validation. Qui la
+# contribuzione viene fermata prima, cosi' un cambio di tassonomia resta una decisione
+# esplicita dei maintainer e non un effetto collaterale di un upload.
+TAG_FINALI = {
+    "FULLNAME", "AGE", "GENDER", "DATE", "TIME", "STREET", "BUILDINGNUM", "ZIPCODE",
+    "CITY", "PROVINCE", "EMAIL", "TELEPHONENUM", "CF", "PIVA", "ID_DOC", "IBAN",
+    "CREDITCARDNUMBER", "AMOUNT", "TARGA", "ORG", "DOCID", "CATASTO",
+}
+# label "grezze" che TAG_MAP in train_pii.py sa rimappare su un tag finale
+TAG_GREZZI = {
+    "GIVENNAME", "SURNAME", "GIUDICE", "AVVOCATO", "ATTORE", "CONVENUTO", "TESTIMONE",
+    "SEX", "TAXNUM", "PEC", "RG", "IDCARDNUM", "PASSPORTNUM", "DRIVERLICENSENUM",
+    "SOCIALNUM", "CONTO",
+}
+TAG_AMMESSI = TAG_FINALI | TAG_GREZZI
+
+
 def _validate_record(rec):
     """Controlli di integrita' strutturale + checksum su una riga generata."""
     if len(rec["tokens"]) != len(rec["bio_labels"]):
         return "tokens/bio_labels di lunghezza diversa"
+    for lab in rec["bio_labels"]:
+        if lab != "O" and lab[2:] not in TAG_AMMESSI:
+            return f"label BIO fuori tassonomia: '{lab}'"
     for e in rec["entities"]:
         # offset coerenti col testo
         if rec["source_text"][e["start"]:e["end"]] != e["value"]:
             return f"offset entita' incoerente: {e}"
+        if e["label"] not in TAG_AMMESSI:
+            return (f"label fuori tassonomia: '{e['label']}' (aggiungerebbe una classe "
+                    f"nuova al modello; vedi docs/TASSONOMIA_TAG.md)")
         if e["label"] == "CF" and not cf_ok(e["value"]):
             return f"CF con checksum non valido: {e['value']}"
         if e["label"] == "PIVA" and not piva_ok(e["value"]):


### PR DESCRIPTION
Rifiuta le label fuori tassonomia nei contributi

train_pii.py costruisce l'elenco delle label DAI DATI (label_set dall'unione
train+validation, num_labels=len(label_list)) e normalize_labels lascia passare
invariata ogni label non presente in TAG_MAP.

Quindi una label sconosciuta in un file contribuito -- anche solo un refuso come
'CREDITCARD' -- non da' errore: diventa una classe nuova del modello, con dati di
training e zero support in validation, e rende non confrontabili le metriche
per-tag pubblicate.

Ora _validate_record rifiuta le righe con label fuori dai 22 tag finali o dai tag
grezzi che TAG_MAP sa rimappare, su entities e bio_labels. Proporre un tag nuovo
resta possibile, ma via PR sul codice: e' dove la decisione va discussa.

