### PR TITLE
fix: "Pulisci" non cancellava il dizionario PII

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,27 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-02 — "Pulisci" non cancellava il dizionario PII (`src/app/app.py`)
+
+Il bottone **Pulisci** nascondeva la card del dizionario ma lasciava i valori in `MAP` e in
+`localStorage['pii_map']`: nomi, CF e IBAN in chiaro restavano sul disco, e dall'interfaccia
+non c'era nessun modo di toglierli (`removeItem` non compariva da nessuna parte nel repo).
+
+Non è solo igiene. All'avvio il dizionario della sessione precedente viene ricaricato in `MAP`,
+quindi la guardia di `reverse()` — «Nessun dizionario: caricane uno .json» — non scatta mai:
+chi riapre l'app e incolla la risposta dell'LLM di oggi **senza** caricare il `.json` si vede
+sostituire i valori del caso precedente, con l'esito «Valori ripristinati».
+
+    dizionario rimasto sul disco: {"[FULLNAME_1]": "Mario Rossi", "[IBAN_1]": "IT60X054…"}
+    "Il ricorrente [FULLNAME_1] chiede il bonifico su [IBAN_1]."
+      ->  "Il ricorrente Mario Rossi chiede il bonifico su IT60X054…"
+
+Ora «Pulisci» azzera `MAP`, rimuove `pii_map` da `localStorage` e ripulisce l'etichetta: è
+quello che l'UI già dichiara in italiano e in inglese («il dizionario **di questa sessione**…
+se hai chiuso e riaperto l'app, **carica il dizionario .json**»). Nient'altro cambia.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -1850,6 +1850,9 @@ $('clear').onclick=()=>{$('src').value='';$('pdf').value='';$('dropTxt').innerHT
   DATA=null;$('prev').style.display='none';$('emptyPrev').style.display='';
   $('anon').value='';$('meta').innerHTML='';$('legend').innerHTML='';
   $('dictCard').style.display='none';$('ulock').textContent='';
+  // la card era solo nascosta: senza queste tre righe il dizionario resta in MAP e su
+  // disco, e al riavvio ricompare zitto al posto di quello del documento nuovo
+  MAP={};localStorage.removeItem('pii_map');$('dictInfo').textContent='';
   SRC_DOC=null;OUT_DOC=null;$('pdfSrcView').innerHTML='';$('pdfOutView').innerHTML='';
   $('srcTabs').style.display='none';$('inHint').innerHTML=tt('in_hint');
   $('inHint').style.display='';setSrcView('text');setView('prev');


### PR DESCRIPTION
Il bottone **Pulisci** nasconde la card del dizionario (`$('dictCard').style.display='none'`)
ma lascia i valori in `MAP` e in `localStorage['pii_map']`. Nomi, CF e IBAN in chiaro restano
sul disco, e dall'interfaccia non c'è modo di toglierli: `removeItem` non compare da nessuna
parte nel repo.

Non è solo igiene. All'avvio il dizionario della sessione precedente viene ricaricato in `MAP`
(`app.py`, in fondo allo script), quindi la guardia di `reverse()`

```js
if(!Object.keys(MAP).length){toast(tt('t_no_dict'),false);return;}   // "Nessun dizionario"
```

non scatta mai. Chi riapre l'app e incolla la risposta dell'LLM di oggi **senza** caricare il
`.json` si vede sostituire i valori del caso precedente, e legge «Valori ripristinati»:

```
dizionario rimasto sul disco: {"[FULLNAME_1]": "Mario Rossi", "[IBAN_1]": "IT60X054…"}
"Il ricorrente [FULLNAME_1] chiede il bonifico su [IBAN_1]."
  ->  "Il ricorrente Mario Rossi chiede il bonifico su IT60X054…"
```

È il contrario di quello che l'UI dichiara, in italiano e in inglese: «l'app rimette i valori
veri usando il dizionario **di questa sessione**. Se hai chiuso e riaperto l'app, **carica il
dizionario .json** che avevi salvato.»

## La modifica

Tre righe nel gestore di «Pulisci», che completano un'intenzione già presente lì (la card era
solo nascosta):

```js
MAP={};localStorage.removeItem('pii_map');$('dictInfo').textContent='';
```

Nient'altro cambia. I due percorsi che leggono `MAP` sono già protetti: «Scarica dizionario» e
«Ripristina» mostrano il rispettivo avviso quando è vuoto — che ora è la verità.

## Verifica

Eseguendo il JavaScript dell'UI con un DOM finto (`node`), prima e dopo:

```
prima : dopo Pulisci -> MAP ancora pieno, ancora su disco: true,  chiamate a storage: []
dopo  : dopo Pulisci -> MAP vuoto,        ancora su disco: false, chiamate: [["removeItem","pii_map"]]
```

## Una scelta, dichiarata

«Pulisci» azzera anche un dizionario caricato da `.json` nella scheda Ripristina (quel percorso
non tocca il disco). Mi è sembrato preferibile a introdurre uno stato che distingua i due casi:
il file resta sul disco dell'utente e si ricarica in un clic.

Indipendente dalla #32: parte da `main` e tocca righe diverse.
