### PR TITLE
Policy di anonimizzazione: scegliere quali tag lasciare in chiaro (chiude #41 e #31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,14 @@ modelli in `models/<versione>/`, artefatti dei run in `experiments/<run>/`, doc 
   codice di uscita `EXIT_PORT_CONFLICT = 76`: i 3 entry point escono con 76 se la porta è occupata
   **prima di caricare il modello** (evita secondi sprecati). Tauri riconosce il codice 76 e mostra
   il form di configurazione nello splash screen.
+- `policy.py` — **policy di anonimizzazione**: per ogni tag decide `mask` (placeholder reversibile,
+  default) o `keep` (resta in chiaro). Catena di precedenza: **CLI `--profile`/`--keep-tags` > env
+  `PII_PROFILE`/`PII_KEEP_TAGS` > `policy.json` > default**. Profili: `full`, `clinical`,
+  `compare-amounts`; i tag espliciti si sommano a quelli del profilo. `policy.json` sta nella stessa
+  directory di `config.json` ma è un **file separato** (Tauri riscrive `config.json` dal lato Rust e
+  cancellerebbe una chiave estranea). Modulo **puro** (niente torch/flask) → testabile senza modello.
+  Le entità tenute in chiaro escono con `action: "keep"` + `preservation_reason` e **non** entrano nel
+  dizionario. Endpoint `GET/POST /policy`: si applica subito, senza riavvio.
 - `app.py` — server Flask + **UI**: testo o PDF, chunking con overlap, offset globali + dedup.
   Anonimizzazione **reversibile** (ogni PII → `[FULLNAME_1]`/`[IBAN_1]`… + dizionario locale; tab
   "Ripristina"). Affianca al modello una **rete regex/checksum** (EMAIL/TELEFONO/IBAN/CF/PIVA/carta/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ python src/data_pipeline/build_subset.py
 python src/training/train_pii.py --type subset     # ~3 min
 ```
 
+Run the test suite — stdlib `unittest`, **no extra dependency and no model needed** (the
+token-classification pipeline is stubbed, so the regex/checksum net and the merge are exercised
+for real):
+
+```bash
+python -m unittest discover -s tests
+```
+
 ## Pull request workflow
 
 1. Create a topic branch: `git checkout -b fix/short-description`.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,28 @@ The five Italian-legal tags (`CF`, `PIVA`, `CATASTO`, `DOCID`, `PROVINCE`) are t
 rizzo-pii exists: they do not appear as labeled data in any public corpus, so they are created
 through synthesis with mathematically valid checksums.
 
+### Choosing what to mask: profiles and policy
+
+Masking every category is the right default, but not always the right answer. A task that asks the
+frontier model to cross-check two amounts cannot work on `[AMOUNT_1]` vs `[AMOUNT_2]`; in a clinical
+setting, age and sex are often the object of the study rather than the identifier to remove. A
+**policy** decides, per tag, whether an entity is masked (reversible placeholder — the default) or
+left in clear, resolved through the same chain used for host/port:
+**CLI > env > `policy.json` > default**.
+
+```bash
+python src/app/app.py --profile clinical               # AGE, GENDER, DATE, TIME stay readable
+python src/app/app.py --keep-tags AMOUNT               # amounts stay comparable
+PII_KEEP_TAGS=AGE,GENDER python src/app/app.py         # same, from the environment
+python src/training/test_pii.py --profile clinical "…"
+```
+
+Entities left in clear are still **detected and reported** (`action: "keep"`,
+`preservation_reason: "excluded_by_config"`, counted in `n_kept`); they simply never enter the
+reversible dictionary, because there is nothing to restore. Profile and tags are also editable from
+the ⚙️ dialog in the app and apply immediately, with no restart. Keeping a direct identifier
+(`FULLNAME`, `CF`, `IBAN`…) in clear is allowed, and warned about.
+
 ---
 
 ## Dataset & training

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,43 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-02 — Policy di anonimizzazione: scegliere quali tag lasciare in chiaro
+
+Fino a oggi ogni entità rilevata veniva mascherata, senza eccezioni. Per alcuni compiti questo
+rende il documento inutilizzabile: se si chiede al modello di frontiera di verificare la coerenza
+fra due importi, `[AMOUNT_1]` e `[AMOUNT_2]` non sono confrontabili (#31); in ambito clinico età e
+sesso sono spesso l'oggetto dello studio, non l'identificatore da togliere (#41).
+
+Nuovo modulo **`src/app/policy.py`** (puro: nessun import di torch/flask). Per ogni tag decide
+`mask` (placeholder reversibile, default) o `keep` (resta in chiaro), con la stessa catena di
+precedenza di `server_config`: **CLI > env (`PII_PROFILE`/`PII_KEEP_TAGS`) > `policy.json` > default**.
+
+- **Default invariato**: senza configurazione si maschera tutto, esattamente come prima.
+- **Profili**: `full` (default), `clinical` (AGE/GENDER/DATE/TIME), `compare-amounts` (AMOUNT).
+  I tag indicati esplicitamente si **aggiungono** a quelli del profilo.
+- **`policy.json` è un file separato da `config.json`**: quest'ultimo è riscritto anche dall'app
+  Tauri dal lato Rust come `{host, port}`, e cancellerebbe una chiave estranea.
+- **Le entità tenute in chiaro restano visibili**: escono con `action: "keep"` e
+  `preservation_reason: "excluded_by_config"`, contano in `n_kept` e nella legenda, ma **non
+  entrano nel dizionario** (non c'è nulla da ripristinare).
+- **Validazione**: i tag sono confrontati con la tassonomia presa dal modello caricato
+  (`label2id`, senza prefisso BIO) più le label della rete regex — non da un elenco scritto a mano
+  che invecchierebbe. I tag sconosciuti vengono segnalati e ignorati. Lasciare in chiaro un
+  identificatore diretto (FULLNAME/CF/PIVA/IBAN/carta/ID_DOC/EMAIL/telefono) produce un avviso
+  esplicito: è una scelta legittima, ma va vista.
+- **UI**: profilo e tag in chiaro nel modale ⚙️ (si applicano **subito**, senza riavvio, a
+  differenza di host/porta); nell'anteprima le entità lasciate in chiaro hanno il bordo
+  tratteggiato e mostrano il valore vero.
+- **CLI**: `--profile` e `--keep-tags` su `src/app/app.py` e `src/training/test_pii.py`.
+- **Test**: prima suite del repo in `tests/`, con `unittest` della stdlib (nessuna nuova
+  dipendenza) — `python -m unittest discover -s tests`. Il modello è sostituito da uno stub,
+  quindi girano senza torch/transformers e senza checkpoint; rete regex, merge, assegnazione dei
+  placeholder ed endpoint sono reali.
+
+Nessun impatto sul training: la policy agisce **solo in inferenza**, la tassonomia non cambia.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/docs/TASSONOMIA_TAG.md
+++ b/docs/TASSONOMIA_TAG.md
@@ -91,6 +91,13 @@ non chiedendolo alla token-classification.
   diretti**; in un atto spesso servono. Politica di mascheramento da decidere a valle,
   non necessariamente "sempre".
 
+**La politica è configurabile** (`src/app/policy.py`): per ogni tag si sceglie `mask`
+(placeholder reversibile, default) o `keep` (resta in chiaro), via profilo
+(`full` / `clinical` / `compare-amounts`), `--keep-tags`, env `PII_KEEP_TAGS` o `policy.json`.
+Non tocca né il modello né il training: **la tassonomia resta questa**, cambia solo cosa ne fa
+l'app a valle. Le entità lasciate in chiaro vengono comunque rilevate e riportate
+(`action: "keep"`), ma non entrano nel dizionario reversibile.
+
 ---
 
 ## Fonti dei dati e validation

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -31,6 +31,7 @@ import torch
 from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
 
+import policy
 import server_config
 from transformers import pipeline
 
@@ -190,6 +191,20 @@ DETECTORS = [
 ]
 
 
+def known_tags():
+    """Tassonomia valida per la policy: i tipi base delle label del modello (senza il
+    prefisso BIO) piu' le label della rete regex. Presa dal modello caricato, non da un
+    elenco scritto a mano che invecchierebbe."""
+    cfg = getattr(getattr(nlp, "model", None), "config", None)
+    labels = set(getattr(cfg, "label2id", None) or ())
+    return {l.split("-", 1)[1] for l in labels if "-" in l} | {d[0] for d in DETECTORS}
+
+
+# Policy attiva: cosa mascherare e cosa lasciare in chiaro (env / policy.json).
+# In __main__ viene ricaricata con gli eventuali argomenti da riga di comando.
+POLICY = policy.load_policy(known_tags=known_tags())
+
+
 def detect_regex(text):
     """Entita' della rete regex. validated=True solo quando il checksum passa."""
     ents = []
@@ -289,9 +304,15 @@ def analyze(text):
     kept = _merge(cands, text)
 
     # ID reversibili: stesso (label, valore-normalizzato) -> stesso placeholder.
+    # I tag che la policy lascia in chiaro non ricevono un placeholder e restano fuori
+    # dal dizionario: non c'e' nulla da ripristinare.
     counters, seen, mapping = {}, {}, {}
     for e in kept:
         val = text[e["start"]:e["end"]]
+        e["action"] = POLICY.action(e["label"])
+        if e["action"] == policy.ACTION_KEEP:
+            e["preservation_reason"] = policy.REASON_CONFIG
+            continue
         key = (e["label"], _norm(val))
         if key in seen:
             e["ph"] = seen[key]
@@ -304,18 +325,27 @@ def analyze(text):
 
     # segmenti per la preview + testo anonimizzato + statistiche
     segments, anon, by_label, by_source, pos = [], [], {}, {}, 0
+    n_kept = 0
     for e in kept:
+        val = text[e["start"]:e["end"]]
         if e["start"] > pos:
             segments.append({"t": text[pos:e["start"]]})
             anon.append(text[pos:e["start"]])
-        segments.append({
-            "t": text[e["start"]:e["end"]],
+        seg = {
+            "t": val,
             "label": e["label"],
-            "ph": e["ph"],
+            "ph": e.get("ph"),
             "src": e["source"],
             "validated": e["validated"],
-        })
-        anon.append(e["ph"])
+            "action": e["action"],
+        }
+        if e["action"] == policy.ACTION_KEEP:
+            seg["preservation_reason"] = e["preservation_reason"]
+            anon.append(val)          # entita' rilevata ma lasciata in chiaro
+            n_kept += 1
+        else:
+            anon.append(e["ph"])
+        segments.append(seg)
         by_label[e["label"]] = by_label.get(e["label"], 0) + 1
         by_source[e["source"]] = by_source.get(e["source"], 0) + 1
         pos = e["end"]
@@ -330,7 +360,9 @@ def analyze(text):
         "n_chunks": n_chunks,
         "n_chars": len(text),
         "n_entities": len(kept),
+        "n_kept": n_kept,
         "n_unique": len(mapping),
+        "policy": POLICY.as_dict(),
         "by_label": dict(sorted(by_label.items(), key=lambda x: -x[1])),
         "by_source": by_source,
     }
@@ -409,6 +441,38 @@ def config_post():
         return jsonify({"error": "La porta deve essere tra 1024 e 65535."}), 400
     server_config.save_config(host, port)
     return jsonify({"ok": True, "host": host, "port": port})
+
+
+# --------------------------------------------------------------------------- #
+# Policy di anonimizzazione (GET = leggi, POST = salva e applica SUBITO)
+# --------------------------------------------------------------------------- #
+@app.route("/policy", methods=["GET"])
+def policy_get():
+    return jsonify({
+        **POLICY.as_dict(),
+        "profiles": {name: sorted(tags) for name, tags in policy.PROFILES.items()},
+        "known_tags": sorted(known_tags()),
+        "high_risk_tags": sorted(policy.HIGH_RISK_TAGS),
+        "policy_path": str(policy.policy_path()),
+    })
+
+
+@app.route("/policy", methods=["POST"])
+def policy_post():
+    global POLICY
+    data = request.get_json(silent=True) or {}
+    profile = str(data.get("profile", policy.DEFAULT_PROFILE)).strip().lower()
+    if profile not in policy.PROFILES:
+        return jsonify({"error": f"Profilo sconosciuto: {profile}"}), 400
+    keep = policy.parse_tags(data.get("keep_tags"))
+    unknown = sorted(set(keep) - known_tags())
+    if unknown:
+        return jsonify({"error": "Tag non riconosciuti: " + ", ".join(unknown)}), 400
+    policy.save_file(profile, keep)
+    # a differenza di host/porta, la policy non richiede un riavvio: si applica alla
+    # prossima analisi.
+    POLICY = policy.Policy(keep_tags=keep, profile=profile)
+    return jsonify({"ok": True, **POLICY.as_dict()})
 
 
 @app.route("/port-check")
@@ -553,6 +617,8 @@ PAGE = r"""
       transition:.12s}
   .ph .ck{font-size:10px;opacity:.8;margin-left:3px}
   .ph.dim{opacity:.25;filter:grayscale(.6)}
+  /* entita' rilevata ma lasciata in chiaro dalla policy: bordo tratteggiato, valore vero */
+  .ph.keep{border-style:dashed;font-weight:500}
   .empty{color:var(--soft);display:flex;flex-direction:column;align-items:center;justify-content:center;
          height:100%;gap:9px;text-align:center;font-size:14px}
   .empty .big{font-size:34px;opacity:.6}
@@ -641,9 +707,11 @@ PAGE = r"""
   .cfg-row{display:flex;flex-direction:column;gap:5px;margin-bottom:14px}
   .cfg-row label{font-size:12.5px;font-weight:600;color:var(--muted);text-transform:uppercase;
                  letter-spacing:.04em}
-  .cfg-row input{border:1px solid var(--line);border-radius:9px;padding:9px 12px;font:inherit;
-                 font-size:14px;color:var(--ink);background:#fcfcfe}
-  .cfg-row input:focus{outline:none;border-color:var(--brand);box-shadow:0 0 0 3px rgba(124,58,158,.13)}
+  .cfg-row input,.cfg-row select{border:1px solid var(--line);border-radius:9px;padding:9px 12px;
+                 font:inherit;font-size:14px;color:var(--ink);background:#fcfcfe}
+  .cfg-row input:focus,.cfg-row select:focus{outline:none;border-color:var(--brand);
+                 box-shadow:0 0 0 3px rgba(124,58,158,.13)}
+  .cfg-row .sub{font-size:11.5px;color:var(--soft);font-weight:400;text-transform:none;letter-spacing:0}
   .cfg-status{font-size:12.5px;font-weight:600;padding:7px 11px;border-radius:8px;margin-bottom:14px;
               display:none}
   .cfg-status.ok{display:block;background:#eaf7ef;color:var(--ok)}
@@ -809,6 +877,15 @@ PAGE = r"""
       <label data-i18n="cfg_port">Porta</label>
       <input id="cfgPort" type="number" min="1024" max="65535" value="5005">
     </div>
+    <div class="cfg-row">
+      <label data-i18n="cfg_profile">Profilo di anonimizzazione</label>
+      <select id="cfgProfile"></select>
+    </div>
+    <div class="cfg-row">
+      <label data-i18n="cfg_keep">Tag lasciati in chiaro</label>
+      <input id="cfgKeep" type="text" placeholder="AGE,GENDER" spellcheck="false">
+      <span class="sub" data-i18n="cfg_keep_note">Elenco separato da virgole; vuoto = maschera tutto.</span>
+    </div>
     <div class="cfg-status" id="cfgStatus"></div>
     <div class="cfg-btns">
       <button class="btn" id="cfgSave" onclick="saveConfig()">💾 <span data-i18n="cfg_save">Salva</span></button>
@@ -849,6 +926,7 @@ const T = {
   empty_rout:"Il testo con i valori reali apparirà qui.", rcopy:"Copia testo ripristinato",
   st_ent:"entità", st_uniq:"valori unici", st_model:"dal modello",
   st_regex:"da regex/checksum", st_chars:"caratteri", analyzing:"Analizzo…",
+  st_kept:"lasciate in chiaro", kept_tip:"rilevata e lasciata in chiaro dalla policy",
   t_need_input:"Inserisci del testo o un PDF", t_error:"Errore",
   t_copied:"Testo anonimizzato copiato", t_need_anon:"Prima anonimizza un testo",
   t_nothing_dl:"Niente da scaricare", t_dl_ok:"Dizionario scaricato",
@@ -865,8 +943,10 @@ const T = {
   cfg_title:"Configurazione server", cfg_host:"Indirizzo", cfg_port:"Porta",
   cfg_check:"Verifica porta", cfg_save:"Salva", cfg_cancel:"Annulla",
   cfg_available:"Porta disponibile ✓", cfg_in_use:"Porta occupata ✗",
-  cfg_saved:"Configurazione salvata (riavvia per applicare)",
-  cfg_restart_note:"Le modifiche avranno effetto al prossimo avvio.",
+  cfg_saved:"Configurazione salvata",
+  cfg_restart_note:"Indirizzo e porta valgono dal prossimo avvio; la policy si applica subito.",
+  cfg_profile:"Profilo di anonimizzazione", cfg_keep:"Tag lasciati in chiaro",
+  cfg_keep_note:"Elenco separato da virgole; vuoto = maschera tutto.",
  },
  en:{
   tagline:"local model on CPU · GDPR compliant", badge:"100% local",
@@ -889,6 +969,7 @@ const T = {
   empty_rout:"The text with the real values will appear here.", rcopy:"Copy restored text",
   st_ent:"entities", st_uniq:"unique values", st_model:"from the model",
   st_regex:"from regex/checksum", st_chars:"characters", analyzing:"Analyzing…",
+  st_kept:"left in clear", kept_tip:"detected and left in clear by the policy",
   t_need_input:"Enter some text or a PDF", t_error:"Error",
   t_copied:"Anonymized text copied", t_need_anon:"Anonymize a text first",
   t_nothing_dl:"Nothing to download", t_dl_ok:"Dictionary downloaded",
@@ -905,8 +986,10 @@ const T = {
   cfg_title:"Server configuration", cfg_host:"Host", cfg_port:"Port",
   cfg_check:"Check port", cfg_save:"Save", cfg_cancel:"Cancel",
   cfg_available:"Port available ✓", cfg_in_use:"Port in use ✗",
-  cfg_saved:"Config saved (restart to apply)",
-  cfg_restart_note:"Changes take effect on next startup.",
+  cfg_saved:"Config saved",
+  cfg_restart_note:"Host and port apply on next startup; the policy applies immediately.",
+  cfg_profile:"Anonymization profile", cfg_keep:"Tags left in clear",
+  cfg_keep_note:"Comma-separated list; empty = mask everything.",
  }
 };
 const tt=k=>T[L][k];
@@ -986,10 +1069,13 @@ function render(){
   for(const s of d.segments){
     if(s.label){
       const c=colors(s.label);const sp=document.createElement('span');
-      sp.className='ph'+(off.has(s.label)?' dim':'');
-      sp.style.background=c.bg;sp.style.borderColor=c.bd;sp.style.color=c.tx;
-      sp.title=`${s.t}\n(${s.src}${s.validated?' · checksum ✓':''})`;
-      sp.innerHTML=s.ph.replace(/[\[\]]/g,'')+(s.validated?'<span class="ck">✓</span>':'');
+      const keep=s.action==='keep';                 // rilevata ma non mascherata
+      sp.className='ph'+(keep?' keep':'')+(off.has(s.label)?' dim':'');
+      sp.style.background=keep?'transparent':c.bg;sp.style.borderColor=c.bd;sp.style.color=c.tx;
+      sp.title=keep?`${s.label} · ${tt('kept_tip')}`
+                   :`${s.t}\n(${s.src}${s.validated?' · checksum ✓':''})`;
+      sp.innerHTML=keep?escapeHtml(s.t)
+                       :s.ph.replace(/[\[\]]/g,'')+(s.validated?'<span class="ck">✓</span>':'');
       prev.appendChild(sp);
     }else prev.appendChild(document.createTextNode(s.t));
   }
@@ -999,6 +1085,7 @@ function render(){
   $('meta').innerHTML=
     `<span class="stat"><b>${d.n_entities}</b> ${tt('st_ent')}</span>`+
     `<span class="stat"><b>${d.n_unique}</b> ${tt('st_uniq')}</span>`+
+    (d.n_kept?`<span class="stat"><b>${d.n_kept}</b> ${tt('st_kept')}</span>`:'')+
     `<span class="stat"><b>${(d.by_source.modello||0)}</b> ${tt('st_model')}</span>`+
     `<span class="stat"><b>${(d.by_source.regex||0)}</b> ${tt('st_regex')}</span>`+
     `<span class="stat"><b>${T[L].chars(d.n_chars)}</b> ${tt('st_chars')}</span>`;
@@ -1109,6 +1196,20 @@ async function openConfig(){
   const r=await fetch('/config');const d=await r.json();
   $('cfgHost').value=d.host||'127.0.0.1';
   $('cfgPort').value=d.port||5005;
+  try{
+    const p=await (await fetch('/policy')).json();
+    const sel=$('cfgProfile');sel.innerHTML='';
+    for(const name of Object.keys(p.profiles||{})){
+      const o=document.createElement('option');o.value=name;
+      o.textContent=name+(p.profiles[name].length?' ('+p.profiles[name].join(', ')+')':'');
+      sel.appendChild(o);}
+    sel.value=p.profile;
+    // cambiando profilo il campo torna ai tag di quel profilo: cosi' e' chiaro
+    // quali tag arrivano dal profilo e quali sono stati aggiunti a mano
+    sel.onchange=()=>{$('cfgKeep').value=(p.profiles[sel.value]||[]).join(',');};
+    $('cfgKeep').value=(p.keep_tags||[]).join(',');
+    $('cfgKeep').title=(p.known_tags||[]).join(', ');
+  }catch{}
   $('cfgStatus').className='cfg-status';$('cfgStatus').textContent='';
   $('cfgOverlay').classList.add('open');
 }
@@ -1127,6 +1228,12 @@ async function saveConfig(){
   if(!p||p<1024||p>65535){toast(tt('cfg_in_use'),false);return;}
   await fetch('/config',{method:'POST',headers:{'Content-Type':'application/json'},
     body:JSON.stringify({host:h,port:p})});
+  const pr=await fetch('/policy',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({profile:$('cfgProfile').value,keep_tags:$('cfgKeep').value})});
+  const pd=await pr.json();
+  if(!pr.ok){                                  // tag inesistente: resta aperto, mostra l'errore
+    $('cfgStatus').className='cfg-status fail';$('cfgStatus').textContent=pd.error||tt('t_error');
+    return;}
   toast(tt('cfg_saved'));
   closeConfig();
 }
@@ -1144,7 +1251,17 @@ if __name__ == "__main__":
     _p = _ap.ArgumentParser(description="Rizzo PII — server locale di anonimizzazione.")
     _p.add_argument("--host", default=None, help="indirizzo su cui ascoltare (default da config/env/127.0.0.1)")
     _p.add_argument("--port", type=int, default=None, help="porta su cui ascoltare (default da config/env/5005)")
+    _p.add_argument("--keep-tags", default=None,
+                    help="tag da lasciare IN CHIARO, es. \"AGE,GENDER\" (default: si maschera tutto)")
+    _p.add_argument("--profile", default=None,
+                    help=f"profilo di anonimizzazione: {', '.join(sorted(policy.PROFILES))}")
     _args = _p.parse_args()
+
+    POLICY = policy.load_policy(cli_keep_tags=_args.keep_tags, cli_profile=_args.profile,
+                                known_tags=known_tags())
+    if POLICY.keep_tags:
+        print(f"Policy: profilo '{POLICY.profile}' | lasciati in chiaro: "
+              f"{', '.join(sorted(POLICY.keep_tags))}")
 
     _host, _port = server_config.resolve(cli_host=_args.host, cli_port=_args.port)
 

--- a/src/app/policy.py
+++ b/src/app/policy.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""
+Politica di anonimizzazione: per ogni tag decide se MASCHERARE l'entita' con un
+placeholder reversibile (comportamento storico, default) o LASCIARLA IN CHIARO.
+
+Perche' serve: alcuni compiti chiesti al modello di frontiera dipendono proprio dai
+valori che l'anonimizzazione rimuove — il confronto fra due importi dello stesso
+contratto, l'eta' e il sesso in uno studio clinico. Con la policy l'utente sceglie
+per tag cosa esce dal documento; senza configurazione si maschera tutto, come prima.
+
+Risoluzione con precedenza, la stessa catena di server_config:
+
+    CLI  >  env (PII_PROFILE / PII_KEEP_TAGS)  >  policy.json  >  default
+
+Il profilo da' un insieme di tag di partenza; i tag indicati esplicitamente si
+AGGIUNGONO a quelli del profilo (unione). Per mascherare tutto: profilo "full",
+nessun tag.
+
+policy.json sta nella stessa directory di config.json (server_config.config_dir())
+ma e' un file SEPARATO: config.json e' scritto anche dall'app Tauri dal lato Rust,
+che lo riscrive come {"host", "port"} e cancellerebbe una chiave estranea.
+
+    Formato:  {"profile": "clinical", "keep_tags": ["AMOUNT"]}
+
+Il modulo e' puro (nessun import di torch/flask/transformers): si puo' testare e
+usare senza caricare il modello.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import server_config
+
+# Azioni possibili su un'entita' rilevata.
+ACTION_MASK = "mask"    # -> [TAG_n] + voce nel dizionario reversibile
+ACTION_KEEP = "keep"    # -> resta in chiaro nel testo anonimizzato
+ACTIONS = (ACTION_MASK, ACTION_KEEP)
+
+# Motivo riportato nell'output per un'entita' rilevata ma non mascherata.
+REASON_CONFIG = "excluded_by_config"
+
+DEFAULT_PROFILE = "full"
+
+# Profili preconfezionati: nome -> tag lasciati in chiaro.
+PROFILES = {
+    "full": (),                                        # maschera tutto (storico)
+    "clinical": ("AGE", "GENDER", "DATE", "TIME"),     # cartelle/studi clinici
+    "compare-amounts": ("AMOUNT",),                    # confronti fra importi
+}
+
+# Identificatori diretti: lasciarli in chiaro e' una scelta legittima ma pesante,
+# quindi la si segnala una volta al caricamento. Non e' un divieto.
+HIGH_RISK_TAGS = frozenset({
+    "FULLNAME", "CF", "PIVA", "IBAN", "CREDITCARDNUMBER", "ID_DOC",
+    "EMAIL", "TELEPHONENUM",
+})
+
+POLICY_FILENAME = "policy.json"
+
+
+def _warn(message: str) -> None:
+    print(f"[policy] {message}", file=sys.stderr)
+
+
+def policy_path() -> Path:
+    """Percorso di policy.json (stessa directory di config.json)."""
+    return server_config.config_dir() / POLICY_FILENAME
+
+
+def load_file() -> dict:
+    """Legge policy.json; ritorna {} se manca o e' corrotto (come server_config)."""
+    p = policy_path()
+    if p.exists():
+        try:
+            data = json.loads(p.read_text("utf-8"))
+            if isinstance(data, dict):
+                return data
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def save_file(profile: str, keep_tags) -> None:
+    """Scrive policy.json (crea la directory se necessario)."""
+    d = server_config.config_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    payload = {"profile": profile, "keep_tags": list(parse_tags(keep_tags))}
+    (d / POLICY_FILENAME).write_text(json.dumps(payload, indent=2), "utf-8")
+
+
+def parse_tags(raw) -> tuple:
+    """Normalizza una lista di tag scritta come stringa o come lista.
+
+    Accetta "age, gender" oppure ["AGE", "GENDER"]; ritorna una tupla di tag in
+    MAIUSCOLO, senza vuoti e senza duplicati, nell'ordine di apparizione.
+    """
+    if raw is None:
+        return ()
+    items = raw.replace(";", ",").split(",") if isinstance(raw, str) else list(raw)
+    out = []
+    for item in items:
+        tag = str(item).strip().upper()
+        if tag and tag not in out:
+            out.append(tag)
+    return tuple(out)
+
+
+class Policy:
+    """Cosa fare di ogni entita' rilevata, tag per tag.
+
+    keep_tags: tag lasciati in chiaro; tutto il resto e' mascherato.
+    """
+
+    def __init__(self, keep_tags=(), profile: str = DEFAULT_PROFILE):
+        self.profile = profile
+        self.keep_tags = frozenset(parse_tags(keep_tags))
+
+    def action(self, label: str) -> str:
+        """ACTION_KEEP se il tag va lasciato in chiaro, altrimenti ACTION_MASK."""
+        return ACTION_KEEP if str(label).upper() in self.keep_tags else ACTION_MASK
+
+    def keeps(self, label: str) -> bool:
+        return self.action(label) == ACTION_KEEP
+
+    def as_dict(self) -> dict:
+        """Rappresentazione serializzabile (risposta API / UI)."""
+        return {"profile": self.profile, "keep_tags": sorted(self.keep_tags)}
+
+    def __repr__(self):
+        return f"Policy(profile={self.profile!r}, keep_tags={sorted(self.keep_tags)})"
+
+
+def _profile_tags(name: str, warn) -> tuple:
+    """Tag del profilo; profilo sconosciuto -> avviso e default."""
+    if name in PROFILES:
+        return PROFILES[name]
+    warn(f"profilo sconosciuto '{name}': uso '{DEFAULT_PROFILE}'. "
+         f"Disponibili: {', '.join(sorted(PROFILES))}")
+    return PROFILES[DEFAULT_PROFILE]
+
+
+def load_policy(cli_keep_tags=None, cli_profile=None, known_tags=None, warn=_warn) -> Policy:
+    """Risolve la policy con la catena CLI > env > policy.json > default.
+
+    cli_keep_tags / cli_profile: valori da riga di comando (None = non specificati).
+    known_tags: tassonomia valida (label del modello + della rete regex). I tag non
+        riconosciuti vengono segnalati e ignorati, non fanno fallire il caricamento.
+    warn: funzione di avviso, iniettabile nei test.
+
+    Il primo livello che fornisce dei tag vince (non si sommano fra loro); i tag del
+    profilo si aggiungono sempre.
+    """
+    cfg = load_file()
+
+    profile = (cli_profile
+               or os.environ.get("PII_PROFILE")
+               or cfg.get("profile")
+               or DEFAULT_PROFILE)
+    profile = str(profile).strip().lower()
+
+    explicit = ()
+    for source in (cli_keep_tags, os.environ.get("PII_KEEP_TAGS"), cfg.get("keep_tags")):
+        explicit = parse_tags(source)
+        if explicit:
+            break
+
+    tags = list(_profile_tags(profile, warn))
+    for tag in explicit:
+        if tag not in tags:
+            tags.append(tag)
+
+    if known_tags:
+        known = {str(t).upper() for t in known_tags}
+        unknown = [t for t in tags if t not in known]
+        if unknown:
+            warn(f"tag non presenti nella tassonomia, ignorati: {', '.join(unknown)}")
+        tags = [t for t in tags if t in known]
+
+    risky = sorted(t for t in tags if t in HIGH_RISK_TAGS)
+    if risky:
+        warn(f"ATTENZIONE: identificatori diretti lasciati IN CHIARO: {', '.join(risky)}")
+
+    return Policy(keep_tags=tags, profile=profile)

--- a/src/training/test_pii.py
+++ b/src/training/test_pii.py
@@ -7,10 +7,13 @@ individua le entita' sensibili in alcuni esempi (o in un testo passato da riga d
 comando), stampando le entita' trovate e una versione anonimizzata con [TIPO].
 
 Uso:
-  python src/training/test_pii.py                       # esempi predefiniti
-  python src/training/test_pii.py "Mi chiamo Mario..."  # testa un testo tuo
+  python src/training/test_pii.py                        # esempi predefiniti
+  python src/training/test_pii.py "Mi chiamo Mario..."   # testa un testo tuo
+  python src/training/test_pii.py --keep-tags AGE,GENDER "..."   # li lascia in chiaro
+  python src/training/test_pii.py --profile clinical "..."       # profilo preconfezionato
 """
 
+import argparse
 import io
 import sys
 from pathlib import Path
@@ -19,6 +22,18 @@ import torch
 from transformers import pipeline
 
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+# policy.py vive con l'app (src/app/): stessa politica di anonimizzazione per CLI e server.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+import policy  # noqa: E402
+
+_ap = argparse.ArgumentParser(description="Inferenza PII sul modello addestrato.")
+_ap.add_argument("text", nargs="*", help="testo da analizzare (vuoto = esempi predefiniti)")
+_ap.add_argument("--keep-tags", default=None,
+                 help="tag da lasciare IN CHIARO, es. \"AGE,GENDER\" (default: si maschera tutto)")
+_ap.add_argument("--profile", default=None,
+                 help=f"profilo di anonimizzazione: {', '.join(sorted(policy.PROFILES))}")
+args = _ap.parse_args()
 
 # Modello: ULTIMA versione models/rizzo-pii-0.3B-v* (storico versioni); fallback al vecchio
 # models/rizzo-pii-0.3B non versionato, poi al legacy. Override puntuale: env PII_MODEL_DIR.
@@ -52,7 +67,14 @@ nlp = pipeline(
     aggregation_strategy="simple",
     device=device,
 )
-print(f"Modello caricato da {MODEL_DIR} | device: {'GPU' if device == 0 else 'CPU'}\n")
+print(f"Modello caricato da {MODEL_DIR} | device: {'GPU' if device == 0 else 'CPU'}")
+
+# Tassonomia valida presa dal modello (senza il prefisso BIO), non da un elenco scritto a mano.
+KNOWN_TAGS = {l.split("-", 1)[1] for l in nlp.model.config.label2id if "-" in l}
+POLICY = policy.load_policy(cli_keep_tags=args.keep_tags, cli_profile=args.profile,
+                            known_tags=KNOWN_TAGS)
+print(f"Policy: profilo '{POLICY.profile}' | lasciati in chiaro: "
+      f"{', '.join(sorted(POLICY.keep_tags)) or 'nessuno'}\n")
 
 EXAMPLES = [
     "Mi chiamo Mario Rossi e la mia email e' mario.rossi@gmail.com, "
@@ -67,9 +89,12 @@ EXAMPLES = [
 
 
 def anonymize(text, ents):
-    """Sostituisce le entita' con [TIPO], lavorando da destra per non sfasare gli offset."""
+    """Sostituisce le entita' con [TIPO], lavorando da destra per non sfasare gli offset.
+    Le entita' che la policy lascia in chiaro restano nel testo."""
     out = text
     for e in sorted(ents, key=lambda x: x["start"], reverse=True):
+        if POLICY.keeps(e["entity_group"]):
+            continue
         out = out[: e["start"]] + f"[{e['entity_group']}]" + out[e["end"]:]
     return out
 
@@ -80,13 +105,14 @@ def run(text):
     if ents:
         print("ENTITA' :")
         for e in ents:
-            print(f"   [{e['entity_group']:<14}] '{e['word']}'  (score {e['score']:.2f})")
+            kept = "  <- in chiaro (policy)" if POLICY.keeps(e["entity_group"]) else ""
+            print(f"   [{e['entity_group']:<14}] '{e['word']}'  (score {e['score']:.2f}){kept}")
     else:
         print("ENTITA' : nessuna trovata")
     print("ANONIMO :", anonymize(text, ents))
     print("-" * 80)
 
 
-texts = [" ".join(sys.argv[1:])] if len(sys.argv) > 1 else EXAMPLES
+texts = [" ".join(args.text)] if args.text else EXAMPLES
 for t in texts:
     run(t)

--- a/tests/test_analyze_policy.py
+++ b/tests/test_analyze_policy.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""
+Test d'integrazione della policy dentro analyze() (src/app/app.py).
+
+Il MODELLO e' sostituito da uno stub (e' una dipendenza esterna, non il codice sotto
+esame): restano reali la rete regex+checksum, il merge e l'assegnazione dei placeholder.
+Cosi' il test gira senza torch/transformers e senza scaricare il checkpoint.
+
+    python -m unittest discover -s tests
+"""
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "app"))
+
+MODEL_LABELS = ("O", "B-FULLNAME", "I-FULLNAME", "B-AGE", "B-GENDER", "B-DATE", "B-TIME",
+                "B-AMOUNT", "B-EMAIL", "B-IBAN", "B-CF")
+
+
+class _FakeNlp:
+    """Pipeline di token-classification finta: non trova nulla, ma espone la stessa
+    tassonomia del modello vero (serve a known_tags())."""
+
+    def __init__(self):
+        self.model = types.SimpleNamespace(config=types.SimpleNamespace(
+            label2id={name: i for i, name in enumerate(MODEL_LABELS)}))
+
+    def __call__(self, texts, *args, **kwargs):
+        return [[] for _ in texts] if isinstance(texts, list) else []
+
+
+def _install_stubs():
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    sys.modules.setdefault("torch", torch)
+
+    transformers = types.ModuleType("transformers")
+    transformers.pipeline = lambda *a, **k: _FakeNlp()
+    sys.modules.setdefault("transformers", transformers)
+
+    fitz = types.ModuleType("fitz")
+    fitz.open = lambda *a, **k: None
+    sys.modules.setdefault("fitz", fitz)
+
+
+_install_stubs()
+
+import app  # noqa: E402
+import policy  # noqa: E402
+
+EMAIL = "mario.rossi@studiolegale.it"
+IBAN = "IT60X0542811101000000123456"
+TEXT = (f"Per ogni comunicazione scrivere a {EMAIL}; il pagamento di € 12.500,00 "
+        f"va effettuato sull'IBAN {IBAN}.")
+
+
+class AnalyzeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._orig = app.POLICY
+        app.POLICY = policy.Policy()          # default: maschera tutto
+
+    def tearDown(self):
+        app.POLICY = self._orig
+
+    def entity_segments(self, out):
+        return [s for s in out["segments"] if s.get("label")]
+
+    def segment_for(self, out, label):
+        return next(s for s in self.entity_segments(out) if s["label"] == label)
+
+
+class TestDefaultPolicy(AnalyzeTestCase):
+
+    def test_everything_is_masked_and_reversible(self):
+        out = app.analyze(TEXT)
+        self.assertNotIn(EMAIL, out["anonymized_text"])
+        self.assertNotIn(IBAN, out["anonymized_text"])
+        self.assertIn("[EMAIL_1]", out["anonymized_text"])
+        self.assertEqual(out["mapping"]["[EMAIL_1]"], EMAIL)
+        self.assertEqual(out["mapping"]["[IBAN_1]"], IBAN)
+        self.assertEqual(out["n_kept"], 0)
+
+    def test_every_segment_declares_the_mask_action(self):
+        out = app.analyze(TEXT)
+        for seg in self.entity_segments(out):
+            self.assertEqual(seg["action"], policy.ACTION_MASK)
+            self.assertNotIn("preservation_reason", seg)
+
+    def test_identical_values_share_one_placeholder(self):
+        out = app.analyze(f"{EMAIL} e ancora {EMAIL}")
+        self.assertEqual(out["n_entities"], 2)
+        self.assertEqual(out["n_unique"], 1)
+
+
+class TestKeepPolicy(AnalyzeTestCase):
+
+    def test_kept_tag_stays_in_clear_and_out_of_the_dictionary(self):
+        app.POLICY = policy.Policy(keep_tags=["EMAIL"])
+        out = app.analyze(TEXT)
+        self.assertIn(EMAIL, out["anonymized_text"])          # in chiaro
+        self.assertNotIn(IBAN, out["anonymized_text"])        # mascherato
+        self.assertNotIn("[EMAIL_1]", out["anonymized_text"])
+        self.assertNotIn(EMAIL, out["mapping"].values())
+        self.assertEqual(out["n_kept"], 1)
+
+    def test_kept_entity_is_still_reported_with_its_reason(self):
+        app.POLICY = policy.Policy(keep_tags=["EMAIL"])
+        out = app.analyze(TEXT)
+        seg = self.segment_for(out, "EMAIL")
+        self.assertEqual(seg["action"], policy.ACTION_KEEP)
+        self.assertEqual(seg["preservation_reason"], policy.REASON_CONFIG)
+        self.assertEqual(seg["t"], EMAIL)
+        self.assertIsNone(seg["ph"])
+        self.assertEqual(out["by_label"]["EMAIL"], 1)         # rilevata, non nascosta
+
+    def test_masked_entities_keep_working_next_to_a_kept_one(self):
+        app.POLICY = policy.Policy(keep_tags=["EMAIL"])
+        out = app.analyze(TEXT)
+        self.assertEqual(out["mapping"]["[IBAN_1]"], IBAN)
+        self.assertEqual(self.segment_for(out, "IBAN")["action"], policy.ACTION_MASK)
+
+    def test_response_declares_the_active_policy(self):
+        app.POLICY = policy.Policy(keep_tags=["AMOUNT"], profile="compare-amounts")
+        out = app.analyze(TEXT)
+        self.assertEqual(out["policy"],
+                         {"profile": "compare-amounts", "keep_tags": ["AMOUNT"]})
+        self.assertIn("€ 12.500,00", out["anonymized_text"])
+
+    def test_text_is_unchanged_when_every_detected_tag_is_kept(self):
+        app.POLICY = policy.Policy(keep_tags=["EMAIL", "IBAN", "AMOUNT"])
+        out = app.analyze(TEXT)
+        self.assertEqual(out["anonymized_text"], TEXT)
+        self.assertEqual(out["mapping"], {})
+
+
+class TestPolicyEndpoint(AnalyzeTestCase):
+    """Endpoint /policy con il test client di Flask. La config dir e' temporanea:
+    i test non scrivono nella cartella di configurazione dell'utente."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_dir = policy.server_config.config_dir
+        policy.server_config.config_dir = lambda: Path(self._tmp.name)
+        self.client = app.app.test_client()
+
+    def tearDown(self):
+        policy.server_config.config_dir = self._orig_dir
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_get_reports_profiles_and_taxonomy(self):
+        body = self.client.get("/policy").get_json()
+        self.assertEqual(body["profile"], policy.DEFAULT_PROFILE)
+        self.assertIn("clinical", body["profiles"])
+        self.assertIn("EMAIL", body["known_tags"])       # dal modello (stub)
+        self.assertIn("TARGA", body["known_tags"])       # dalla rete regex
+
+    def test_post_applies_immediately_and_persists(self):
+        r = self.client.post("/policy", json={"profile": "full", "keep_tags": "EMAIL"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(app.POLICY.keep_tags, frozenset({"EMAIL"}))
+        self.assertEqual(policy.load_file(), {"profile": "full", "keep_tags": ["EMAIL"]})
+        out = self.client.post("/analyze", json={"text": TEXT}).get_json()
+        self.assertIn(EMAIL, out["anonymized_text"])
+
+    def test_post_rejects_unknown_tag_without_changing_anything(self):
+        r = self.client.post("/policy", json={"profile": "full", "keep_tags": "NONESISTE"})
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("NONESISTE", r.get_json()["error"])
+        self.assertEqual(app.POLICY.keep_tags, frozenset())
+        self.assertEqual(policy.load_file(), {})         # niente scritto su disco
+
+    def test_post_rejects_unknown_profile(self):
+        r = self.client.post("/policy", json={"profile": "inesistente"})
+        self.assertEqual(r.status_code, 400)
+
+    def test_analyze_response_carries_the_policy(self):
+        self.client.post("/policy", json={"profile": "clinical", "keep_tags": ""})
+        out = self.client.post("/analyze", json={"text": TEXT}).get_json()
+        self.assertEqual(out["policy"]["profile"], "clinical")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""
+Test della policy di anonimizzazione (src/app/policy.py).
+
+Solo stdlib: si eseguono senza torch/transformers/flask e senza modello.
+
+    python -m unittest discover -s tests
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "app"))
+
+import policy  # noqa: E402
+
+TAXONOMY = {"FULLNAME", "AGE", "GENDER", "DATE", "TIME", "AMOUNT", "CF", "EMAIL", "IBAN"}
+
+
+class PolicyTestCase(unittest.TestCase):
+    """Isola i test dall'ambiente reale: niente env ereditate, config dir temporanea."""
+
+    def setUp(self):
+        self._env = {k: os.environ.pop(k) for k in ("PII_PROFILE", "PII_KEEP_TAGS")
+                     if k in os.environ}
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_config_dir = policy.server_config.config_dir
+        policy.server_config.config_dir = lambda: Path(self._tmp.name)
+        self.warnings = []
+
+    def tearDown(self):
+        policy.server_config.config_dir = self._orig_config_dir
+        self._tmp.cleanup()
+        os.environ.update(self._env)
+        for k in ("PII_PROFILE", "PII_KEEP_TAGS"):
+            if k not in self._env:
+                os.environ.pop(k, None)
+
+    def load(self, **kwargs):
+        kwargs.setdefault("warn", self.warnings.append)
+        return policy.load_policy(**kwargs)
+
+
+class TestParseTags(PolicyTestCase):
+
+    def test_parse_tags_string_normalizes_case_and_spaces(self):
+        self.assertEqual(policy.parse_tags(" age, gender "), ("AGE", "GENDER"))
+
+    def test_parse_tags_accepts_list_and_semicolon(self):
+        self.assertEqual(policy.parse_tags(["age", "AGE"]), ("AGE",))
+        self.assertEqual(policy.parse_tags("age;gender"), ("AGE", "GENDER"))
+
+    def test_parse_tags_empty_sources_give_empty_tuple(self):
+        for raw in (None, "", "   ", [], ",,"):
+            self.assertEqual(policy.parse_tags(raw), (), f"input: {raw!r}")
+
+
+class TestPolicyDecision(PolicyTestCase):
+
+    def test_default_policy_masks_every_tag(self):
+        p = self.load()
+        self.assertEqual(p.profile, policy.DEFAULT_PROFILE)
+        self.assertEqual(p.keep_tags, frozenset())
+        for tag in TAXONOMY:
+            self.assertEqual(p.action(tag), policy.ACTION_MASK)
+
+    def test_kept_tag_is_case_insensitive(self):
+        p = policy.Policy(keep_tags=["age"])
+        self.assertTrue(p.keeps("AGE"))
+        self.assertTrue(p.keeps("age"))
+        self.assertFalse(p.keeps("FULLNAME"))
+
+    def test_as_dict_is_sorted_and_serializable(self):
+        p = policy.Policy(keep_tags=["GENDER", "AGE"], profile="clinical")
+        self.assertEqual(p.as_dict(), {"profile": "clinical", "keep_tags": ["AGE", "GENDER"]})
+
+
+class TestProfiles(PolicyTestCase):
+
+    def test_clinical_profile_keeps_its_tags_and_masks_the_rest(self):
+        p = self.load(cli_profile="clinical", known_tags=TAXONOMY)
+        for tag in ("AGE", "GENDER", "DATE", "TIME"):
+            self.assertTrue(p.keeps(tag), tag)
+        self.assertFalse(p.keeps("FULLNAME"))
+
+    def test_explicit_tags_are_added_to_the_profile_tags(self):
+        p = self.load(cli_profile="clinical", cli_keep_tags="AMOUNT", known_tags=TAXONOMY)
+        self.assertTrue(p.keeps("AMOUNT"))
+        self.assertTrue(p.keeps("AGE"))
+
+    def test_unknown_profile_falls_back_to_default_with_a_warning(self):
+        p = self.load(cli_profile="inesistente")
+        self.assertEqual(p.keep_tags, frozenset())
+        self.assertTrue(any("profilo sconosciuto" in w for w in self.warnings))
+
+
+class TestPrecedence(PolicyTestCase):
+
+    def test_cli_beats_env_and_file(self):
+        os.environ["PII_KEEP_TAGS"] = "GENDER"
+        policy.save_file("full", ["DATE"])
+        p = self.load(cli_keep_tags="AGE", known_tags=TAXONOMY)
+        self.assertEqual(p.keep_tags, frozenset({"AGE"}))
+
+    def test_env_beats_file(self):
+        os.environ["PII_KEEP_TAGS"] = "GENDER"
+        policy.save_file("full", ["DATE"])
+        p = self.load(known_tags=TAXONOMY)
+        self.assertEqual(p.keep_tags, frozenset({"GENDER"}))
+
+    def test_file_is_used_when_cli_and_env_are_absent(self):
+        policy.save_file("full", ["DATE"])
+        p = self.load(known_tags=TAXONOMY)
+        self.assertEqual(p.keep_tags, frozenset({"DATE"}))
+
+    def test_profile_precedence_is_independent_from_tags(self):
+        os.environ["PII_PROFILE"] = "clinical"
+        p = self.load(cli_keep_tags="AMOUNT", known_tags=TAXONOMY)
+        self.assertEqual(p.profile, "clinical")
+        self.assertTrue(p.keeps("AGE"))
+        self.assertTrue(p.keeps("AMOUNT"))
+
+    def test_save_and_load_file_round_trip(self):
+        policy.save_file("clinical", " amount , age ")
+        self.assertEqual(policy.load_file(),
+                         {"profile": "clinical", "keep_tags": ["AMOUNT", "AGE"]})
+
+    def test_corrupt_file_is_ignored(self):
+        policy.policy_path().write_text("{non json", "utf-8")
+        p = self.load(known_tags=TAXONOMY)
+        self.assertEqual(p.keep_tags, frozenset())
+
+
+class TestValidation(PolicyTestCase):
+
+    def test_unknown_tag_is_dropped_with_a_warning(self):
+        p = self.load(cli_keep_tags="AGE,NONESISTE", known_tags=TAXONOMY)
+        self.assertEqual(p.keep_tags, frozenset({"AGE"}))
+        self.assertTrue(any("NONESISTE" in w for w in self.warnings))
+
+    def test_without_known_tags_no_validation_happens(self):
+        p = self.load(cli_keep_tags="QUALSIASI")
+        self.assertTrue(p.keeps("QUALSIASI"))
+
+    def test_direct_identifier_left_in_clear_is_warned_about(self):
+        self.load(cli_keep_tags="CF", known_tags=TAXONOMY)
+        self.assertTrue(any("IN CHIARO" in w and "CF" in w for w in self.warnings))
+
+    def test_no_warning_for_low_risk_tags(self):
+        self.load(cli_profile="clinical", known_tags=TAXONOMY)
+        self.assertEqual(self.warnings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ciao Simone,

questa PR risponde a due issue aperte che, guardandole insieme, chiedono la stessa cosa:
la **#31** (l'anonimizzazione indistinta di `AMOUNT` impedisce di far confrontare due importi) e
la **#41** (in ambito clinico età e sesso sono l'oggetto dello studio, non l'identificatore da
togliere).

## Il problema

Mascherare tutto è il default giusto, ma non è sempre la risposta giusta. Se il compito che si
chiede al modello di frontiera dipende proprio dai valori mascherati, il documento anonimizzato
diventa inutilizzabile: `[AMOUNT_1]` e `[AMOUNT_2]` non si confrontano, e una cartella clinica
senza età e sesso non si legge. Oggi non c'è modo di scegliere.

## Cosa fa questa PR

Un modulo `src/app/policy.py` che, per ogni tag, decide **`mask`** (placeholder reversibile — il
comportamento attuale) oppure **`keep`** (resta in chiaro). La risoluzione segue la **stessa
catena di precedenza** già usata per host/porta in `server_config`:

```
CLI  >  env (PII_PROFILE / PII_KEEP_TAGS)  >  policy.json  >  default
```

```bash
python src/app/app.py --profile clinical            # AGE, GENDER, DATE, TIME restano leggibili
python src/app/app.py --keep-tags AMOUNT            # importi confrontabili
PII_KEEP_TAGS=AGE,GENDER python src/app/app.py      # stesso effetto, da ambiente
python src/training/test_pii.py --profile clinical "..."
```

Profili preconfezionati: `full` (default, maschera tutto), `clinical` (`AGE`/`GENDER`/`DATE`/
`TIME`), `compare-amounts` (`AMOUNT`). I tag indicati esplicitamente si **aggiungono** a quelli
del profilo. Dall'app si impostano nel modale ⚙️ e — a differenza di host e porta — **si applicano
subito, senza riavvio**.

## Le scelte che vale la pena discutere

**1. Il default non cambia.** Senza configurazione si maschera tutto, esattamente come prima.

**2. `policy.json` è un file separato da `config.json`.** Non ho aggiunto una chiave `policy`
dentro `config.json` perché quel file lo riscrive anche l'app Tauri dal lato Rust come
`{"host", "port"}`: al primo salvataggio dallo splash la chiave estranea sparirebbe. Sta nella
stessa directory (`server_config.config_dir()`) e nessun codice Rust va toccato.

**3. Un'entità lasciata in chiaro resta visibile, ma fuori dal dizionario.** Esce con
`action: "keep"` e `preservation_reason: "excluded_by_config"`, conta in `n_kept` e nella
legenda, e nell'anteprima ha il bordo tratteggiato con il valore vero. Non entra nel dizionario
reversibile perché non c'è nulla da ripristinare — se ci entrasse, il tab "Ripristina" cercherebbe
un placeholder che nel testo non esiste. Il punto è che l'utente **veda** che un dato sensibile è
stato riconosciuto e deliberatamente lasciato passare: è il contrario di nasconderlo.

**4. La tassonomia valida viene dal modello caricato** (`label2id` senza il prefisso BIO) più le
label della rete regex, non da un elenco scritto a mano in un secondo file: quello sarebbe
invecchiato al primo tag nuovo. I tag non riconosciuti vengono segnalati e ignorati, non fanno
fallire l'avvio; `POST /policy` invece li rifiuta con 400 senza toccare né lo stato né il file.

**5. Lasciare in chiaro un identificatore diretto** (`FULLNAME`, `CF`, `PIVA`, `IBAN`,
`CREDITCARDNUMBER`, `ID_DOC`, `EMAIL`, `TELEPHONENUM`) **produce un avviso esplicito**, non un
divieto. È una scelta legittima dell'utente, ma non deve poter passare inosservata.

**6. Nessuna dipendenza nuova.** Configurazione in JSON (coerente con `config.json`, e
`requirements.txt` non ha PyYAML) e test con `unittest` della stdlib (non c'è pytest). Su un
progetto che si vanta di girare offline su CPU, una dipendenza in più è un costo reale.

**Nota sulla precedenza:** se `PII_KEEP_TAGS` è impostata nell'ambiente, vince sul `policy.json`
salvato dall'UI anche al riavvio successivo. È voluto ed è lo stesso comportamento di
`PII_HOST`/`PII_PORT`, ma vale la pena saperlo.

## API

| Endpoint | Cosa fa |
|---|---|
| `GET /policy` | profilo attivo, tag in chiaro, profili disponibili, tassonomia valida, tag ad alto rischio, percorso del file |
| `POST /policy` | valida, salva e **applica subito**; 400 su profilo o tag sconosciuti |
| `POST /analyze` | la risposta ora porta `policy`, `n_kept` e, per ogni entità, `action` (+ `preservation_reason` se tenuta) |

## Test

Test in `tests/`: **`unittest` della stdlib, nessuna dipendenza nuova**.
La pipeline di token-classification è sostituita da uno stub — è una dipendenza esterna, non il
codice sotto esame — quindi girano **senza torch e senza scaricare il checkpoint**, mentre la rete
regex, il merge, l'assegnazione dei placeholder e gli endpoint HTTP (via test client di Flask)
sono reali.

```bash
python -m unittest discover -s tests      # 32 test
```

Coprono: la catena di precedenza in tutte le direzioni, profilo sconosciuto, tag fuori
tassonomia, file corrotto, avviso sugli identificatori diretti, testo invariato quando ogni tag
rilevato è tenuto, entità tenuta assente dal dizionario ma presente nelle statistiche, e i
percorsi 200/400 di `POST /policy` (con la config dir dirottata su una temporanea: i test non
scrivono nella cartella di configurazione dell'utente).

Il modulo `policy.py` non importa torch né flask, quindi resta testabile e riusabile da solo.

## Impatto e convivenza con le altre PR

- **Nessun impatto sul training**: la policy agisce solo in inferenza, la tassonomia non cambia
  (era un requisito esplicito della #41).
- Su `app.py` il diff è contenuto: la policy si applica nel punto in cui si assegnano i
  placeholder, più i due endpoint e i campi nel modale.
- Il blocco "test suite" aggiunto a `CONTRIBUTING.md` è **identico** a quello dell'altra mia PR
  (detector cyber): se le prendi entrambe, git le fonde senza conflitto.

## Cosa NON fa

Niente pseudonimi che preservano la struttura (per la #31 sarebbe il passo successivo: importi o
indirizzi surrogati che conservano ordine e relazioni invece di un placeholder opaco), niente
regole per singolo valore, niente modifiche al modello. Ho preferito il pezzo più piccolo che
chiude davvero le due issue.
