### PR TITLE
fix: la porta poteva risultare libera mentre era occupata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,32 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — La porta poteva risultare libera mentre era occupata (`src/app/server_config.py`)
+
+`port_available()` provava a legare solo `host:porta`. Se un altro programma ascolta su
+`0.0.0.0:5005`, il bind su `127.0.0.1:5005` riesce lo stesso: il controllo diceva **libera**,
+l'app partiva, e da quel momento non è definito chi serve le connessioni — l'utente può
+ritrovarsi sul server dell'altro programma. È il sintomo riportato nella #17: «You're speaking
+plain HTTP to an SSL-enabled server port».
+
+Ora si prova a legare anche l'indirizzo jolly, **senza** `SO_REUSEADDR`: quando ce l'ha anche
+il socket dell'altro programma — Werkzeug la imposta di default, quindi vale per qualsiasi
+Flask — su Windows il bind riesce lo stesso, ed è proprio il caso da rilevare. Se il jolly
+risulta occupato si guarda, con una connessione, se qualcuno risponde davvero su `host:porta`:
+potrebbe ascoltare su un'altra interfaccia, e allora la nostra è libera.
+
+| chi occupa la porta | prima | dopo |
+|---|---|---|
+| nessuno | libera | libera |
+| `127.0.0.1:5005` | occupata | occupata |
+| **`0.0.0.0:5005`** | **libera** | **occupata** |
+| un'altra interfaccia | libera | libera |
+
+Costo: 0,12 ms a chiamata quando la porta è libera. Vale per i tre entry point (`app.py`,
+`serve.py`, `desktop_app.py`), che escono con `EXIT_PORT_CONFLICT`, e per `/port-check`.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/server_config.py
+++ b/src/app/server_config.py
@@ -176,11 +176,32 @@ def resolve(cli_host=None, cli_port=None):
 
 
 def port_available(host: str, port: int) -> bool:
-    """True se la porta e' libera (tenta un bind effimero)."""
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((host, port))
-            return True
-    except OSError:
+    """True se la porta e' libera.
+
+    Il bind del solo host non basta: se un altro programma ascolta su 0.0.0.0:PORT,
+    il bind su 127.0.0.1:PORT riesce comunque e da quel momento non e' definito chi
+    serve le connessioni - l'utente puo' finire sul server dell'altro programma.
+    Quindi si prova a legare anche l'indirizzo jolly; se e' occupato si guarda, con
+    una connessione, se qualcuno risponde davvero su host:port (potrebbe ascoltare
+    su un'altra interfaccia, e allora la nostra e' libera).
+    """
+    def _bind(addr, riusa):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if riusa:
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind((addr, port))
+                return True
+        except OSError:
+            return False
+
+    if not _bind(host, True):
         return False
+    # il jolly si prova SENZA SO_REUSEADDR: quando ce l'ha anche il socket dell'altro
+    # programma (Werkzeug la imposta di default) su Windows il bind riesce lo stesso,
+    # ed e' proprio il caso da rilevare.
+    if _bind("", False):
+        return True
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.3)
+        return s.connect_ex((host, port)) != 0


### PR DESCRIPTION
`port_available()` prova a legare solo `host:porta`. Se un altro programma ascolta su
`0.0.0.0:5005`, il bind su `127.0.0.1:5005` **riesce lo stesso**: il controllo dice «libera»,
l'app parte, e da quel momento non è definito chi serve le connessioni — l'utente può
ritrovarsi sul server dell'altro programma. È il sintomo della #17: «You're speaking plain HTTP
to an SSL-enabled server port».

Riproduzione (un secondo processo in ascolto sulla stessa porta, `port_available('127.0.0.1', P)`):

| chi occupa la porta | prima | dopo |
|---|---|---|
| nessuno | libera | libera |
| `127.0.0.1:P` | occupata | occupata |
| **`0.0.0.0:P`** | **libera** ← il difetto | **occupata** |
| un'altra interfaccia (`192.168.x.y:P`) | libera | libera |

## La modifica

Si prova a legare anche l'indirizzo jolly, **senza** `SO_REUSEADDR`: quando ce l'ha anche il
socket dell'altro programma — Werkzeug la imposta di default, quindi vale per qualsiasi Flask —
su Windows il bind riesce lo stesso, ed è proprio il caso da rilevare. Se il jolly risulta occupato non basta
concludere: qualcuno potrebbe ascoltare su un'altra interfaccia, e allora la nostra porta è
libera davvero; lo si verifica con una connessione a `host:porta`.

Costo: **0,12 ms** a chiamata quando la porta è libera — i due bind riescono e si esce
subito, la connessione non viene tentata. La sonda per connessione entra in gioco solo nel
caso ambiguo.

Tocca i tre entry point che escono con `EXIT_PORT_CONFLICT` (`app.py`, `serve.py`,
`desktop_app.py`) e `/port-check`.

## Nota

Non posso dimostrare che la macchina della #17 avesse un servizio sul jolly, quindi non
scrivo «closes #17»: il meccanismo però spiega esattamente quel messaggio, e vale la pena
escluderlo. Se vuoi te lo verifico su un caso reale.

Indipendente dalla #32 e dalla #48: file diverso.
