### PR TITLE
Registro linguistico per tipo, e 14 tipi fuori dal mondo legale

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -412,6 +412,33 @@ Motivazione: consentono di **arricchire il pool offline da 25 a 85 template senz
 `MIXEDLIST` e `PROVINCE`) per mitigare l'overfit strutturale sui tag IT-legali rari
 (`CATASTO`/`DOCID`/`CF`/`TARGA`). Complementare al percorso Gemini raccomandato in
 `CONTRIBUTING.md`, non sostitutivo. Nessun impatto sul training.
+## 2026-07-30 — 20 tipi di documento oltre il tribunale (a costo invariato)
+
+`DOC_TYPES` conteneva **10** tipi, tutti atti giudiziari civili. Ma gli identificativi italiani
+compaiono anche fuori da un'aula, e il modello è debole proprio sulle **classi aperte**: `ORG` è il
+tag peggiore (F1 .983 su 145 esempi di validazione), seguito da `ZIPCODE`/`STREET`/`CITY`. Restare
+sugli atti civili significa non mostrare mai `ORG` nei contesti dove è il soggetto naturale.
+
+Aggiunti **20 tipi**: appalti pubblici, perizia di stima, successioni, lavoro subordinato,
+contestazione disciplinare, assemblea condominiale, sinistro assicurativo, mutuo ipotecario,
+informativa GDPR, ricorso tributario, atto notarile di S.r.l., accesso agli atti, denuncia per uso
+fraudolento di carta, reclamo all'ABF, sommarie informazioni testimoniali, sinistro stradale,
+opposizione a sanzione, consenso informato sanitario, verbale di identificazione, prestazione
+previdenziale. Portano anche **strutture** che gli atti civili non hanno: moduli, informative,
+capitolati.
+
+**Il costo non aumenta.** Scrivere un template per ognuno dei 30 tipi a ogni run triplicherebbe le
+chiamate all'LLM — e per chi usa Gemini il costo è in euro. `sample_doc_types()` ne campiona **10
+per run** (`--doc-types N`, `0` = tutti): stesso numero di chiamate di prima, e contributori diversi
+coprono domini diversi. Due run consecutive differiscono di ~7 tipi su 10, quindi **l'unione delle
+contribuzioni copre tutto senza che nessuno paghi per tutto** — che è il modo giusto di far crescere
+un dataset comunitario.
+
+Nota per chi rivede: `find_stray_names()` è tarata sul lessico dei tribunali
+(`LEGAL_CAPITALIZED`) e nei domini nuovi scarta template validi perché legge come nomi di persona
+espressioni come *"Risorse Umane"*, *"Ufficio Protocollo"*, *"Sala Udienze"*. È perdita di recall,
+non un rischio di sicurezza (misurata: 8 template scartati su 44 in una banca di prova), ma conviene
+estendere il vocabolario insieme ai domini.
 
 ---
 

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -263,8 +263,10 @@ def gen_new_templates(per_type, boost, n_doc_types=None):
     for doc_type in doc_types:
         for _ in range(per_type):
             done += 1
+            persona, stile = tb.registro(doc_type)
             prompt = tb.PROMPT.format(doc_type=doc_type, slot_list=slot_list,
-                                      slot_hints=tb.SLOT_HINTS) + hint
+                                      slot_hints=tb.SLOT_HINTS,
+                                      persona=persona, stile=stile) + hint
             text = tb.clean_and_validate(tb.call_llm(prompt))
             if text:
                 out.append(text)

--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -228,7 +228,7 @@ def _validate_record(rec):
     return None
 
 
-def gen_new_templates(per_type, boost):
+def gen_new_templates(per_type, boost, n_doc_types=None):
     """Fa scrivere a Gemini NUOVI template legali (prosa con soli segnaposto).
 
     Ritorna la lista dei testi-template validi. Ogni esecuzione produce prosa
@@ -253,12 +253,14 @@ def gen_new_templates(per_type, boost):
         hint = ("\n\nIMPORTANTE: in questo documento usa PIU' VOLTE, in modo naturale, "
                 "i seguenti segnaposto: " + " ".join(f"{{{s}}}" for s in boost_slots) + ".")
 
-    total = len(tb.DOC_TYPES) * per_type
+    doc_types = tb.sample_doc_types(
+        tb.DEFAULT_DOC_TYPES if n_doc_types is None else n_doc_types)
+    total = len(doc_types) * per_type
     print(f"Scrivo {total} NUOVI template con [{tb.backend_name()}] "
-          f"({len(tb.DOC_TYPES)} tipi x {per_type}) ...")
+          f"({len(doc_types)} tipi su {len(tb.DOC_TYPES)} x {per_type}) ...")
 
     out, done, ok = [], 0, 0
-    for doc_type in tb.DOC_TYPES:
+    for doc_type in doc_types:
         for _ in range(per_type):
             done += 1
             prompt = tb.PROMPT.format(doc_type=doc_type, slot_list=slot_list,
@@ -312,7 +314,7 @@ STOP_TEMPLATE = 2_000
 
 
 def generate(n, seed, handle, per_type, offline, boost, out_path=None,
-             max_per_structure=25):
+             max_per_structure=25, n_doc_types=None):
     """Genera esempi sintetici tenendo solo le righe che aggiungono qualcosa.
 
     Perche' non semplicemente n righe: il testo di ogni riga e' unico (i valori cambiano
@@ -344,7 +346,7 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     # Seed diverso per contributore => valori diversi => no duplicati nel dataset.
     random.seed(seed)
 
-    new_templates = [] if offline else gen_new_templates(per_type, boost)
+    new_templates = [] if offline else gen_new_templates(per_type, boost, n_doc_types)
     # i built-in garantiscono comunque la copertura dei tag rari (CATASTO/DOCID/CONTO...);
     # la NOVITA' del testo viene dai template freschi di Gemini.
     templates = new_templates + gen.TEMPLATES + gen.load_external_templates()
@@ -499,6 +501,8 @@ def main():
                     help="quanti NUOVI template per tipo documento far scrivere a Gemini (default 2)")
     ap.add_argument("--boost", nargs="*", metavar="TAG=PESO",
                     help="rinforza i tag sotto-rappresentati, es. --boost ORG=6 IBAN=4 CF=4")
+    ap.add_argument("--doc-types", type=int, default=None,
+                    help="quanti tipi di documento campionare per run (0 = tutti)")
     ap.add_argument("--offline", action="store_true",
                     help="non usare Gemini: genera dai soli template built-in (dati meno nuovi)")
     ap.add_argument("--no-upload", action="store_true",
@@ -548,7 +552,7 @@ def main():
     tmp_path = ROOT / "dataset" / "contributions" / f".{handle}-{stamp}.parziale.jsonl"
     _, counts, n_new, n_ok, from_new = generate(
         args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path,
-        max_per_structure=args.max_per_structure)
+        max_per_structure=args.max_per_structure, n_doc_types=args.doc_types)
     if n_new:
         print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
     print(f"Generati {n_ok} esempi validi. Entita' per label:")

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -30,6 +30,7 @@ import argparse
 import io
 import json
 import os
+import random
 import re
 import sys
 import time
@@ -66,11 +67,53 @@ SLOT_HINTS = """  {ORG}     = ragione sociale di una societa'/studio legale/banc
   {MATRICOLA} = matricola aziendale INPS/INAIL del datore di lavoro"""
 
 DOC_TYPES = [
+    # --- atti giudiziari civili ---
     "atto di citazione", "comparsa di costituzione e risposta", "sentenza civile",
     "decreto ingiuntivo", "contratto di locazione", "procura alle liti",
     "ricorso per decreto ingiuntivo", "verbale di udienza", "atto di diffida",
     "contratto di compravendita immobiliare",
+    # --- oltre il tribunale ---------------------------------------------------------
+    # Gli identificativi italiani (CF, P.IVA, catasto, IBAN, carta) compaiono anche fuori
+    # dagli atti civili, e il modello e' debole proprio sulle classi aperte -- ORG in testa
+    # (F1 .983 su 145 esempi di validazione), poi ZIPCODE/STREET/CITY. Questi domini portano
+    # ORG in contesti dove e' il soggetto naturale (appalti, banche, assicurazioni, condominio)
+    # e strutture di documento che gli atti civili non hanno (moduli, informative, capitolati).
+    "capitolato di appalto pubblico di lavori",
+    "perizia tecnica di stima immobiliare",
+    "atto di successione e dichiarazione di eredita'",
+    "contratto di lavoro subordinato a tempo indeterminato",
+    "lettera di contestazione disciplinare a un dipendente",
+    "verbale di assemblea condominiale",
+    "denuncia di sinistro assicurativo con controparte",
+    "contratto di mutuo ipotecario bancario",
+    "informativa privacy e consenso al trattamento dei dati (GDPR)",
+    "ricorso tributario alla Corte di Giustizia Tributaria",
+    "atto notarile di costituzione di societa' a responsabilita' limitata",
+    "istanza di accesso agli atti amministrativi",
+    "denuncia-querela per uso fraudolento di una carta di credito",
+    "reclamo all'Arbitro Bancario Finanziario per operazione non autorizzata su carta",
+    "verbale di sommarie informazioni testimoniali",
+    "atto di citazione per risarcimento danni da sinistro stradale",
+    "ricorso al Giudice di Pace in opposizione a sanzione amministrativa",
+    "consenso informato al trattamento sanitario",
+    "verbale di identificazione di persona sottoposta a controllo",
+    "domanda di ammissione a prestazione previdenziale",
 ]
+
+# quanti tipi campionare per run, quando non specificato
+DEFAULT_DOC_TYPES = 10
+
+
+def sample_doc_types(n=DEFAULT_DOC_TYPES):
+    """Sottoinsieme casuale dei tipi di documento (n=0 -> tutti).
+
+    Con 30 tipi, scrivere un template per OGNI tipo a ogni run triplicherebbe il costo
+    rispetto a prima -- e per chi usa Gemini il costo e' in euro. Campionarne 10 per run
+    tiene il costo invariato e fa si' che contributori diversi coprano domini diversi:
+    l'unione delle contribuzioni copre tutto senza che nessuno paghi per tutto."""
+    if not n or n >= len(DOC_TYPES):
+        return list(DOC_TYPES)
+    return random.sample(DOC_TYPES, n)
 
 # >>> incolla qui la tua chiave NUOVA (solo locale: non committare / non condividere questo file).
 # Lasciala "" per usare invece la variabile d'ambiente GEMINI_API_KEY.
@@ -310,6 +353,9 @@ def clean_and_validate(text):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--per-type", type=int, default=3, help="template per tipo documento")
+    ap.add_argument("--doc-types", type=int, default=DEFAULT_DOC_TYPES,
+                    help=f"quanti tipi di documento campionare per run "
+                         f"(0 = tutti i {len(DOC_TYPES)})")
     ap.add_argument("--out", default=str(ROOT / "dataset" / "synthetic" / "legal_templates.json"))
     ap.add_argument("--append", action="store_true", help="accoda al file esistente")
     args = ap.parse_args()
@@ -322,17 +368,18 @@ def main():
     base = len(templates)            # quanti c'erano gia'
     tid = len(templates)
 
-    total = len(DOC_TYPES) * args.per_type
+    doc_types = sample_doc_types(args.doc_types)
+    total = len(doc_types) * args.per_type
     done = ok = skip = 0
     t0 = time.time()
-    print(f"Genero {total} template ({len(DOC_TYPES)} tipi x {args.per_type}) "
-          f"con [{backend_name()}]\n")
+    print(f"Genero {total} template ({len(doc_types)} tipi su {len(DOC_TYPES)} "
+          f"x {args.per_type}) con [{backend_name()}]\n")
 
     def save():
         with open(args.out, "w", encoding="utf-8") as f:
             json.dump(templates, f, ensure_ascii=False, indent=2)
 
-    for doc_type in DOC_TYPES:
+    for doc_type in doc_types:
         for _ in range(args.per_type):
             done += 1
             elapsed = time.time() - t0

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -98,10 +98,122 @@ DOC_TYPES = [
     "consenso informato al trattamento sanitario",
     "verbale di identificazione di persona sottoposta a controllo",
     "domanda di ammissione a prestazione previdenziale",
+    # --- fuori dal mondo legale ------------------------------------------------------
+    # I tipi sopra sono tutti atti, verbali, ricorsi, contratti: un unico mondo
+    # linguistico. Aggiungere l'ennesimo atto rende poco -- il modello ha gia' detto
+    # quello che si dice in un atto -- mentre una bolletta, un cedolino o una multa hanno
+    # parole, formule e impaginato che negli atti non esistono. Sono i documenti in cui un
+    # italiano incontra davvero i propri dati personali.
+    "bolletta di fornitura di energia elettrica",
+    "cedolino della retribuzione mensile di un dipendente",
+    "fattura elettronica di un professionista con ritenuta d'acconto",
+    "verbale di accertamento di violazione del codice della strada",
+    "dichiarazione sostitutiva di certificazione (autocertificazione)",
+    "domanda di partecipazione a un concorso pubblico",
+    "modulo di apertura di un conto corrente bancario",
+    "contratto di attivazione di una linea telefonica mobile",
+    "contratto di noleggio di un autoveicolo a breve termine",
+    "certificato di iscrizione scolastica con scheda di valutazione",
+    "richiesta di prenotazione di una prestazione ambulatoriale",
+    "reclamo per rimborso a un vettore di trasporto passeggeri",
+    "lettera di sollecito di pagamento a un cliente moroso",
+    "modulo di adesione a un'associazione con addebito SEPA",
 ]
 
 # quanti tipi campionare per run, quando non specificato
 DEFAULT_DOC_TYPES = 10
+
+# --- chi scrive, e in che lingua ------------------------------------------------------
+# Il prompt diceva "Sei un giurista italiano ... nel linguaggio dei tribunali": giusto per
+# un atto di citazione, sbagliato per una bolletta. Chiedere a un giurista di scrivere una
+# bolletta produce una bolletta in legalese, cioe' di nuovo le strutture che si volevano
+# evitare aprendo un dominio nuovo -- e la struttura e' esattamente cio' che il modello
+# impara. Ogni voce qui sotto dice chi scrive e con che lessico: e' la differenza fra un
+# tipo di documento nuovo per davvero e un atto travestito.
+REGISTRO_LEGALE = (
+    "un giurista italiano",
+    "il linguaggio tecnico-giuridico autentico usato nei tribunali italiani")
+
+REGISTRI = {
+    "bolletta di fornitura di energia elettrica": (
+        "un addetto alla fatturazione di una societa' di vendita di energia elettrica",
+        "il linguaggio amministrativo delle bollette: intestatario della fornitura, "
+        "indirizzo di fornitura, periodo di riferimento, letture del contatore, voci di "
+        "spesa in elenco (energia, trasporto, oneri, imposte), totale da pagare, scadenza "
+        "e modalita' di pagamento"),
+    "cedolino della retribuzione mensile di un dipendente": (
+        "un consulente del lavoro che compila un cedolino paga",
+        "il linguaggio delle buste paga: dati del datore e del lavoratore, qualifica e "
+        "livello, voci di competenza e di trattenuta in elenco, imponibile "
+        "previdenziale, ritenute, netto in busta, accredito"),
+    "fattura elettronica di un professionista con ritenuta d'acconto": (
+        "un commercialista che emette una fattura",
+        "il linguaggio della fatturazione: cedente e committente, numero e data del "
+        "documento, descrizione della prestazione, compenso, cassa previdenza, IVA, "
+        "ritenuta d'acconto, netto a pagare, riferimenti di pagamento"),
+    "verbale di accertamento di violazione del codice della strada": (
+        "un agente di polizia locale che redige un verbale",
+        "il linguaggio degli accertamenti stradali: luogo e ora del rilievo, veicolo e "
+        "targa, dati del trasgressore e del proprietario, norma violata, sanzione, "
+        "decurtazione di punti, termini e modi per il pagamento e per il ricorso"),
+    "dichiarazione sostitutiva di certificazione (autocertificazione)": (
+        "un cittadino che compila un'autocertificazione allo sportello",
+        "il linguaggio dei moduli della pubblica amministrazione: consapevole delle "
+        "sanzioni penali, dichiara, elenco puntato di stati e qualita' personali, luogo e "
+        "data, firma, informativa sul trattamento dei dati"),
+    "domanda di partecipazione a un concorso pubblico": (
+        "un candidato che compila la domanda di ammissione a un concorso",
+        "il linguaggio delle domande di concorso: bando di riferimento, dati anagrafici e "
+        "di residenza, titoli di studio, requisiti dichiarati, allegati, recapiti per le "
+        "comunicazioni"),
+    "modulo di apertura di un conto corrente bancario": (
+        "un impiegato di banca che compila la scheda di apertura di un rapporto",
+        "il linguaggio bancario dell'anagrafica cliente: dati identificativi e documento "
+        "esibito, residenza e domicilio, professione, dichiarazioni antiriciclaggio, "
+        "condizioni economiche del conto, coordinate del rapporto"),
+    "contratto di attivazione di una linea telefonica mobile": (
+        "un addetto di un operatore telefonico che compila un contratto di attivazione",
+        "il linguaggio dei contratti di telefonia: intestatario, offerta e canone, "
+        "numerazione attivata, portabilita' da altro operatore, durata e recesso, "
+        "domiciliazione dei pagamenti, recapiti"),
+    "contratto di noleggio di un autoveicolo a breve termine": (
+        "un addetto al banco di una societa' di autonoleggio",
+        "il linguaggio dei noleggi: conducente e patente, veicolo e targa, ritiro e "
+        "riconsegna con data e ora, chilometraggio, franchigia e coperture, garanzia sulla "
+        "carta di credito, stato del veicolo"),
+    "certificato di iscrizione scolastica con scheda di valutazione": (
+        "una segreteria scolastica che rilascia un certificato di iscrizione",
+        "il linguaggio della scuola italiana: istituto e anno scolastico, alunno e classe "
+        "frequentata, esercente la responsabilita' genitoriale, discipline e valutazioni, "
+        "note sulla frequenza, uso del certificato"),
+    "richiesta di prenotazione di una prestazione ambulatoriale": (
+        "un operatore di sportello che registra una prenotazione al CUP",
+        "il linguaggio amministrativo delle prenotazioni sanitarie: assistito e tessera, "
+        "medico richiedente, prestazione richiesta con codice, classe di priorita', sede e "
+        "appuntamento, quota di partecipazione o esenzione, disdetta. Nessun dato clinico: "
+        "solo la parte amministrativa della prenotazione"),
+    "reclamo per rimborso a un vettore di trasporto passeggeri": (
+        "un passeggero che scrive all'assistenza clienti di una compagnia di trasporto",
+        "il linguaggio dei reclami al servizio clienti: riferimento della prenotazione e "
+        "del titolo di viaggio, tratta e orari, disservizio subito, spese sostenute, "
+        "rimborso richiesto e coordinate per l'accredito, termini di risposta"),
+    "lettera di sollecito di pagamento a un cliente moroso": (
+        "un addetto all'amministrazione di un'impresa che scrive un sollecito",
+        "il linguaggio dell'amministrazione commerciale: riferimento alle fatture "
+        "insolute, scadenze superate, importo dovuto, invito al pagamento entro un "
+        "termine, coordinate per il versamento, avvertimento sulle azioni successive"),
+    "modulo di adesione a un'associazione con addebito SEPA": (
+        "una segreteria associativa che raccoglie le adesioni dei soci",
+        "il linguaggio dei moduli di adesione: dati del socio, quota e periodicita', "
+        "mandato di addebito diretto SEPA con identificativo del creditore, consensi al "
+        "trattamento dei dati e alle comunicazioni, firma e data"),
+}
+
+
+def registro(doc_type):
+    """Chi scrive il documento e con che lessico. Fuori dai tipi elencati vale il registro
+    legale: i tipi giudiziari e contrattuali sono nati con quel prompt."""
+    return REGISTRI.get(doc_type, REGISTRO_LEGALE)
 
 
 def sample_doc_types(n=DEFAULT_DOC_TYPES):
@@ -133,8 +245,11 @@ LLM_BASE_URL = os.environ.get("LLM_BASE_URL")
 LLM_MODEL = os.environ.get("LLM_MODEL", "local-model")
 LLM_API_KEY = os.environ.get("LLM_API_KEY", "sk-no-key-required")
 
-PROMPT = """Sei un giurista italiano. Scrivi un {doc_type} REALISTICO e completo (da 8 a 18 righe),
-nel linguaggio tecnico-giuridico autentico usato nei tribunali italiani.
+                                        # "Scrivi un {doc_type}" non concorda con i tipi
+                                        # femminili ("un bolletta", "un fattura"): il tipo
+                                        # va dopo i due punti, senza articolo da azzeccare
+PROMPT = """Sei {persona}. Scrivi questo documento, REALISTICO e completo (da 8 a 18 righe): {doc_type}.
+Usa {stile}.
 
 REGOLA ASSOLUTA: non inserire MAI dati reali o inventati (niente nomi, codici fiscali,
 IBAN, indirizzi, importi scritti per esteso). Dove servirebbe un dato personale usa
@@ -356,6 +471,10 @@ def main():
     ap.add_argument("--doc-types", type=int, default=DEFAULT_DOC_TYPES,
                     help=f"quanti tipi di documento campionare per run "
                          f"(0 = tutti i {len(DOC_TYPES)})")
+    ap.add_argument("--types", default=None,
+                    help="genera solo per i tipi di documento che contengono uno di questi "
+                         "pezzi di testo, separati da virgola (es. --types bolletta,multa). "
+                         "Serve per coprire un dominio alla volta senza rigenerare il resto")
     ap.add_argument("--out", default=str(ROOT / "dataset" / "synthetic" / "legal_templates.json"))
     ap.add_argument("--append", action="store_true", help="accoda al file esistente")
     args = ap.parse_args()
@@ -368,7 +487,14 @@ def main():
     base = len(templates)            # quanti c'erano gia'
     tid = len(templates)
 
-    doc_types = sample_doc_types(args.doc_types)
+    if args.types:
+        pezzi = [p.strip().lower() for p in args.types.split(",") if p.strip()]
+        doc_types = [d for d in DOC_TYPES if any(p in d.lower() for p in pezzi)]
+        if not doc_types:
+            sys.exit(f"ERRORE: nessun tipo di documento contiene {pezzi}. "
+                     f"Tipi disponibili:\n  " + "\n  ".join(DOC_TYPES))
+    else:
+        doc_types = sample_doc_types(args.doc_types)
     total = len(doc_types) * args.per_type
     done = ok = skip = 0
     t0 = time.time()
@@ -387,8 +513,10 @@ def main():
             pct = 100 * done // total
             print(f"[{done:>3}/{total} | {pct:>3}%] OK={ok} scartati={skip} | "
                   f"trascorso {elapsed:>4.0f}s | ETA {eta:>4.0f}s | {doc_type} ...")
+            persona, stile = registro(doc_type)
             raw = call_llm(PROMPT.format(doc_type=doc_type, slot_list=slot_list,
-                                         slot_hints=SLOT_HINTS))
+                                         slot_hints=SLOT_HINTS,
+                                         persona=persona, stile=stile))
             text = clean_and_validate(raw)
             if text:
                 templates.append({"id": tid, "doc_type": doc_type, "text": text})


### PR DESCRIPTION
20 tipi di documento oltre il tribunale, a costo invariato

DOC_TYPES aveva 10 tipi, tutti atti giudiziari civili. Ma ORG e' il tag piu'
debole del modello (F1 .983) e resta invisibile nei contesti dove e' il soggetto
naturale: appalti, banche, assicurazioni, condominio.

Aggiunti 20 tipi (appalti, perizie, successioni, lavoro, condominio, sinistri,
mutui, GDPR, tributario, notarile, amministrativo, carte di credito, sanitario,
previdenziale), che portano anche strutture non giudiziarie: moduli, informative,
capitolati.

Il costo resta invariato: sample_doc_types() campiona 10 tipi per run
(--doc-types N, 0 = tutti). Contributori diversi coprono domini diversi ->
l'unione delle contribuzioni copre tutto senza che nessuno paghi per tutto.

Registro linguistico per tipo, e 14 tipi fuori dal mondo legale

I 30 tipi di documento erano tutti atti, verbali, ricorsi, contratti: un unico mondo
linguistico. Misurato sul giro precedente, chiedere altri template degli stessi tipi rende
poco -- raddoppiare la banca (142 -> 273 template nel pool) ha dato +21% di strutture
distinte, non +100%, perche' ogni tipo ha una capacita' interna limitata e al settimo atto
di citazione il modello ripete quello che si dice in un atto di citazione. La leva non e'
il numero di template, e' il numero di MONDI.

Qui si aprono 14 tipi in cui un italiano incontra davvero i propri dati personali:
bolletta, cedolino paga, fattura con ritenuta, verbale del codice della strada,
autocertificazione, domanda di concorso, apertura di conto, attivazione di una SIM,
noleggio auto, certificato scolastico, prenotazione al CUP, reclamo a un vettore,
sollecito di pagamento, adesione con mandato SEPA.

Ma il tipo da solo non basta, e questo e' il punto della patch: il prompt diceva "Sei un
giurista italiano ... nel linguaggio dei tribunali", e a un giurista che scrive una
bolletta esce una bolletta in legalese -- cioe' di nuovo le strutture che si volevano
evitare aprendo il dominio. La struttura e' esattamente cio' che il modello impara, quindi
ogni tipo nuovo porta un REGISTRO: chi scrive (un addetto alla fatturazione, un agente di
polizia locale, una segreteria scolastica) e con che lessico (letture del contatore e voci
di spesa; norma violata e decurtazione di punti; anno scolastico e classe frequentata). I
tipi giudiziari e contrattuali tengono il registro legale di prima: erano nati con quello.

Il tipo entra nel prompt dopo i due punti e non dopo un articolo: "Scrivi un {doc_type}"
non concorda con i tipi femminili ("un bolletta", "un fattura").

--types filtra i tipi per pezzo di testo ("--types bolletta,noleggio"): serve a coprire un
dominio alla volta accodando alla banca, senza rigenerare quello che c'e' gia'.

Sulla prenotazione sanitaria il registro dice esplicitamente "nessun dato clinico, solo la
parte amministrativa": i dati dell'art. 9 GDPR non hanno label nella tassonomia, e
generarli vorrebbe dire mettere nel testo entita' sensibili che nessuna label copre --
esattamente il difetto che le guardie cercano di evitare.


---

**Dipende dalla #22**: il primo dei due commit e' quello dei 20 tipi di documento, e il registro
linguistico si applica per tipo. Va letta dopo la #22.
