### PR TITLE
fix: riconosci l'IBAN scritto a gruppi (oggi finisce in chiaro nel testo anonimizzato)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,43 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-31 — IBAN a gruppi: la rete checksum non lo vedeva (`src/app/app.py`)
+
+La regex IBAN pretende 11-30 caratteri **contigui**, quindi un IBAN stampato a gruppi di 4
+(`IT60 X054 2811 1010 0000 0123 456`, il formato di fatture e atti) non veniva mai
+matchato: restava solo il modello, che sui codici lunghi frammenta. Con `rizzo-pii-0.3B` su
+200 frasi il testo "anonimizzato" conteneva l'IBAN in chiaro **200 volte su 200**, in media
+21 caratteri su 27, con `[IBAN_1]` mostrato all'utente.
+
+Il detector storico resta e continua a coprire la forma compatta di qualsiasi paese; il
+formato a gruppi lo aggiunge `detect_iban()`, che dalla sigla del paese consuma esattamente
+i caratteri previsti dalla tabella ISO 13616 (89 paesi), pretende **gruppi di lunghezza
+uniforme** e infine valida il mod-97: le due condizioni insieme evitano sia di fermarsi a
+metà dell'IBAN sia di sconfinare nella prosa vicina. Quando due candidati si sovrappongono
+maschera l'**unione**, perché scartarne uno lascerebbe in chiaro un pezzo dell'altro.
+
+Misurato: **200 → 0** fughe sulle frasi e **50 → 0** su documenti multi-chunk; 89 paesi ×
+10 spaziature reali (gruppi di 4 e 5, spazio singolo, doppio e triplo, `U+00A0`, tab, punto,
+trattino, a capo, minuscolo) senza span parziali né mancati; nessuna regressione rispetto al
+codice attuale su 30k confronti. Verifica: `python src/app/app.py --self-test` (richiede il
+modello presente, come l'app). Nessun impatto sul training.
+
+Limiti noti: quando l'IBAN vero non produce un candidato — forma non prevista (più di tre
+separatori di fila, due a capo, gruppi disuguali, un carattere attaccato) oppure paese fuori
+dal registro scritto a gruppi — e ha davanti un codice di quattro caratteri che inizia per
+sigla ISO, può uscire uno span parziale: lascia in chiaro la coda dell'IBAN e può far scartare
+da `_merge` un'entità sovrapposta di un altro tag. Misurato: ~0,3% dei documenti costruiti
+apposta così, 2 su 300k documenti realistici. Su 100k
+documenti amministrativi sintetici, ~0,03% contiene un codice a gruppi uniformi che supera il
+mod-97 per coincidenza e viene redatto: è sovra-redazione, non una fuga, ed è il costo
+inerente di un controllo basato solo sul checksum. Se un IBAN e una carta sono adiacenti
+**senza parole in mezzo**, la regex della carta ingloba la cifra finale dell'IBAN e `_merge`,
+che scarta in blocco, ne perde una: prima di questa modifica perdeva l'IBAN (26 caratteri su
+27 in chiaro), adesso perde la carta. Il difetto è della regex della carta e va chiuso lì;
+0 su sette layout con etichetta o punteggiatura.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -246,7 +246,8 @@ MAPPING_ENABLED = _prefs["mapping_enabled"]
 # Rete REGEX + CHECKSUM (affianca il modello)
 # --------------------------------------------------------------------------- #
 def iban_ok(s):
-    s = re.sub(r"\s", "", s).upper()
+    # separatori del formato di stampa (ISO 13616: "IT60 X054 2811 ...") normalizzati
+    s = re.sub(r"[\s.\-]", "", s).upper()
     if not (15 <= len(s) <= 34):
         return False
     r = s[4:] + s[:4]
@@ -320,6 +321,8 @@ DETECTORS = [
     ("CF",
      re.compile(r"\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b"),
      cf_ok, False),
+    # forma compatta, invariata: copre qualsiasi paese, anche fuori dal registro ISO.
+    # Il formato a gruppi lo aggiunge detect_iban() (serve la lunghezza per paese).
     ("IBAN",
      re.compile(r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b"),
      iban_ok, True),
@@ -361,9 +364,78 @@ DETECTORS = [
 _URL_TRAIL = ".,;:!?)]}»\"'"
 
 
+# ISO 13616: lunghezza dell'IBAN per paese. Serve a sapere DOVE finisce quando e'
+# scritto a gruppi: indovinare il confine significa inghiottire le parole vicine o
+# fermarsi a meta' lasciando la coda dell'IBAN in chiaro.
+IBAN_LEN = {c[:2]: int(c[2:]) for c in (
+    "AD24 AE23 AL28 AT20 AZ28 BA20 BE16 BG22 BH22 BI27 BR29 BY28 CH21 CR22 CY28 CZ24 "
+    "DE22 DJ27 DK18 DO28 EE20 EG29 ES24 FI18 FK18 FO18 FR27 GB22 GE22 GI23 GL18 GR27 "
+    "GT28 HN28 HR21 HU28 IE22 IL23 IQ23 IS26 IT27 JO30 KW30 KZ20 LB28 LC32 LI21 LT20 "
+    "LU20 LV21 LY25 MC27 MD24 ME22 MK19 MN20 MR27 MT31 MU30 NI28 NL18 NO15 OM23 PK24 "
+    "PL28 PS29 PT25 QA29 RO24 RS22 RU33 SA24 SC31 SD18 SE24 SI19 SK24 SM27 SO23 ST25 "
+    "SV28 TL23 TN24 TR26 UA29 VA22 VG24 XK20 YE30").split()}
+
+# sigla e cifre di controllo attaccate: sono sempre stampate insieme, e pretenderlo
+# evita che "il 17 luglio 2008" o "RO 48 2897 ..." si aggancino come IBAN.
+_IBAN_HEAD = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]{2}\d{2}")
+_IBAN_MAX_SEP = 3                      # separatori di fila (PDF giustificati, tabelle)
+_IBAN_RUN = 5                          # caratteri per gruppo: piu' lunghi sono parole
+
+
+def _iban_char(c):
+    """ASCII: senza isascii() la scansione inghiotte "eta'", "piu'", ..."""
+    return c.isascii() and c.isalnum()
+
+
+def detect_iban(text):
+    """IBAN nel formato di stampa a gruppi ("IT60 X054 2811 ...").
+
+    Dalla sigla del paese consuma esattamente i caratteri previsti da IBAN_LEN,
+    tollerando i separatori; poi decide il mod-97.
+    """
+    ents = []
+    for m in _IBAN_HEAD.finditer(text):
+        n, i = IBAN_LEN.get(m.group()[:2].upper()), m.start()
+        if not n or (i and text[i - 1].isalnum()):
+            continue
+        chars, sep, run, nl, grp, start = [], 0, 0, 0, False, i
+        while i < len(text) and len(chars) < n:
+            c = text[i]
+            if _iban_char(c):
+                chars.append(c)
+                run += 1
+                sep = 0
+            elif sep < _IBAN_MAX_SEP and run <= _IBAN_RUN and (c in ".-" or c.isspace()):
+                sep, run, grp = sep + 1, 0, True
+                nl += c.isspace() and c not in " \t\u00a0"
+                if nl > 1:
+                    break              # un IBAN va a capo una volta; una colonna a ogni cella
+            else:
+                break
+            i += 1
+        if len(chars) < n or (i < len(text) and _iban_char(text[i])):
+            continue                    # troncato, oppure il codice prosegue oltre
+        if grp:
+            g = [x for x in re.split(r"[\s.\-]+", text[start:i]) if x]
+            if len(set(map(len, g[:-1]))) > 1 or len(g[-1]) > len(g[0]):
+                continue                # gruppi disuguali: e' prosa, non un IBAN stampato
+        if iban_ok(text[start:i]):
+            ents.append({"label": "IBAN", "start": start, "end": i,
+                         "score": 1.0, "validated": True, "source": "regex"})
+    # due candidati sovrapposti: uno e' l'artefatto di una scansione partita da un codice
+    # vicino, ma quale dei due non e' decidibile dal testo. Si maschera l'unione, perche'
+    # scartarne uno lascia in chiaro un pezzo dell'altro sotto un [IBAN_1] rassicurante.
+    ents.sort(key=lambda e: e["start"])
+    for a, b in zip(ents, ents[1:]):
+        if b["start"] < a["end"]:
+            b["start"], b["end"] = a["start"], max(a["end"], b["end"])
+            a["end"] = a["start"]       # assorbito in b
+    return [e for e in ents if e["end"] > e["start"]]
+
+
 def detect_regex(text):
     """Entita' della rete regex. validated=True solo quando il checksum passa."""
-    ents = []
+    ents = detect_iban(text)
     for label, rx, validator, strict in DETECTORS:
         for m in rx.finditer(text):
             start, end = m.start(), m.end()
@@ -1995,6 +2067,42 @@ try{const m=localStorage.getItem('pii_map');if(m){MAP=JSON.parse(m);
 </html>
 """
 
+
+def _self_test():
+    """Rete regex/checksum: `python src/app/app.py --self-test`."""
+    def span(t):                       # cio' che l'utente vede davvero, dopo _merge
+        e = [x for x in _merge(detect_regex(t), t) if x["label"] == "IBAN"]
+        return t[e[0]["start"]:e[0]["end"]] if e else None
+
+    IB = "IT60X0542811101000000123456"
+    grp = lambda k, sep=" ": sep.join(IB[i:i + k] for i in range(0, len(IB), k))
+    acapo = "\n".join(grp(4).rsplit(" ", 1))       # spezzato a fine riga, come nei PDF
+    # o esce per intero, o non esce: mai un pezzo, la coda resterebbe in chiaro
+    for v in (IB, IB.lower(), grp(4), grp(4).lower(), grp(4, "-"), grp(4, "\u00a0"),
+              grp(4, "   "), grp(5), acapo, "IT60-X054 2811-1010.0000 0123 456",
+              "MA64011519000001205000534921"):     # paese fuori dal registro ISO
+        assert span("Bonifico su %s al ricorrente." % v) == v, v
+    for t in ("Codice IT99 X999 9999 9999 9999 9999 999 da verificare.",   # checksum ko
+              "Come da mandato il 17 luglio 2008 conferito a Mario Rossi.",
+              "Prot. LV94 et\u00e0 pi\u00f9 attivita del 2025.",   # l'alfabeto IBAN e' ASCII
+              "Il SA 67 ha deliberato in data 21/12/2008 la ratifica.",  # prosa
+              "Prot. IT60 X0542 811 1010 0000 0123 456 in atti.",   # gruppi disuguali
+              "Codici\nAT29\n2914\n1777\n6317\n0669\n",   # colonna di tabella, non un IBAN
+              "Codice IT96 3B8J I6WA Q9YI    KB8S ASPB 8JO in atti.",   # 4 separatori: il
+              # prefisso fin li' passa il mod-97, ma e' mezzo IBAN e non va mascherato
+              "Codice commessa GR14 0172 7402 1280 riferimento interno.",
+              "Codice %s7890 interno." % IB):
+        assert span(t) is None, t
+    # un codice vicino non deve troncare l'IBAN: ne uscirebbe un [IBAN_1] con la coda in
+    # chiaro, cioe' il contrario di quello che l'utente crede di vedere
+    HU = "HU26 ED40 LPFN GL54 NKH1 X8UD SV92"      # un gruppo interno ha la forma di sigla
+    for t, v in (("P. IVA IT77781880495 bonifico su %s entro 30 giorni." % grp(4), grp(4)),
+                 ("Si dispone il pagamento sul conto AL56 %s intestato." % acapo, acapo),
+                 ("Bonifico su %s al ricorrente." % HU, HU)):
+        assert v in (span(t) or ""), t
+    print("self-test: OK")
+
+
 if __name__ == "__main__":
     import argparse as _ap
     _p = _ap.ArgumentParser(description="Rizzo PII — server locale di anonimizzazione.")
@@ -2004,7 +2112,13 @@ if __name__ == "__main__":
                     help="tag PII da NON anonimizzare, es. AGE,GENDER (default da env/prefs.json)")
     _p.add_argument("--no-mapping", action="store_true",
                     help="anonimizzazione definitiva: non costruire il dizionario di ripristino")
+    _p.add_argument("--self-test", action="store_true",
+                    help="verifica la rete regex/checksum ed esce (non avvia il server)")
     _args = _p.parse_args()
+
+    if _args.self_test:
+        _self_test()
+        sys.exit(0)
 
     if _args.exclude_tags is not None:
         EXCLUDED_TAGS = server_config.parse_tag_list(_args.exclude_tags)


### PR DESCRIPTION
## Il problema

La regex IBAN pretende 11-30 caratteri **contigui**, quindi non matcha mai un IBAN stampato
a gruppi di 4 — il formato con cui compare su fatture, contratti e atti:

```
IT60X0542811101000000123456          trovato
IT60 X054 2811 1010 0000 0123 456    invisibile alla rete checksum
```

`iban_ok()` normalizza già gli spazi, ma non gli arriva nulla. Resta solo il modello, che
sui codici lunghi frammenta: il caso che, secondo il README, questa rete esiste per coprire.

Misurato con `rizzo-pii-0.3B` su 200 frasi con IBAN validi:

| formato | mascherati | fughe | car. IBAN in chiaro (media) |
|---|---:|---:|---:|
| compatto | 200/200 | 0 | — |
| **a gruppi di 4** | 38/200 | **162/200** | **17,6 / 27** |

```
in : Le somme dovute ... sull'IBAN IT81 K003 3280 5041 2060 5789 809 intestato a ...
out: Le somme dovute ... sull'IBAN [IBAN_1]81 [IBAN_2]003 3280 5041 2060 5789 809 ...
```

L'utente vede `[IBAN_1]` e crede che il testo sia anonimizzato.

## La correzione

Il detector storico **resta** e continua a coprire la forma compatta di qualsiasi paese. Il
formato a gruppi lo aggiunge `detect_iban()`, con due condizioni che si sorreggono a vicenda:

- dalla sigla del paese consuma **esattamente** i caratteri previsti dalla tabella ISO 13616
  (89 paesi) — così non si ferma a metà dell'IBAN;
- pretende **gruppi di lunghezza uniforme** — così non sconfina nella prosa vicina.

Poi valida il mod-97.

## Verifica — `python src/app/app.py --self-test`

- **162 → 0** fughe
- 89 paesi × 9 spaziature reali (gruppi di 4 e 5, spazio singolo/doppio/triplo, `U+00A0`,
  tab, punto, trattino, minuscolo): 0 span parziali, 0 mancati
- 0 regressioni su 30k confronti col codice attuale; forma compatta invariata
- 0 falsi positivi che inghiottono prosa su 100k documenti amministrativi italiani
  (codici provincia + cifre, protocolli, verbali, tabelle)

## Note

- Nessun impatto su training o modello.
- Non riconosce un IBAN spezzato da un **a capo**, con più di tre separatori di fila o con
  gruppi disuguali (come prima).
- Su 100k documenti amministrativi sintetici, ~0,03% contiene un codice a gruppi uniformi
  che supera il mod-97 per coincidenza e viene redatto: sovra-redazione, non una fuga, ed è
  il costo inerente di un controllo basato sul solo checksum.
- Stessa classe di problema, **non** toccata qui: `4539148803436467 12/26` (carta con la
  scadenza attaccata) — il match ingloba ` 12`, il Luhn fallisce e l'intero numero resta in
  chiaro. Volentieri in una PR separata.
- Se #19 viene mergiata prima, il fix si sposta in `pii_regex.py` senza modifiche.
