### PR TITLE
fix(app): detector regex DATE e DOCID contro la frammentazione delle …

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,21 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-07-31 — Detector regex DATE e DOCID nell'app (niente più frammentazione)
+
+Il modello da solo frammentava date e numeri di registro in più span, lasciando
+**caratteri in chiaro** nel testo anonimizzato (es. `12/06/2025` → `[DATE_1][DATE_2]2[DATE_3]`,
+`R.G. 1234/2024` → quattro frammenti + `4` finale scoperta) e corrompendo il ripristino
+(`1234/202` al posto di `1234/2024`). Aggiunti in `src/app/app.py` due detector
+deterministici alla rete regex+checksum (stesso meccanismo di CF/IBAN, priorità sul modello):
+
+- **`DATE`**: date numeriche (`12/06/2025`, `12-06-25`, `12.06.2025`) e letterali (`12 giugno 2025`)
+- **`DOCID`**: `R.G.`/`RG`/`R.G.N.R.`, `Prot.`/`protocollo`, `Rep.`/`repertorio` + numero (con anno opzionale)
+
+Nessun impatto su training e pipeline dati.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -187,6 +187,20 @@ DETECTORS = [
     ("TARGA",
      re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b"),
      None, True),
+    ("DATE",
+     # date numeriche (12/06/2025, 12-06-25, 12.06.2025) e letterali (12 giugno 2025)
+     re.compile(r"\b\d{1,2}[/\-.]\d{1,2}[/\-.]\d{2,4}\b"
+                r"|\b\d{1,2}\s+(?:gennaio|febbraio|marzo|aprile|maggio|giugno|luglio|agosto"
+                r"|settembre|ottobre|novembre|dicembre)\s+\d{2,4}\b",
+                re.IGNORECASE),
+     None, True),
+    ("DOCID",
+     # R.G. 1234/2024, RG 1234/2024, R.G.N.R. 123/2023, Prot. 123/2024, repertorio 45
+     re.compile(r"\b(?:R\.?G\.?\s*N\.?R\.?|R\.?G\.?|RG)\s*\d{1,8}(?:[/\-]\d{2,4})?\b"
+                r"|\b(?:Prot\.?|protocollo(?:\s*(?:n\.?|num\.?))?|Rep\.?|repertorio)"
+                r"\s*\d{1,8}(?:[/\-]\d{2,4})?\b",
+                re.IGNORECASE),
+     None, True),
 ]
 
 


### PR DESCRIPTION
…entità

Il modello da solo frammenta date e R.G. in più span, lasciando caratteri in chiaro nel testo anonimizzato (12/06/2025 -> [DATE_1][DATE_2]2[DATE_3], R.G. 1234/2024 -> quattro frammenti + '4' finale scoperta) e corrompendo il ripristino. Aggiunti due detector deterministici alla rete regex+checksum in DETECTORS (app.py), con priorità sul modello in caso di sovrapposizione (come già per CF/IBAN/PIVA):

- DATE: date numeriche (12/06/2025, 12-06-25, 12.06.2025) e letterali (12 giugno 2025)
- DOCID: R.G./RG/R.G.N.R., Prot./protocollo, Rep./repertorio + numero (anno opzionale)

Nessun impatto su training e pipeline dati.