### PR TITLE
Pacchetto opt-in di detector per documenti di sicurezza (IP, domini, hash, ID cloud) + keeplist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,12 @@ modelli in `models/<versione>/`, artefatti dei run in `experiments/<run>/`, doc 
   codice di uscita `EXIT_PORT_CONFLICT = 76`: i 3 entry point escono con 76 se la porta è occupata
   **prima di caricare il modello** (evita secondi sprecati). Tauri riconosce il codice 76 e mostra
   il form di configurazione nello splash screen.
+- `detectors_cyber.py` — **pacchetto di detector opt-in per documenti di sicurezza**: IP/CIDR
+  (validati con `ipaddress`), DOMAIN, URL, MAC, HASH, WALLET (Base58Check), CLOUDID, PATH, USER,
+  ASN, **anche in forma defanged** (`203[.]0[.]113[.]42`, `hxxps://`). Porta anche una **keeplist**
+  (CVE/CWE/CAPEC/RFC/ATT&CK) di riferimenti pubblici da non mascherare mai. Si attiva con
+  `--detectors cyber` o `PII_DETECTORS=cyber`; spento, il comportamento sui documenti legali è
+  invariato. Modulo puro (solo `re`, `ipaddress`, `hashlib`) → testabile senza modello.
 - `app.py` — server Flask + **UI**: testo o PDF, chunking con overlap, offset globali + dedup.
   Anonimizzazione **reversibile** (ogni PII → `[FULLNAME_1]`/`[IBAN_1]`… + dizionario locale; tab
   "Ripristina"). Affianca al modello una **rete regex/checksum** (EMAIL/TELEFONO/IBAN/CF/PIVA/carta/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ python src/data_pipeline/build_subset.py
 python src/training/train_pii.py --type subset     # ~3 min
 ```
 
+Run the test suite — stdlib `unittest`, **no extra dependency and no model needed** (the
+token-classification pipeline is stubbed, so the regex/checksum net and the merge are exercised
+for real):
+
+```bash
+python -m unittest discover -s tests
+```
+
 ## Pull request workflow
 
 1. Create a topic branch: `git checkout -b fix/short-description`.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ The five Italian-legal tags (`CF`, `PIVA`, `CATASTO`, `DOCID`, `PROVINCE`) are t
 rizzo-pii exists: they do not appear as labeled data in any public corpus, so they are created
 through synthesis with mathematically valid checksums.
 
+### Security documents: the optional `cyber` detector pack
+
+Security work — assessment reports, forensic timelines, incident tickets, log extracts — has the
+same need, plus an NDA on top of the GDPR. Its identifiers are not in the 22 tags, though: IP
+addresses and CIDR ranges, domains, URLs, MACs, hashes, wallets, cloud identifiers, paths that
+embed a username, domain accounts, ASNs. They are all **structured**, so they are covered by an
+**opt-in pack of deterministic detectors** — regex plus validators, no retraining, no new
+dependency (`ipaddress` from the stdlib for IP/CIDR, Base58Check via `hashlib` for Bitcoin):
+
+```bash
+python src/app/app.py --detectors cyber      # or: PII_DETECTORS=cyber
+```
+
+It also recognizes **defanged** indicators (`203[.]0[.]113[.]42`, `evil(.)com`, `hxxps://`) — the
+form these values usually take in a report — and ships a **keeplist** so that public references
+(`CVE-…`, `CWE-…`, ATT&CK techniques, `RFC …`) are never masked: replacing `CVE-2024-3094` with a
+placeholder would make the sentence unreadable for the frontier model while protecting nobody.
+
+With the pack disabled — the default — behaviour on legal documents is unchanged: a court docket
+number must never turn into an IP address.
+
 ---
 
 ## Dataset & training

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,37 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-02 — Pacchetto di detector "cyber" (opt-in) + keeplist dei riferimenti pubblici
+
+Chi scrive documenti di sicurezza — report di assessment, timeline forensi, ticket di incidente,
+estratti di log — ha lo stesso problema degli studi legali, con in più un NDA. Ma i suoi
+identificatori non sono nei 22 tag: **IP, CIDR, domini, URL, MAC, hash, wallet, identificativi
+cloud, percorsi con lo username, account di dominio, ASN oggi restano in chiaro al 100%**.
+
+Sono tutti dati a forma specifica: nuovo modulo `src/app/detectors_cyber.py` con regex +
+validatori, **nessun riaddestramento**, nessuna nuova dipendenza (IP e CIDR validati con
+`ipaddress` della stdlib, Bitcoin con Base58Check via `hashlib`).
+
+- **Opt-in**: `--detectors cyber` o `PII_DETECTORS=cyber`. Con il pacchetto spento il
+  comportamento sui documenti legali è **identico**: un numero di repertorio non deve diventare un
+  IP. C'è un test che verifica l'assenza di falsi positivi cyber su prosa legale col pacchetto
+  **acceso**.
+- **Forme defanged riconosciute direttamente** (`203[.]0[.]113[.]42`, `evil(.)com`, `hxxps://`):
+  normalizzare il testo prima sfaserebbe gli offset, e un indicatore defangato non mascherato è
+  comunque un leak.
+- **Keeplist**: i riferimenti pubblici (CVE, CWE, CAPEC, RFC, tecniche ATT&CK) non vengono mai
+  mascherati, nemmeno se li propone il modello — mascherare `CVE-2024-3094` rende la frase
+  incomprensibile all'LLM senza proteggere nessuno. È volutamente **stretta**: in una keeplist un
+  falso positivo non produce una parola illeggibile, produce un dato sensibile lasciato in chiaro.
+- **Non include `SECRET`** (password, API key, JWT, chiavi PEM, seed): lo copre già la PR #37.
+- Bug evitato in fase di scrittura, degno di nota: con un lookahead `(?![\w.])` un indirizzo a
+  **fine frase** («il C2 è 203.0.113.42.») non veniva rilevato. Falso negativo, cioè un leak; ora
+  c'è un test di regressione.
+
+Nessun impatto sul training: sono detector deterministici, la tassonomia del modello non cambia.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -31,6 +31,7 @@ import torch
 from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
 
+import detectors_cyber
 import server_config
 from transformers import pipeline
 
@@ -190,10 +191,73 @@ DETECTORS = [
 ]
 
 
+# --------------------------------------------------------------------------- #
+# Pacchetti di detector OPZIONALI (opt-in).
+#
+# Il core qui sopra resta il default: con i pacchetti spenti il comportamento sui
+# documenti legali e' identico a prima — un numero di repertorio non deve diventare
+# un IP. Attivazione: env PII_DETECTORS=cyber, oppure --detectors cyber.
+#
+# Ogni pacchetto porta i propri detector e la propria KEEPLIST (riferimenti pubblici
+# da non mascherare mai).
+# --------------------------------------------------------------------------- #
+DETECTOR_PACKS = {
+    "cyber": (detectors_cyber.DETECTORS, detectors_cyber.KEEP_PATTERNS),
+}
+ACTIVE_DETECTORS = list(DETECTORS)
+ACTIVE_KEEP = []
+ACTIVE_PACKS = []
+
+
+def parse_packs(raw):
+    """Nomi dei pacchetti da una stringa "cyber,altro" o da una lista."""
+    if not raw:
+        return []
+    items = raw.replace(";", ",").split(",") if isinstance(raw, str) else list(raw)
+    return [str(i).strip().lower() for i in items if str(i).strip()]
+
+
+def enable_packs(names):
+    """Ricompone i detector attivi = core + pacchetti richiesti. Ritorna quelli attivati."""
+    global ACTIVE_DETECTORS, ACTIVE_KEEP, ACTIVE_PACKS
+    unknown = [n for n in names if n not in DETECTOR_PACKS]
+    if unknown:
+        print(f"ATTENZIONE: pacchetti di detector sconosciuti, ignorati: {', '.join(unknown)} "
+              f"(disponibili: {', '.join(sorted(DETECTOR_PACKS))})")
+    active = [n for n in names if n in DETECTOR_PACKS]
+    ACTIVE_DETECTORS, ACTIVE_KEEP = list(DETECTORS), []
+    for name in active:
+        pack_detectors, pack_keep = DETECTOR_PACKS[name]
+        ACTIVE_DETECTORS += pack_detectors
+        ACTIVE_KEEP += pack_keep
+    ACTIVE_PACKS = active
+    return active
+
+
+enable_packs(parse_packs(os.environ.get("PII_DETECTORS")))
+
+
+def drop_protected(cands, text):
+    """Scarta le entita' che toccano un riferimento pubblico della keeplist.
+
+    Vale anche per le entita' del MODELLO: mascherare 'CVE-2024-3094' o 'T1059.001'
+    renderebbe la frase incomprensibile all'LLM a cui la si manda, senza proteggere
+    nessuno (sono identificatori pubblici, non dati di una persona)."""
+    if not ACTIVE_KEEP:
+        return cands
+    protected = []
+    for rx in ACTIVE_KEEP:
+        protected.extend((m.start(), m.end()) for m in rx.finditer(text))
+    if not protected:
+        return cands
+    return [c for c in cands
+            if all(c["end"] <= start or c["start"] >= end for start, end in protected)]
+
+
 def detect_regex(text):
     """Entita' della rete regex. validated=True solo quando il checksum passa."""
     ents = []
-    for label, rx, validator, strict in DETECTORS:
+    for label, rx, validator, strict in ACTIVE_DETECTORS:
         for m in rx.finditer(text):
             ok = validator(m.group(0)) if validator else False
             if validator and strict and not ok:
@@ -286,6 +350,7 @@ def _norm(s):
 def analyze(text):
     model_ents, n_chunks = detect_model(text)
     cands = model_ents + detect_regex(text)
+    cands = drop_protected(cands, text)      # keeplist: i riferimenti pubblici restano
     kept = _merge(cands, text)
 
     # ID reversibili: stesso (label, valore-normalizzato) -> stesso placeholder.
@@ -1144,7 +1209,14 @@ if __name__ == "__main__":
     _p = _ap.ArgumentParser(description="Rizzo PII — server locale di anonimizzazione.")
     _p.add_argument("--host", default=None, help="indirizzo su cui ascoltare (default da config/env/127.0.0.1)")
     _p.add_argument("--port", type=int, default=None, help="porta su cui ascoltare (default da config/env/5005)")
+    _p.add_argument("--detectors", default=None,
+                    help=f"pacchetti di detector opzionali, es. \"cyber\" "
+                         f"(disponibili: {', '.join(sorted(DETECTOR_PACKS))}; default: solo core)")
     _args = _p.parse_args()
+
+    if _args.detectors:
+        enable_packs(parse_packs(_args.detectors))
+    print("Detector attivi: core" + (f" + {', '.join(ACTIVE_PACKS)}" if ACTIVE_PACKS else ""))
 
     _host, _port = server_config.resolve(cli_host=_args.host, cli_port=_args.port)
 

--- a/src/app/detectors_cyber.py
+++ b/src/app/detectors_cyber.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""
+Detector deterministici per documenti di SICUREZZA (pacchetto opt-in "cyber").
+
+Chi scrive report di assessment, timeline forensi, ticket di incidente o estratti di
+log ha lo stesso problema degli studi legali — usare un LLM di frontiera senza
+spedirgli i dati di un terzo — ma i suoi identificatori non sono nella tassonomia dei
+22 tag: indirizzi IP, domini, URL, MAC, hash, wallet, identificativi cloud, percorsi
+che contengono lo username, account di dominio, ASN. Oggi restano tutti in chiaro.
+
+Sono tutti dati a FORMA specifica: si riconoscono con regex + validatore, senza
+toccare il modello e senza riaddestrare nulla. Il pacchetto si attiva esplicitamente
+(env PII_DETECTORS=cyber, oppure --detectors cyber): con il pacchetto spento il
+comportamento sui documenti legali resta identico, cosi' un numero di repertorio non
+rischia di diventare un IP.
+
+Due scelte da spiegare:
+
+1. **Le forme "defanged" si matchano direttamente** (203[.]0[.]113[.]42, evil(.)com,
+   hxxps://). Normalizzare il testo prima dell'analisi sfaserebbe gli offset, e un IP
+   defangato non mascherato e' comunque un leak: e' la forma in cui gli indirizzi
+   compaiono piu' spesso nei documenti di sicurezza.
+
+2. **La keeplist (KEEP_PATTERNS) e' volutamente stretta.** Protegge i riferimenti
+   pubblici (CVE, CWE, CAPEC, RFC, tecniche ATT&CK) dall'essere mascherati: senza,
+   "CVE-2024-3094" sparirebbe e la frase diventerebbe incomprensibile per l'LLM. Ma
+   una keeplist e' l'inverso di un detector: un falso positivo qui non produce una
+   parola illeggibile, produce un dato sensibile lasciato in chiaro. Per questo si
+   protegge solo cio' che ha un prefisso inequivocabile, e non forme generiche come
+   "S1234"/"G0016" degli id ATT&CK di software e gruppi.
+
+Non e' incluso il tag SECRET (password, API key, JWT, chiavi PEM, seed phrase): lo
+copre gia' la PR #37, che aggiunge anche il supporto ai gruppi in detect_regex per
+mascherare il solo valore lasciando leggibile l'etichetta. Duplicarlo qui creerebbe
+solo un conflitto.
+
+Ogni voce di DETECTORS ha la stessa forma del core in app.py:
+    (label, regex compilata, validatore o None, strict)
+"""
+
+import hashlib
+import ipaddress
+import re
+
+# --------------------------------------------------------------------------- #
+# Defang: separatori alternativi usati per rendere non cliccabili gli indicatori
+# --------------------------------------------------------------------------- #
+DOT = r"(?:\.|\[\.\]|\(\.\)|\[dot\])"
+COLON = r"(?::|\[:\])"
+
+# Coda di uno span "lungo" (URL, path, risorsa cloud): prende tutto tranne gli spazi,
+# ma non puo' FINIRE con punteggiatura, altrimenti il punto di fine frase o la virgola
+# di un elenco entrano nel placeholder (e quindi anche nel dizionario reversibile).
+TAIL = r"[^\s<>\"']*[^\s<>\"'.,;:!?)\]]"
+
+
+def _refang(value):
+    """Riporta un indicatore defangato alla forma canonica, per poterlo validare."""
+    value = re.sub(r"\[\.\]|\(\.\)|\[dot\]", ".", value, flags=re.IGNORECASE)
+    return value.replace("[:]", ":")
+
+
+# --------------------------------------------------------------------------- #
+# Validatori
+# --------------------------------------------------------------------------- #
+def ip_ok(value):
+    """IPv4/IPv6, singolo o come rete CIDR. Usa ipaddress della stdlib: niente
+    'regex che sembra giusta' (999.1.1.1, /48 su IPv4, 6 gruppi esadecimali...)."""
+    value = _refang(value).strip()
+    try:
+        if "/" in value:
+            ipaddress.ip_network(value, strict=False)
+        else:
+            ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def url_ok(value):
+    """Forma minima di un URL: schema + host non vuoto. Il validatore serve anche a
+    dare all'URL la priorita' sul dominio che contiene (vedi _merge in app.py: a pari
+    fonte vince lo span validato, poi il piu' lungo)."""
+    value = _refang(value)
+    m = re.match(r"[A-Za-z][A-Za-z0-9+.\-]*://([^/\s]+)", value)
+    return bool(m and m.group(1))
+
+
+def hash_ok(value):
+    """Hash esadecimale di lunghezza nota. Deve contenere almeno una lettera a-f:
+    una sequenza di sole cifre e' quasi sempre un altro identificativo."""
+    return bool(re.search(r"[a-fA-F]", value))
+
+
+def asn_ok(value):
+    number = int(re.sub(r"\D", "", value))
+    return 0 < number <= 4294967295
+
+
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def btc_ok(value):
+    """Base58Check di un indirizzo Bitcoin legacy/P2SH: versione + doppio SHA-256.
+    E' l'equivalente del mod-97 dell'IBAN: elimina i falsi positivi su parole lunghe."""
+    number = 0
+    for char in value:
+        index = _B58.find(char)
+        if index < 0:
+            return False
+        number = number * 58 + index
+    if number >= 256 ** 25:
+        return False
+    raw = number.to_bytes(25, "big")
+    if raw[0] not in (0x00, 0x05):
+        return False
+    return hashlib.sha256(hashlib.sha256(raw[:21]).digest()).digest()[:4] == raw[21:]
+
+
+# --------------------------------------------------------------------------- #
+# Domini: TLD piu' comuni + suffissi delle reti interne.
+# Esclusi di proposito i TLD che sono anche estensioni di file (zip, mov, app):
+# "allegato.zip" non e' un dominio.
+# --------------------------------------------------------------------------- #
+TLDS = """
+com net org edu gov mil int info biz name pro io co me tv cc ly sh gg
+it eu de fr uk es nl be ch at pt ie dk se no fi is pl cz sk hu ro bg gr hr si lt lv ee
+ru ua by tr il ae sa in cn jp kr hk sg my th vn id ph au nz za eg ma ng ke
+us ca mx br ar cl pe uy ve
+dev cloud tech online site website space store shop blog news live link click
+ai app agency digital email network solutions systems security expert
+local internal lan corp intranet intra home arpa onion test invalid example localdomain
+""".split()
+_TLD_ALT = "|".join(sorted(TLDS, key=len, reverse=True))
+
+_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?"
+
+# --------------------------------------------------------------------------- #
+# Detector (stessa forma delle voci di DETECTORS in app.py)
+# --------------------------------------------------------------------------- #
+DETECTORS = [
+    # URL prima del dominio: e' lo span piu' lungo e validato, quindi vince il merge.
+    ("URL",
+     re.compile(rf"(?<![\w@])(?:h[xt]{{2}}ps?|ftps?|wss?){COLON}//{TAIL}"),
+     url_ok, True),
+
+    # IPv4 (anche in forma CIDR e defangata). Il lookbehind esclude le versioni
+    # software scritte come v1.2.3.4; "versione 1.2.3.4" resta un falso positivo noto.
+    # La coda e' (?!\.?\d) e non (?![\w.]): con quest'ultima un indirizzo a FINE FRASE
+    # ("il C2 e' 203.0.113.42.") non veniva rilevato — falso negativo, cioe' un leak.
+    ("IP",
+     re.compile(rf"(?<![\w.])\d{{1,3}}(?:{DOT}\d{{1,3}}){{3}}(?:/\d{{1,2}})?(?!\.?\d)(?![\w])"),
+     ip_ok, True),
+
+    # IPv6: la regex e' larga di proposito, la selezione la fa ipaddress
+    # (cosi' un MAC 00:1A:2B:3C:4D:5E o un orario 15:30:45 vengono scartati).
+    ("IP",
+     re.compile(r"(?<![\w:.])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}"
+                r"(?:/\d{1,3})?(?![\w:])"),
+     ip_ok, True),
+
+    ("MAC",
+     re.compile(r"(?<![\w:.\-])(?:[0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}(?![\w:\-])"
+                r"|(?<![\w.\-])(?:[0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}(?![\w.\-])"),
+     None, True),
+
+    ("HASH",
+     re.compile(r"(?<![0-9A-Za-z])(?:[0-9a-fA-F]{128}|[0-9a-fA-F]{64}"
+                r"|[0-9a-fA-F]{40}|[0-9a-fA-F]{32})(?![0-9A-Za-z])"),
+     hash_ok, True),
+
+    # Wallet. Ethereum: solo forma (il checksum EIP-55 richiede keccak256, che NON e'
+    # in hashlib — sha3_256 e' un altro algoritmo, confonderli e' un errore classico).
+    ("WALLET",
+     re.compile(r"(?<![\w])0x[0-9a-fA-F]{40}(?![\w])"
+                r"|(?<![\w])bc1[023456789acdefghjklmnpqrstuvwxyz]{11,71}(?![\w])"),
+     None, True),
+    ("WALLET",
+     re.compile(r"(?<![\w])[13][a-km-zA-HJ-NP-Z1-9]{25,34}(?![\w])"),
+     btc_ok, True),
+
+    ("CLOUDID",
+     re.compile(rf"arn:[a-z0-9\-]*:[a-z0-9\-]+:[a-z0-9\-]*:\d{{0,12}}:{TAIL}"
+                rf"|(?:s3|gs|az|abfss?|wasbs?)://{TAIL}"
+                r"|(?<![\w\-])(?:i|vol|ami|snap|sg|vpc|subnet|eni|acl|rtb|igw|nat)"
+                r"-[0-9a-f]{8,17}(?![\w\-])"
+                r"|(?<![\w\-])[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+                r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?![\w\-])", re.IGNORECASE),
+     None, True),
+
+    # Solo i percorsi che incorporano un'identita' (utente o host): /etc/passwd non
+    # identifica nessuno, C:\Users\m.rossi e \\FS01\condivisa si'.
+    ("PATH",
+     re.compile(rf"[A-Za-z]:\\Users\\{TAIL}"
+                rf"|\\\\[A-Za-z0-9._\-]+\\{TAIL}"
+                rf"|/(?:home|Users|root)/{TAIL}", re.IGNORECASE),
+     None, True),
+
+    # Account di dominio (DOMINIO\utente) e utenze di servizio.
+    ("USER",
+     re.compile(r"(?<![\\\w])[A-Za-z][A-Za-z0-9._\-]{1,30}\\[A-Za-z][A-Za-z0-9._\-]{1,30}"
+                r"(?![\\\w])"
+                r"|(?<![\w\-])(?:svc|srv|sa)[._\-][A-Za-z0-9._\-]{2,30}(?![\w\-])"),
+     None, True),
+
+    ("ASN",
+     re.compile(r"(?<![\w])AS\d{1,10}(?![\w])"),
+     asn_ok, True),
+
+    # Il dominio per ultimo: se e' dentro un URL, vince l'URL (piu' lungo e validato).
+    ("DOMAIN",
+     re.compile(rf"(?<![\w@.\-])(?:{_LABEL}{DOT})+(?:{_TLD_ALT})(?![\w\-])",
+                re.IGNORECASE),
+     None, True),
+]
+
+# --------------------------------------------------------------------------- #
+# Keeplist: riferimenti PUBBLICI che nessun detector deve mascherare.
+# Volutamente ristretta ai prefissi inequivocabili (vedi il docstring in testa).
+# --------------------------------------------------------------------------- #
+KEEP_PATTERNS = [
+    re.compile(r"\bCVE-\d{4}-\d{4,7}\b", re.IGNORECASE),
+    re.compile(r"\bCWE-\d{1,4}\b", re.IGNORECASE),
+    re.compile(r"\bCAPEC-\d{1,4}\b", re.IGNORECASE),
+    re.compile(r"\bRFC\s?\d{1,5}\b", re.IGNORECASE),
+    re.compile(r"\bTA?\d{4}(?:\.\d{3})?\b"),          # tecniche/tattiche ATT&CK
+    re.compile(r"\b(?:attack\.mitre\.org|cve\.mitre\.org|nvd\.nist\.gov|cwe\.mitre\.org)"
+               r"(?:/[^\s\"'<>]*)?", re.IGNORECASE),
+]

--- a/tests/test_detectors_cyber.py
+++ b/tests/test_detectors_cyber.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""
+Test del pacchetto di detector "cyber" (src/app/detectors_cyber.py) e della sua
+integrazione in analyze() (src/app/app.py).
+
+Il MODELLO e' sostituito da uno stub (dipendenza esterna, non il codice sotto esame):
+restano reali le regex, i validatori, la keeplist e il merge. Girano quindi senza
+torch/transformers e senza scaricare il checkpoint.
+
+    python -m unittest discover -s tests
+
+Tutti i valori usati qui sono inventati: nessun IOC reale, nessun indirizzo o dominio
+di un caso vero (vedi CONTRIBUTING.md).
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "app"))
+
+import detectors_cyber as cyber  # noqa: E402
+
+
+class _FakeNlp:
+    """Pipeline di token-classification finta: non trova nulla, cosi' il test misura
+    solo la rete regex, la keeplist e il merge."""
+
+    def __init__(self):
+        self.model = types.SimpleNamespace(config=types.SimpleNamespace(
+            label2id={"O": 0, "B-FULLNAME": 1, "I-FULLNAME": 2}))
+
+    def __call__(self, texts, *args, **kwargs):
+        return [[] for _ in texts] if isinstance(texts, list) else []
+
+
+def _install_stubs():
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    sys.modules.setdefault("torch", torch)
+    transformers = types.ModuleType("transformers")
+    transformers.pipeline = lambda *a, **k: _FakeNlp()
+    sys.modules.setdefault("transformers", transformers)
+    fitz = types.ModuleType("fitz")
+    fitz.open = lambda *a, **k: None
+    sys.modules.setdefault("fitz", fitz)
+
+
+_install_stubs()
+
+import app  # noqa: E402
+
+
+def find(label, text):
+    """Match del detector `label` sul testo, gia' filtrati dal loro validatore."""
+    out = []
+    for lab, rx, validator, strict in cyber.DETECTORS:
+        if lab != label:
+            continue
+        for m in rx.finditer(text):
+            ok = validator(m.group(0)) if validator else True
+            if validator and strict and not ok:
+                continue
+            out.append(m.group(0))
+    return out
+
+
+class TestIp(unittest.TestCase):
+
+    def test_ipv4_cidr_and_defanged_forms(self):
+        self.assertEqual(find("IP", "il C2 e' 203.0.113.42"), ["203.0.113.42"])
+        self.assertEqual(find("IP", "range 10.0.0.0/8 interno"), ["10.0.0.0/8"])
+        self.assertEqual(find("IP", "defangato 198[.]51[.]100[.]7 nel report"),
+                         ["198[.]51[.]100[.]7"])
+        self.assertEqual(find("IP", "oppure 198(.)51(.)100(.)7 qui"), ["198(.)51(.)100(.)7"])
+
+    def test_ip_at_the_end_of_a_sentence_is_detected(self):
+        # regressione: con un lookahead (?![\w.]) il punto finale faceva perdere
+        # l'indirizzo -> falso negativo, cioe' un leak
+        self.assertEqual(find("IP", "Il server e' 192.168.1.10."), ["192.168.1.10"])
+
+    def test_ipv6_is_detected_and_lookalikes_are_rejected(self):
+        self.assertEqual(find("IP", "host 2001:db8::1 raggiungibile"), ["2001:db8::1"])
+        self.assertEqual(find("IP", "alle ore 15:30:45 esatte"), [])
+        self.assertEqual(find("IP", "scheda 00:1A:2B:3C:4D:5E"), [])   # e' un MAC
+
+    def test_invalid_octets_and_version_numbers_are_rejected(self):
+        self.assertEqual(find("IP", "valore 999.1.1.1 non valido"), [])
+        self.assertEqual(find("IP", "aggiornato a v1.2.3.4 stabile"), [])
+        self.assertEqual(find("IP", "build 1.2.3.4.5 interna"), [])
+
+
+class TestNetworkAndFiles(unittest.TestCase):
+
+    def test_mac_both_notations(self):
+        self.assertEqual(find("MAC", "MAC 00:1A:2B:3C:4D:5E"), ["00:1A:2B:3C:4D:5E"])
+        self.assertEqual(find("MAC", "MAC 001a.2b3c.4d5e cisco"), ["001a.2b3c.4d5e"])
+
+    def test_url_keeps_the_whole_defanged_address(self):
+        text = "payload da hxxps://consegna(.)example/.github/rel.zip e basta"
+        self.assertEqual(find("URL", text), ["hxxps://consegna(.)example/.github/rel.zip"])
+
+    def test_url_does_not_swallow_the_closing_punctuation(self):
+        self.assertEqual(find("URL", "vedi (https://acme.com/a) e poi"),
+                         ["https://acme.com/a"])
+        self.assertEqual(find("URL", "vedi https://acme.com/a."), ["https://acme.com/a"])
+
+    def test_domain_ignores_email_hosts_and_file_extensions(self):
+        self.assertEqual(find("DOMAIN", "host dc01.corp.local nel dominio"),
+                         ["dc01.corp.local"])
+        self.assertEqual(find("DOMAIN", "scrivi a mario.rossi@studiolegale.it"), [])
+        self.assertEqual(find("DOMAIN", "in allegato relazione.zip firmata"), [])
+
+    def test_hash_lengths_and_digit_only_rejection(self):
+        sha256 = "b" * 63 + "a"
+        self.assertEqual(find("HASH", f"campione {sha256} noto"), [sha256])
+        self.assertEqual(find("HASH", "codice " + "1" * 64 + " interno"), [])
+        self.assertEqual(find("HASH", "troncato " + "a" * 63 + " qui"), [])
+
+
+class TestIdentifiers(unittest.TestCase):
+
+    def test_bitcoin_address_needs_a_valid_checksum(self):
+        self.assertEqual(find("WALLET", "wallet 1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2 attivo"),
+                         ["1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"])
+        self.assertEqual(find("WALLET", "wallet 1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN3 attivo"), [])
+
+    def test_ethereum_address_by_form(self):
+        addr = "0xa1b2c3d4e5f60718a1b2c3d4e5f60718a1b2c3d4"
+        self.assertEqual(find("WALLET", f"deployer {addr} on-chain"), [addr])
+
+    def test_cloud_identifiers(self):
+        self.assertEqual(find("CLOUDID", "bucket s3://acme-backups/db.sql, esposto"),
+                         ["s3://acme-backups/db.sql"])
+        self.assertEqual(find("CLOUDID", "ruolo arn:aws:iam::123456789012:role/admin."),
+                         ["arn:aws:iam::123456789012:role/admin"])
+        self.assertEqual(find("CLOUDID", "istanza i-0abc1234def567890 spenta"),
+                         ["i-0abc1234def567890"])
+
+    def test_paths_that_carry_an_identity(self):
+        self.assertEqual(find("PATH", r"profilo C:\Users\m.rossi\Desktop\nota.docx,"),
+                         [r"C:\Users\m.rossi\Desktop\nota.docx"])
+        self.assertEqual(find("PATH", r"share \\FS01\condivisa, montata"),
+                         [r"\\FS01\condivisa"])
+        self.assertEqual(find("PATH", "chiave /home/mrossi/.ssh/id_rsa."),
+                         ["/home/mrossi/.ssh/id_rsa"])
+        self.assertEqual(find("PATH", "file /etc/passwd letto"), [])   # non identifica nessuno
+
+    def test_accounts_and_asn(self):
+        self.assertEqual(find("USER", r"accesso con ACME\m.rossi alle"), [r"ACME\m.rossi"])
+        self.assertEqual(find("USER", "utenza svc_backup disabilitata"), ["svc_backup"])
+        self.assertEqual(find("ASN", "annuncia il prefisso AS64496 dal 2019"), ["AS64496"])
+        self.assertEqual(find("ASN", "sigla AS0 inesistente"), [])
+
+
+class TestKeepList(unittest.TestCase):
+
+    def matches(self, text):
+        return [m.group(0) for rx in cyber.KEEP_PATTERNS for m in rx.finditer(text)]
+
+    def test_public_references_are_recognized(self):
+        for ref in ("CVE-2024-3094", "CWE-506", "CAPEC-137", "RFC 7231", "T1059.001", "TA0002"):
+            self.assertIn(ref, self.matches(f"vedi {ref} nel dettaglio"), ref)
+
+    def test_generic_ids_are_not_protected(self):
+        # una keeplist troppo larga non produce una parola illeggibile: produce un dato
+        # sensibile lasciato in chiaro. Gli id ATT&CK di software/gruppi (S0154, G0016)
+        # sono forme troppo generiche per essere protette.
+        self.assertEqual(self.matches("codice S0154 e gruppo G0016"), [])
+
+
+class TestIntegration(unittest.TestCase):
+    """analyze() con il pacchetto attivo: composizione, keeplist e merge reali."""
+
+    REPORT = (
+        "Il beacon dell'host C:\\Users\\m.rossi\\AppData\\Local\\svc.exe contatta "
+        "203.0.113.42 e il dominio consegna.example, sfruttando CVE-2024-3094 "
+        "(tecnica T1059.001). Campione a2b3c4d5e6f70819a2b3c4d5e6f70819. "
+        "Scrivere a soc@acme.com."
+    )
+
+    def setUp(self):
+        app.enable_packs(["cyber"])
+
+    def tearDown(self):
+        app.enable_packs([])
+
+    def test_pack_is_opt_in(self):
+        app.enable_packs([])
+        out = app.analyze("Il C2 e' 203.0.113.42 e il dominio consegna.example.")
+        self.assertIn("203.0.113.42", out["anonymized_text"])      # core: nessun detector IP
+        self.assertEqual(out["n_entities"], 0)
+
+    def test_technical_identifiers_are_masked(self):
+        out = app.analyze(self.REPORT)
+        for secret in ("203.0.113.42", "consegna.example", "m.rossi",
+                       "a2b3c4d5e6f70819a2b3c4d5e6f70819", "soc@acme.com"):
+            self.assertNotIn(secret, out["anonymized_text"], secret)
+        self.assertLessEqual({"IP", "DOMAIN", "PATH", "HASH", "EMAIL"}, set(out["by_label"]))
+
+    def test_legal_prose_gets_no_cyber_false_positives(self):
+        # il vincolo politico della PR: acceso il pacchetto, un atto resta un atto
+        legal = ("Vista la sentenza n. 1234/2024 del Tribunale di Roma, R.G. 5678/2023, "
+                 "il sottoscritto C.F. RSSMRA85H12F205Y versa € 12.500,00 sull'IBAN "
+                 "IT60X0542811101000000123456 entro il 12/06/2025, tel. 06 5551234.")
+        labels = {s["label"] for s in app.analyze(legal)["segments"] if s.get("label")}
+        self.assertEqual(labels & {"IP", "DOMAIN", "URL", "PATH", "USER", "HASH",
+                                   "MAC", "WALLET", "CLOUDID", "ASN"}, set())
+
+    def test_public_references_survive(self):
+        out = app.analyze(self.REPORT)
+        self.assertIn("CVE-2024-3094", out["anonymized_text"])
+        self.assertIn("T1059.001", out["anonymized_text"])
+
+    def test_url_wins_over_the_domain_it_contains(self):
+        out = app.analyze("Payload da https://consegna.example/rel.zip scaricato.")
+        labels = [s["label"] for s in out["segments"] if s.get("label")]
+        self.assertEqual(labels, ["URL"])
+        self.assertEqual(out["mapping"]["[URL_1]"], "https://consegna.example/rel.zip")
+
+    def test_email_is_not_broken_into_a_domain(self):
+        out = app.analyze("Contatto: soc@acme.com per la risposta.")
+        self.assertEqual(out["mapping"], {"[EMAIL_1]": "soc@acme.com"})
+
+    def test_restore_is_exact_for_masked_technical_values(self):
+        out = app.analyze(self.REPORT)
+        restored = out["anonymized_text"]
+        for placeholder, value in sorted(out["mapping"].items(), key=lambda kv: -len(kv[0])):
+            restored = restored.replace(placeholder, value)
+        self.assertEqual(restored, self.REPORT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ciao Simone,

uso rizzo-pii dal lato di chi scrive documenti di sicurezza — report di assessment, timeline di
analisi forense, ticket di incidente, estratti di log — e ho lo stesso problema degli studi
legali, con in più un vincolo contrattuale (NDA con la parte lesa) oltre a quello del GDPR:
voglio usare un modello di frontiera senza spedirgli l'infrastruttura di un terzo.

## Il problema

Sui miei documenti i 22 tag coprono bene il referente e la ragione sociale. Restano in chiaro
**al 100%** proprio i valori più sensibili del dominio. Un esempio reale come struttura (valori
inventati):

```
Il beacon sull'host C:\Users\m.rossi\AppData\Local\svc.exe contatta 203.0.113.42
e il dominio consegna.example, sfruttando CVE-2024-3094 (tecnica T1059.001).
Campione a2b3c4d5e6f70819a2b3c4d5e6f70819. Bucket esposto: s3://acme-backups.
```

Oggi l'unica cosa che viene mascherata è l'eventuale email. Indirizzo IP, dominio, percorso con
lo username, hash e bucket passano interi al modello di frontiera.

## Cosa fa questa PR

Un **pacchetto di detector opt-in**, `cyber`, nella rete regex/checksum esistente. Sono tutti
dati a forma specifica: servono regex e validatori, non un modello riaddestrato.

| Tag | Copre | Validatore |
|---|---|---|
| `IP` | IPv4, IPv6, CIDR | `ipaddress` (stdlib) |
| `DOMAIN` | FQDN e host DNS, anche suffissi interni (`.local`, `.internal`) | TLD in elenco |
| `URL` | URL completo | schema + host |
| `MAC` | notazione `:`/`-` e Cisco | forma |
| `HASH` | MD5/SHA-1/SHA-256/SHA-512 | lunghezza + alfabeto |
| `WALLET` | Bitcoin, Ethereum, bech32 | **Base58Check** (`hashlib`) |
| `CLOUDID` | ARN, `s3://`/`gs://`, instance-id, subscription/tenant GUID | forma |
| `PATH` | percorsi che incorporano un'identità (`C:\Users\…`, UNC, `/home/…`) | forma |
| `USER` | `DOMINIO\utente`, utenze di servizio | forma |
| `ASN` | numero di sistema autonomo | intervallo valido |

Più una **keeplist**: i riferimenti pubblici (`CVE-…`, `CWE-…`, `CAPEC-…`, `RFC …`, tecniche
ATT&CK) non vengono mai mascherati, **nemmeno se li propone il modello**.

```bash
python src/app/app.py --detectors cyber        # oppure PII_DETECTORS=cyber
```

## Le scelte che vale la pena discutere

**1. È opt-in, e il default non cambia di una virgola.** Con il pacchetto spento il
comportamento sui documenti legali è identico a prima: un numero di repertorio non deve diventare
un `IP`. Non mi fido della mia parola su questo, quindi c'è un test che analizza prosa legale
(sentenza, R.G., C.F., IBAN, importo, telefono) **con il pacchetto acceso** e verifica che non
compaia nessun tag cyber.

**2. Le forme "defanged" si matchano direttamente** (`203[.]0[.]113[.]42`, `evil(.)com`,
`hxxps://`), non normalizzando il testo prima. Normalizzare sfaserebbe tutti gli offset — e
comunque un indicatore defangato lasciato in chiaro è un leak identico: è la forma in cui questi
valori compaiono più spesso in un report.

**3. `ipaddress` della stdlib invece di una regex "che sembra giusta".** La regex resta larga e
la selezione la fa il parser: `999.1.1.1`, un `/48` su IPv4, un orario `15:30:45` e un MAC che
somiglia a un IPv6 vengono scartati senza che io debba prevederli uno per uno. È lo stesso
principio del mod-97 sull'IBAN che il progetto già applica. Zero dipendenze nuove.

**4. Bitcoin con Base58Check, Ethereum solo per forma.** Il checksum EIP-55 richiede keccak256,
che **non** è in `hashlib` (`sha3_256` è un altro algoritmo: confonderli è l'errore classico e
produrrebbe un validatore che scarta indirizzi validi). Meglio dichiararlo che fingere una
validazione che non c'è.

**5. La keeplist è volutamente stretta.** Protegge solo prefissi inequivocabili; ho escluso di
proposito gli id ATT&CK di software e gruppi (`S0154`, `G0016`). Il motivo è che una keeplist è
l'inverso di un detector: un falso positivo qui non produce una parola illeggibile, produce **un
dato sensibile lasciato in chiaro**.

**6. `SECRET` non c'è, di proposito.** Password, API key, JWT, chiavi PEM e seed phrase li copre
già la #37, che aggiunge anche il supporto ai gruppi in `detect_regex` per mascherare il solo
valore lasciando leggibile l'etichetta. Duplicarli qui creerebbe solo un conflitto. Se quella PR
non dovesse andare avanti, li aggiungo volentieri qui.

## Un falso negativo trovato scrivendola

Con un lookahead `(?![\w.])` un indirizzo a **fine frase** («il C2 è 203.0.113.42.») non veniva
rilevato: il punto finale faceva fallire l'asserzione. Per un tool di privacy è il tipo di errore
che conta davvero — l'indirizzo sarebbe finito in chiaro nel prompt. Ora la coda è
`(?!\.?\d)(?![\w])`, che continua a rifiutare `1.2.3.4.5`, e c'è un test di regressione dedicato.

## Test

Test in `tests/`: **`unittest` della stdlib, nessuna dipendenza nuova**.
La pipeline di token-classification è sostituita da uno stub, quindi girano **senza torch e senza
scaricare il checkpoint**, mentre regex, validatori, keeplist e merge sono reali.

```bash
python -m unittest discover -s tests      # 23 test
```

Coprono: forme canoniche e defangate, indirizzo a fine frase, IPv6 contro sosia (MAC, orari),
ottetti non validi e numeri di versione, URL con punteggiatura di chiusura, email che **non**
devono diventare `DOMAIN`, estensioni di file che non sono TLD, checksum Bitcoin valido e non
valido, keeplist, e in integrazione: precedenza dell'`URL` sul dominio che contiene, assenza di
falsi positivi su prosa legale, round-trip esatto anonimizza → ripristina.

Tutti i valori nei test sono **inventati**: nessun IOC reale, nessun dominio esistente, nessun
indirizzo di un caso vero (`CONTRIBUTING.md`).

## Impatto e convivenza con le altre PR

- Nessun riaddestramento, tassonomia del modello invariata, `requirements.txt` invariato.
- Il diff su `app.py` è quasi tutto additivo: **una** riga cambiata in `detect_regex`
  (`DETECTORS` → `ACTIVE_DETECTORS`) e **una** aggiunta in `analyze()` per la keeplist. Le PR
  aperte che toccano `app.py` (#32, #35, #37, #38) aggiungono voci alla lista `DETECTORS` o
  lavorano su `_merge`: non dovrebbero collidere.
- Il blocco "test suite" aggiunto a `CONTRIBUTING.md` è **identico** a quello dell'altra mia PR
  (policy): se le prendi entrambe, git le fonde senza conflitto.

## Cosa NON fa

Niente tag nuovi nel modello (`HOST`, `CODENAME` richiedono dati sintetici e cambiano
`num_labels`), niente scelta mask/keep per tag, niente scope file per valore. Su quella parte —
distinguere l'IP del cliente dall'IP del C2 dell'attaccante — ti ho scritto una proposta a parte,
perché è una decisione di scope del progetto, non un dettaglio implementativo.
