### PR TITLE
feat: ONNX Runtime backend for the desktop app (run without PyTorch, enable browser)

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,0 +1,17 @@
+# rizzo-pii — dipendenze dell'APP desktop quando gira su ONNX Runtime (Fase 4).
+#
+# Con un bundle ONNX esportato da src/export/export_onnx.py, l'app NON usa piu'
+# PyTorch/Transformers: l'inferenza gira su onnxruntime + tokenizers (vedi
+# src/app/onnx_infer.py), molto piu' leggeri del framework di training. Questo separa
+# l'applicazione dal training. Senza bundle, l'app fa fallback su requirements.txt (torch).
+#
+#   pip install -r requirements-app.txt
+
+# inferenza ONNX (niente torch/transformers)
+onnxruntime
+tokenizers
+numpy
+
+# UI Flask + parsing PDF
+flask
+pymupdf

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -27,12 +27,12 @@ import sys
 from pathlib import Path
 
 import fitz  # PyMuPDF
-import torch
 from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
 
 import server_config
-from transformers import pipeline
+# NB: torch / transformers si importano SOLO nel fallback PyTorch (vedi caricamento modello):
+# con un bundle ONNX l'app gira senza il framework di training.
 
 
 def _resource_path(rel):
@@ -72,18 +72,37 @@ MAX_WORDS = 120      # parole per chunk (~180 subword, sotto i 512 del training)
 OVERLAP = 20         # parole di sovrapposizione tra chunk consecutivi
 
 # --------------------------------------------------------------------------- #
-# Caricamento modello (una sola volta all'avvio)
+# Caricamento modello (una sola volta all'avvio).
+#
+# Preferisce il backend ONNX (onnxruntime + tokenizers, leggero): se e' disponibile un
+# bundle esportato con src/export/export_onnx.py, l'app gira SENZA PyTorch/Transformers --
+# l'applicazione e' cosi' separata dal framework di training. Altrimenti fallback a PyTorch.
+# Forza il fallback con PII_FORCE_TORCH=1; forza fp32 nell'ONNX con PII_ONNX_FP32=1.
 # --------------------------------------------------------------------------- #
-device = 0 if torch.cuda.is_available() else -1
-print(f"Carico il modello da {MODEL_DIR} su {'GPU' if device == 0 else 'CPU'}...")
-nlp = pipeline(
-    "token-classification",
-    model=MODEL_DIR,
-    tokenizer=MODEL_DIR,
-    aggregation_strategy="simple",
-    device=device,
-)
-print("Modello pronto.")
+nlp = None
+if os.environ.get("PII_FORCE_TORCH", "") not in ("1", "true", "yes", "on"):
+    try:
+        from onnx_infer import build_tagger
+        nlp = build_tagger()
+        if nlp is not None:
+            print(f"Modello ONNX pronto ({nlp.dtype}, {nlp.model_name}).")
+    except Exception as _e:
+        print(f"Backend ONNX non disponibile ({_e}); passo a PyTorch.")
+        nlp = None
+
+if nlp is None:
+    import torch
+    from transformers import pipeline
+    device = 0 if torch.cuda.is_available() else -1
+    print(f"Carico il modello PyTorch da {MODEL_DIR} su {'GPU' if device == 0 else 'CPU'}...")
+    nlp = pipeline(
+        "token-classification",
+        model=MODEL_DIR,
+        tokenizer=MODEL_DIR,
+        aggregation_strategy="simple",
+        device=device,
+    )
+    print("Modello PyTorch pronto.")
 
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 50 * 1024 * 1024  # 50 MB

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -53,18 +53,13 @@ if getattr(sys, "_MEIPASS", None):
 elif os.environ.get("PII_MODEL_DIR"):
     MODEL_DIR = os.environ["PII_MODEL_DIR"]
 else:
-    import re
-    _models = Path(__file__).resolve().parents[2] / "models"
-    _pinned = _models / f"rizzo-pii-0.3B-v{APP_MODEL_VERSION}" if APP_MODEL_VERSION else None
-    _versioned = [p for p in _models.glob("rizzo-pii-0.3B-v*") if p.is_dir()]
-    if _pinned and _pinned.is_dir():
-        MODEL_DIR = str(_pinned)
-    elif _versioned:
-        MODEL_DIR = str(max(_versioned, key=lambda p: tuple(
-            int(x) for x in re.search(r"-v([0-9][0-9.]*)$", p.name).group(1).split("."))))
-    else:
-        _prod = _models / "rizzo-pii-0.3B"
-        MODEL_DIR = str(_prod if _prod.exists() else _models / "pii_model_legacy")
+    # Import LOCALE al ramo, non in cima al file: quando l'app e' congelata da
+    # PyInstaller si passa dal ramo _MEIPASS qui sopra e questa riga non viene mai
+    # eseguita, quindi il bundle non deve portarsi dietro src/common/.
+    _ROOT = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(_ROOT / "src" / "common"))
+    from model_paths import resolve_model_dir      # noqa: E402
+    MODEL_DIR = resolve_model_dir(_ROOT / "models", pinned=APP_MODEL_VERSION)
 
 ASSETS_DIR = _resource_path("assets")   # mascotte / icone (servite su /assets/<file>)
 APP_VERSION = "1.0.0"                    # versione mostrata nell'UI (allineata a tauri.conf.json)

--- a/src/app/onnx_infer.py
+++ b/src/app/onnx_infer.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Backend d'inferenza ONNX per l'app desktop — separa l'APP dal FRAMEWORK DI TRAINING.
+
+Fase 4 del piano di integrazione (docs/PIANO_INTEGRAZIONE.md). L'app non dipende piu' da
+PyTorch/Transformers (centinaia di MB): il modello si esporta UNA TANTUM con
+src/export/export_onnx.py (PR #12) e qui lo si CONSUMA con onnxruntime + tokenizers, molto
+piu' leggeri.
+
+    Training:  PyTorch + Transformers  --export-->  ONNX (fp32 + INT8)
+    Desktop:   Tokenizer -> ONNX Runtime -> aggregazione BIO -> entita' con offset
+                             ├── INT8  su CPU moderne
+                             └── FP32  fallback
+
+`OnnxTagger` e' un drop-in della pipeline HF "token-classification"
+(aggregation_strategy="simple"): chiamato con un testo (o una lista) ritorna la stessa
+struttura [{entity_group, score, word, start, end}], cosi' app.py lo usa senza altre
+modifiche. In Python la libreria `tokenizers` fornisce gia' gli offset carattere
+(Encoding.offsets), quindi non serve il trucco del cursore Metaspace del lato Transformers.js.
+
+La funzione `aggregate_entities` e' PURA (solo stdlib): tutta la logica delicata
+(raggruppamento BIO, offset, rifilo degli spazi) e' testabile senza un modello.
+"""
+import json
+import os
+from pathlib import Path
+
+
+# --------------------------------------------------------------------------- #
+# Aggregazione BIO -> entita' (funzione pura, testabile senza onnxruntime)     #
+# --------------------------------------------------------------------------- #
+def aggregate_entities(per_token, text):
+    """Raggruppa i token etichettati in entita', come aggregation_strategy="simple".
+
+    `per_token`: lista ordinata di dict {label, score, start, end} SENZA i token speciali
+    ([CLS]/[SEP]). `label` e' in schema BIO ("B-CF", "I-CF", "O", ...). I token consecutivi
+    dello stesso TIPO si fondono (ignorando B/I, come "simple"); "O" chiude il gruppo.
+
+    Ritorna [{entity_group, score, word, start, end}] con offset carattere sul testo
+    originale e gli spazi ai bordi rifilati."""
+    groups, cur = [], None
+    for t in per_token:
+        lab = t["label"]
+        typ = lab.split("-", 1)[1] if "-" in lab else (None if lab == "O" else lab)
+        if typ is None:
+            cur = None
+            continue
+        if cur is not None and typ == cur["type"]:
+            cur["end"] = t["end"]
+            cur["scores"].append(t["score"])
+        else:
+            cur = {"type": typ, "start": t["start"], "end": t["end"], "scores": [t["score"]]}
+            groups.append(cur)
+
+    # rifila spazi e separatori ai bordi: il modello a volte include la virgola dopo il
+    # nome ("Mario Rossi,"), che verrebbe inghiottita nel placeholder. Non si tocca il '.'
+    # (fa parte di abbreviazioni: "S.r.l.").
+    trim = " \t\n\r\f\v,;:"
+    out = []
+    for g in groups:
+        s, e = g["start"], g["end"]
+        while s < e and text[s] in trim:
+            s += 1
+        while e > s and text[e - 1] in trim:
+            e -= 1
+        if s >= e:
+            continue
+        out.append({"entity_group": g["type"], "score": sum(g["scores"]) / len(g["scores"]),
+                    "word": text[s:e], "start": s, "end": e})
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Risoluzione del bundle ONNX                                                  #
+# --------------------------------------------------------------------------- #
+def resolve_bundle(models_dir=None):
+    """Cartella `bundle/` da usare, oppure None se non c'e' un export ONNX.
+
+    Precedenza: env PII_ONNX_BUNDLE > ultima models/rizzo-pii-0.3B-v*-onnx/bundle."""
+    env = os.environ.get("PII_ONNX_BUNDLE")
+    if env:
+        p = Path(env)
+        return p if p.is_dir() else None
+    root = Path(models_dir) if models_dir else Path(__file__).resolve().parents[2] / "models"
+    cands = sorted(root.glob("rizzo-pii-0.3B-v*-onnx/bundle")) if root.is_dir() else []
+    if not cands:
+        return None
+    import re
+    def _key(p):
+        m = re.search(r"-v([0-9][0-9.]*)-onnx", str(p))
+        return tuple(int(x) for x in m.group(1).split(".")) if m else ()
+    return max(cands, key=_key)
+
+
+def build_tagger(models_dir=None, prefer_int8=None):
+    """OnnxTagger sull'ultimo bundle disponibile, o None se non c'e' (l'app fa fallback
+    su PyTorch). prefer_int8=None -> da env PII_ONNX_FP32 (default: INT8 se presente)."""
+    bundle = resolve_bundle(models_dir)
+    if bundle is None:
+        return None
+    if prefer_int8 is None:
+        prefer_int8 = os.environ.get("PII_ONNX_FP32", "") not in ("1", "true", "yes", "on")
+    return OnnxTagger(bundle, prefer_int8=prefer_int8)
+
+
+# --------------------------------------------------------------------------- #
+# OnnxTagger: sessione ORT + tokenizer, drop-in della pipeline HF             #
+# --------------------------------------------------------------------------- #
+class OnnxTagger:
+    """Inferenza token-classification su ONNX Runtime. Dipendenze: onnxruntime, tokenizers,
+    numpy (nessun torch/transformers)."""
+
+    def __init__(self, bundle_dir, prefer_int8=True, max_length=8192):
+        import numpy as np
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+        self._np = np
+        bundle = Path(bundle_dir)
+
+        self.tokenizer = Tokenizer.from_file(str(bundle / "tokenizer.json"))
+        try:
+            self.tokenizer.enable_truncation(max_length=max_length)
+        except Exception:
+            pass
+
+        cfg = json.loads((bundle / "config.json").read_text(encoding="utf-8"))
+        # id2label ha chiavi stringa nel config di transformers
+        self.id2label = {int(k): v for k, v in cfg["id2label"].items()}
+
+        onnx_dir = bundle / "onnx"
+        int8 = onnx_dir / "model_quantized.onnx"
+        fp32 = onnx_dir / "model.onnx"
+        if prefer_int8 and int8.exists():
+            model_path, self.dtype = int8, "INT8"
+        elif fp32.exists():
+            model_path, self.dtype = fp32, "FP32"
+        elif int8.exists():
+            model_path, self.dtype = int8, "INT8"
+        else:
+            raise FileNotFoundError(f"nessun modello ONNX in {onnx_dir}")
+
+        self.model_name = model_path.name
+        self.session = ort.InferenceSession(str(model_path),
+                                            providers=["CPUExecutionProvider"])
+        self._input_names = {i.name for i in self.session.get_inputs()}
+
+    def _softmax_max(self, row):
+        e = self._np.exp(row - row.max())
+        p = e / e.sum()
+        idx = int(p.argmax())
+        return idx, float(p[idx])
+
+    def _tag_one(self, text):
+        if not text:
+            return []
+        enc = self.tokenizer.encode(text)
+        ids = self._np.asarray([enc.ids], dtype=self._np.int64)
+        mask = self._np.asarray([enc.attention_mask], dtype=self._np.int64)
+        feeds = {"input_ids": ids}
+        if "attention_mask" in self._input_names:
+            feeds["attention_mask"] = mask
+        if "token_type_ids" in self._input_names:
+            feeds["token_type_ids"] = self._np.zeros_like(ids)
+        logits = self.session.run(None, {k: v for k, v in feeds.items()
+                                         if k in self._input_names})[0][0]
+
+        # aggrega per PAROLA (come aggregation_strategy="simple"): la label del PRIMO
+        # sub-token vale per l'intera parola, e i sub-token di continuazione ne estendono
+        # solo lo span. Senza questo "RSSMRA80A01H501U" (piu' sub-token, stesso word_id)
+        # si spezzerebbe in tanti frammenti.
+        word_ids = enc.word_ids
+        per_word, seen = [], {}
+        for i, (lo, hi) in enumerate(enc.offsets):
+            if enc.special_tokens_mask[i] or (lo == 0 and hi == 0):
+                continue                       # [CLS]/[SEP]/pad: nessun carattere
+            wid = word_ids[i]
+            if wid is not None and wid in seen:
+                seen[wid]["end"] = hi          # sub-token di continuazione: estendi lo span
+                continue
+            idx, score = self._softmax_max(logits[i])
+            entry = {"label": self.id2label[idx], "score": score, "start": lo, "end": hi}
+            per_word.append(entry)
+            if wid is not None:
+                seen[wid] = entry
+        return aggregate_entities(per_word, text)
+
+    def __call__(self, texts):
+        """Un testo -> lista di entita'; una lista di testi -> lista di liste (come la
+        pipeline HF, cosi' app.py resta invariato)."""
+        if isinstance(texts, str):
+            return self._tag_one(texts)
+        return [self._tag_one(t) for t in texts]

--- a/src/common/model_paths.py
+++ b/src/common/model_paths.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Risoluzione della cartella del modello, in un posto solo.
+
+Perche' esiste questo modulo: la stessa logica ("prendi la versione piu' alta fra
+models/rizzo-pii-0.3B-v*") viveva copiata in quattro punti — app.py, test_pii.py,
+evaluate_pii.py, export_onnx.py. Le copie sono divergute: tre avevano la guardia sul
+match del regex, quella INLINE dentro app.py no, e faceva crashare l'app all'import
+appena in models/ compariva una cartella non versionata.
+
+E' esattamente il caso che l'export ONNX produce: `export_onnx.py` scrive il bundle in
+`models/<nome>-onnx/`, che il glob raccoglie ma il regex della versione non riconosce.
+
+Nessuna dipendenza oltre la stdlib: lo importano sia gli script di training sia l'app.
+"""
+import os
+import re
+from pathlib import Path
+
+MODEL_GLOB = "rizzo-pii-0.3B-v*"
+# Ancorato in fondo: il nome deve FINIRE con la versione. E' voluto — serve proprio a
+# distinguere "…-v1.3.0" (checkpoint) da "…-v1.3.0-onnx" (bundle esportato).
+VERSION_RE = re.compile(r"-v([0-9][0-9.]*)$")
+
+
+def _version_key(name):
+    """(1,3,0) per 'rizzo-pii-0.3B-v1.3.0'; None se il nome non e' versionato."""
+    m = VERSION_RE.search(name)
+    if not m:
+        return None
+    try:
+        return tuple(int(x) for x in m.group(1).split("."))
+    except ValueError:          # es. "-v1..2": cifre attese, punteggiatura sballata
+        return None
+
+
+def versioned_dirs(models_dir):
+    """[(path, chiave_versione)] dei soli checkpoint versionati, ordinati dal piu' vecchio.
+
+    Il filtro sul match NON e' ridondante rispetto al glob: il glob accetta qualsiasi
+    suffisso dopo la 'v', quindi da solo lascia passare anche le cartelle sorelle
+    (-onnx, e domani -gguf o -backup) che non sono checkpoint.
+    """
+    out = []
+    for p in Path(models_dir).glob(MODEL_GLOB):
+        if not p.is_dir():
+            continue
+        key = _version_key(p.name)
+        if key is not None:
+            out.append((p, key))
+    out.sort(key=lambda pk: pk[1])
+    return out
+
+
+def resolve_model_dir(models_dir, pinned=None):
+    """Cartella del modello da usare, come stringa.
+
+    Precedenza: PII_MODEL_DIR (env) > versione richiesta con `pinned` > versione piu'
+    alta presente > vecchio percorso non versionato > legacy. L'ultimo ripiego puo'
+    non esistere: e' il chiamante a decidere cosa farne (l'app mostra un errore utile).
+    """
+    if os.environ.get("PII_MODEL_DIR"):
+        return os.environ["PII_MODEL_DIR"]
+
+    models_dir = Path(models_dir)
+    if pinned:
+        cand = models_dir / f"rizzo-pii-0.3B-v{pinned}"
+        if cand.is_dir():
+            return str(cand)
+
+    found = versioned_dirs(models_dir)
+    if found:
+        return str(found[-1][0])
+
+    base = models_dir / "rizzo-pii-0.3B"
+    return str(base if base.exists() else models_dir / "pii_model_legacy")

--- a/src/training/evaluate_pii.py
+++ b/src/training/evaluate_pii.py
@@ -75,17 +75,11 @@ def load_data(path):
     return recs
 
 
-def resolve_model_dir(models_dir):
-    """Ultima versione models/rizzo-pii-0.3B-v* (storico); fallback al vecchio non versionato, poi legacy."""
-    import re
-    versioned = [p for p in models_dir.glob("rizzo-pii-0.3B-v*") if p.is_dir()]
-    if versioned:
-        def _key(p):
-            m = re.search(r"-v([0-9][0-9.]*)$", p.name)
-            return tuple(int(x) for x in m.group(1).split(".")) if m else ()
-        return str(max(versioned, key=_key))
-    base = models_dir / "rizzo-pii-0.3B"
-    return str(base if base.exists() else models_dir / "pii_model_legacy")
+# Risoluzione della cartella del modello: implementazione unica in
+# src/common/model_paths.py (prima era copiata qui e in altri tre file, e le
+# copie erano divergute -> vedi il docstring di quel modulo).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "common"))
+from model_paths import resolve_model_dir  # noqa: E402
 
 
 def main():

--- a/src/training/test_pii.py
+++ b/src/training/test_pii.py
@@ -25,19 +25,11 @@ sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 _ROOT = Path(__file__).resolve().parents[2]
 
 
-def resolve_model_dir(models_dir):
-    import os
-    import re
-    if os.environ.get("PII_MODEL_DIR"):
-        return os.environ["PII_MODEL_DIR"]
-    versioned = [p for p in models_dir.glob("rizzo-pii-0.3B-v*") if p.is_dir()]
-    if versioned:
-        def _key(p):
-            m = re.search(r"-v([0-9][0-9.]*)$", p.name)
-            return tuple(int(x) for x in m.group(1).split(".")) if m else ()
-        return str(max(versioned, key=_key))
-    base = models_dir / "rizzo-pii-0.3B"
-    return str(base if base.exists() else models_dir / "pii_model_legacy")
+# Risoluzione della cartella del modello: implementazione unica in
+# src/common/model_paths.py (prima era copiata qui e in altri tre file, e le
+# copie erano divergute -> vedi il docstring di quel modulo).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src" / "common"))
+from model_paths import resolve_model_dir  # noqa: E402
 
 
 MODEL_DIR = resolve_model_dir(_ROOT / "models")

--- a/tests/test_model_paths.py
+++ b/tests/test_model_paths.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Risoluzione della cartella del modello (src/common/model_paths.py).
+
+Il caso che ha motivato questo modulo: `export_onnx.py` scrive il bundle in
+`models/<nome>-onnx/`, che il glob `rizzo-pii-0.3B-v*` raccoglie ma il regex della
+versione non riconosce. La copia inline dentro app.py non filtrava sul match e faceva
+`AttributeError` sul `.group(1)` di None — all'IMPORT, quindi l'app non partiva piu'.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "common"))
+
+from model_paths import resolve_model_dir, versioned_dirs, _version_key  # noqa: E402
+
+
+class TestVersionKey(unittest.TestCase):
+    def test_plain_version(self):
+        self.assertEqual(_version_key("rizzo-pii-0.3B-v1.3.0"), (1, 3, 0))
+
+    def test_two_components(self):
+        self.assertEqual(_version_key("rizzo-pii-0.3B-v2.0"), (2, 0))
+
+    def test_onnx_bundle_is_not_a_version(self):
+        # il cuore del bug: il nome non FINISCE con la versione
+        self.assertIsNone(_version_key("rizzo-pii-0.3B-v1.3.0-onnx"))
+
+    def test_other_siblings_ignored(self):
+        for name in ("rizzo-pii-0.3B-v1.3.0-backup", "rizzo-pii-0.3B-vecchio",
+                     "rizzo-pii-0.3B-v1.3.0.tar"):
+            self.assertIsNone(_version_key(name), name)
+
+
+class TestResolve(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.models = Path(self._tmp.name)
+        self._saved = os.environ.pop("PII_MODEL_DIR", None)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        if self._saved is not None:
+            os.environ["PII_MODEL_DIR"] = self._saved
+
+    def _mk(self, *names):
+        for n in names:
+            (self.models / n).mkdir(parents=True)
+
+    def test_picks_highest_version(self):
+        self._mk("rizzo-pii-0.3B-v1.1.0", "rizzo-pii-0.3B-v1.3.0", "rizzo-pii-0.3B-v1.2.0")
+        self.assertTrue(resolve_model_dir(self.models).endswith("v1.3.0"))
+
+    def test_numeric_not_lexicographic(self):
+        # "v1.10.0" > "v1.9.0" solo se si confrontano numeri, non stringhe
+        self._mk("rizzo-pii-0.3B-v1.9.0", "rizzo-pii-0.3B-v1.10.0")
+        self.assertTrue(resolve_model_dir(self.models).endswith("v1.10.0"))
+
+    def test_onnx_sibling_does_not_crash(self):
+        # LA regressione: prima sollevava AttributeError
+        self._mk("rizzo-pii-0.3B-v1.3.0", "rizzo-pii-0.3B-v1.3.0-onnx")
+        self.assertTrue(resolve_model_dir(self.models).endswith("v1.3.0"))
+
+    def test_onnx_alone_is_not_selected(self):
+        # se resta solo il bundle non lo si spaccia per un checkpoint: si ripiega
+        self._mk("rizzo-pii-0.3B-v1.3.0-onnx")
+        got = resolve_model_dir(self.models)
+        self.assertFalse(got.endswith("-onnx"))
+
+    def test_pinned_version_wins(self):
+        self._mk("rizzo-pii-0.3B-v1.2.0", "rizzo-pii-0.3B-v1.3.0")
+        self.assertTrue(resolve_model_dir(self.models, pinned="1.2.0").endswith("v1.2.0"))
+
+    def test_pinned_missing_falls_back_to_latest(self):
+        self._mk("rizzo-pii-0.3B-v1.3.0")
+        self.assertTrue(resolve_model_dir(self.models, pinned="9.9.9").endswith("v1.3.0"))
+
+    def test_env_override_wins_over_everything(self):
+        self._mk("rizzo-pii-0.3B-v1.3.0")
+        os.environ["PII_MODEL_DIR"] = "/percorso/scelto/a/mano"
+        try:
+            self.assertEqual(resolve_model_dir(self.models, pinned="1.3.0"),
+                             "/percorso/scelto/a/mano")
+        finally:
+            os.environ.pop("PII_MODEL_DIR")
+
+    def test_unversioned_fallback(self):
+        self._mk("rizzo-pii-0.3B")
+        self.assertTrue(resolve_model_dir(self.models).endswith("rizzo-pii-0.3B"))
+
+    def test_legacy_last_resort(self):
+        self.assertTrue(resolve_model_dir(self.models).endswith("pii_model_legacy"))
+
+    def test_files_are_not_candidates(self):
+        self._mk("rizzo-pii-0.3B-v1.1.0")
+        (self.models / "rizzo-pii-0.3B-v9.9.9").write_text("non e' una cartella")
+        self.assertTrue(resolve_model_dir(self.models).endswith("v1.1.0"))
+
+    def test_versioned_dirs_sorted(self):
+        self._mk("rizzo-pii-0.3B-v1.3.0", "rizzo-pii-0.3B-v1.1.0", "rizzo-pii-0.3B-v1.3.0-onnx")
+        got = [p.name for p, _ in versioned_dirs(self.models)]
+        self.assertEqual(got, ["rizzo-pii-0.3B-v1.1.0", "rizzo-pii-0.3B-v1.3.0"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_infer.py
+++ b/tests/test_onnx_infer.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""aggregate_entities: la logica pura del backend ONNX (Fase 4). Nessun modello richiesto.
+
+Raggruppa i token BIO in entita' come aggregation_strategy="simple", con offset carattere
+sul testo originale e spazi ai bordi rifilati.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+from onnx_infer import aggregate_entities  # noqa: E402
+
+
+class TestAggregateEntities(unittest.TestCase):
+    def test_multi_token_entity_merged(self):
+        text = "Mario Rossi paga."
+        per_token = [
+            {"label": "B-FULLNAME", "score": 0.9, "start": 0, "end": 5},   # Mario
+            {"label": "I-FULLNAME", "score": 0.8, "start": 6, "end": 11},  # Rossi
+            {"label": "O", "score": 0.99, "start": 12, "end": 16},         # paga
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual(len(ents), 1)
+        self.assertEqual(ents[0]["entity_group"], "FULLNAME")
+        self.assertEqual((ents[0]["start"], ents[0]["end"]), (0, 11))
+        self.assertEqual(ents[0]["word"], "Mario Rossi")
+
+    def test_o_breaks_entities(self):
+        text = "CF poi IBAN"
+        per_token = [
+            {"label": "B-CF", "score": 0.9, "start": 0, "end": 2},
+            {"label": "O", "score": 0.9, "start": 3, "end": 6},
+            {"label": "B-IBAN", "score": 0.9, "start": 7, "end": 11},
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual([e["entity_group"] for e in ents], ["CF", "IBAN"])
+
+    def test_type_change_splits(self):
+        text = "aa bb"
+        per_token = [
+            {"label": "B-CF", "score": 1.0, "start": 0, "end": 2},
+            {"label": "B-IBAN", "score": 1.0, "start": 3, "end": 5},
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual([e["entity_group"] for e in ents], ["CF", "IBAN"])
+
+    def test_same_type_consecutive_merge_like_simple(self):
+        # "simple" fonde token adiacenti dello stesso tipo (anche oltre un B-)
+        text = "aa bb"
+        per_token = [
+            {"label": "B-ORG", "score": 1.0, "start": 0, "end": 2},
+            {"label": "B-ORG", "score": 1.0, "start": 3, "end": 5},
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual(len(ents), 1)
+        self.assertEqual((ents[0]["start"], ents[0]["end"]), (0, 5))
+
+    def test_whitespace_trimmed_at_edges(self):
+        text = "x  Mario  y"
+        per_token = [
+            {"label": "B-FULLNAME", "score": 1.0, "start": 1, "end": 8},   # "  Mario" con spazi
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual(ents[0]["word"], "Mario")
+        self.assertEqual((ents[0]["start"], ents[0]["end"]), (3, 8))
+
+    def test_trailing_separator_trimmed(self):
+        # la virgola finale del modello non deve entrare nell'entita' (ma il '.' sì: S.r.l.)
+        text = "Tecnova S.r.l., paga"
+        per_token = [{"label": "B-ORG", "score": 1.0, "start": 0, "end": 14}]  # "Tecnova S.r.l.,"
+        ents = aggregate_entities(per_token, text)
+        self.assertEqual(ents[0]["word"], "Tecnova S.r.l.")
+
+    def test_score_is_mean(self):
+        text = "Mario Rossi"
+        per_token = [
+            {"label": "B-FULLNAME", "score": 1.0, "start": 0, "end": 5},
+            {"label": "I-FULLNAME", "score": 0.6, "start": 6, "end": 11},
+        ]
+        ents = aggregate_entities(per_token, text)
+        self.assertAlmostEqual(ents[0]["score"], 0.8)
+
+    def test_empty_input(self):
+        self.assertEqual(aggregate_entities([], "qualsiasi"), [])
+
+    def test_all_O(self):
+        text = "solo contesto"
+        per_token = [{"label": "O", "score": 1.0, "start": 0, "end": 4},
+                     {"label": "O", "score": 1.0, "start": 5, "end": 13}]
+        self.assertEqual(aggregate_entities(per_token, text), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ciao! Questa PR completa il percorso ONNX di #12 dal lato **consumo**: aggiunge un backend d'inferenza su ONNX Runtime all'app desktop, così l'app gira **senza PyTorch/Transformers** e lo stesso bundle diventa usabile nel browser. Validata end-to-end esportando il modello reale (`rizzoaiacademy/rizzo-pii-0.3B`) e facendo girare l'app sul risultato.

## What
Adds an **ONNX Runtime inference backend** to the desktop app, so it can run the model **without PyTorch/Transformers** — on `onnxruntime` + `tokenizers` (far lighter) — and, via the same bundle, in the browser through Transformers.js. Complements #12 (ONNX export): #12 produces the bundle, this consumes it.

- `src/app/onnx_infer.py` — `OnnxTagger`, a **drop-in** for the HF `token-classification` pipeline (`aggregation_strategy="simple"`): same output `{entity_group, score, word, start, end}`, so `app.py` is unchanged elsewhere. In Python `tokenizers` gives char offsets directly (`Encoding.offsets`), so the Metaspace-cursor reconstruction needed on the JS side (#12) isn't required. Word-level BIO aggregation matches "simple"; INT8 auto-selected (fp32 fallback).
- `src/app/app.py` — prefers the ONNX backend; imports torch/transformers **only** in the fallback (`PII_FORCE_TORCH=1` / `PII_ONNX_FP32=1` / `PII_ONNX_BUNDLE`).
- `requirements-app.txt` — app deps for the ONNX path (no torch).
- `tests/test_onnx_infer.py` — pure-logic tests for `aggregate_entities`.

## Why
Today the app needs PyTorch (~2 GB). With a bundle it runs on ~350 MB (onnxruntime + INT8): smaller installer, faster startup, and usable in the browser — exactly where "anonymize before sending to the LLM" is the user's gesture. Same privacy: only the engine changes.

## Validated
Exported `rizzoaiacademy/rizzo-pii-0.3B` to ONNX (INT8, via `src/export/export_onnx.py` from #12) and ran the app on it end-to-end: clean, correct entities on Italian PII (FULLNAME/CF/IBAN/ORG/PIVA/AMOUNT/CITY/STREET/ZIPCODE), reversible anonymization, hybrid model + regex/checksum. Pure aggregation tests green.

## Notes
- Consumes a bundle from `PII_ONNX_BUNDLE` or `models/rizzo-pii-0.3B-v*-onnx/bundle`.
- The desktop-usage section for `docs/ONNX.md` will be added once #12 merges (avoids conflict).
