### PR TITLE
fix(tauri): con host localhost l'app non riconosceva mai il backend

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,32 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — Con host `localhost` l'app desktop non partiva mai (`tauri/src-tauri/src/lib.rs`)
+
+`is_our_backend()` costruiva `"{host}:{port}"` e lo passava a `parse::<SocketAddr>()`, che
+accetta **solo IP letterali**: con `host = localhost` (valore che si può scrivere nel form
+dello splash o passare in `PII_HOST`) il parse fallisce e la funzione restituisce sempre
+`false`. Il backend parte e scrive nel log che è pronto, ma `poll_backend` non lo riconosce:
+900 iterazioni × 200 ms → **~180 secondi** di splash, poi «il backend non si è avviato».
+
+Ora l'indirizzo si risolve con `to_socket_addrs()` e si provano **tutti** gli indirizzi
+restituiti, non il primo: su Windows `localhost` risolve prima `::1` e poi `127.0.0.1`, e il
+backend può ascoltare solo sul secondo. I 500 ms restano il budget dell'**intera chiamata** e
+vengono divisi fra gli indirizzi: `poll_backend` la ripete 900 volte, e senza questo l'attesa
+prima dell'errore sarebbe passata da ~10 a ~18 minuti.
+
+| host | prima | dopo |
+|---|---|---|
+| `127.0.0.1` | riconosciuto | riconosciuto |
+| **`localhost`** | **mai riconosciuto** | riconosciuto |
+| servizio estraneo sulla porta | `false` | `false` |
+| nessuno in ascolto | `false` | `false` |
+
+Il controllo che distingue il nostro Flask da un servizio estraneo (`GET /config` → il corpo
+contiene `config_path`) resta invariato.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Mutex;
@@ -104,13 +104,23 @@ fn save_config_file(host: &str, port: u16) {
 /// un altro processo, o il server non risponde come previsto, restituisce false.
 fn is_our_backend(host: &str, port: u16) -> bool {
     let addr_str = format!("{}:{}", host, port);
-    let sock_addr: std::net::SocketAddr = match addr_str.parse() {
-        Ok(a) => a,
+    // il nome va risolto: "localhost:5005".parse::<SocketAddr>() e' un errore, il parse
+    // accetta solo IP letterali. E si provano TUTTI gli indirizzi risolti, non il primo:
+    // "localhost" da' prima ::1, mentre il backend puo' ascoltare solo su 127.0.0.1.
+    let addrs: Vec<_> = match (host, port).to_socket_addrs() {
+        Ok(it) => it.collect(),
         Err(_) => return false,
     };
-    let mut stream = match TcpStream::connect_timeout(&sock_addr, Duration::from_millis(500)) {
-        Ok(s) => s,
-        Err(_) => return false,
+    // i 500 ms sono il budget dell'intera chiamata, non di ogni indirizzo: poll_backend
+    // la ripete 900 volte e la somma sarebbe l'attesa prima dell'errore.
+    let attesa = Duration::from_millis(500) / addrs.len().max(1) as u32;
+    let mut stream = match addrs
+        .into_iter()
+        .filter_map(|a| TcpStream::connect_timeout(&a, attesa).ok())
+        .next()
+    {
+        Some(s) => s,
+        None => return false,
     };
     let _ = stream.set_read_timeout(Some(Duration::from_millis(2000)));
     let req = format!(


### PR DESCRIPTION
`is_our_backend()` costruisce `"{host}:{port}"` e lo passa a `parse::<SocketAddr>()`, che
accetta **solo IP letterali**. Con `host = localhost` — valore che si può scrivere nel form
dello splash o passare in `PII_HOST` — il parse fallisce e la funzione restituisce sempre
`false`.

Il backend parte e scrive nel log che è pronto, ma `poll_backend` non lo riconosce mai: 900
iterazioni × 200 ms → **~180 secondi** di splash, poi «il backend non si è avviato».

```rust
"127.0.0.1:5005".parse::<SocketAddr>()   ->  Ok
"localhost:5005".parse::<SocketAddr>()   ->  Err(AddrParseError)   <- qui
"[::1]:5005".parse::<SocketAddr>()       ->  Ok
"::1:5005".parse::<SocketAddr>()         ->  Err(AddrParseError)
```

## La modifica

L'indirizzo si risolve con `to_socket_addrs()` e si provano **tutti** gli indirizzi
restituiti, non il primo: su Windows `localhost` risolve `["[::1]:5005", "127.0.0.1:5005"]`
in quest'ordine, e il backend può ascoltare solo sul secondo — prendere il primo non
basterebbe.

I 500 ms restano il budget dell'**intera chiamata**, divisi fra gli indirizzi: `poll_backend`
la ripete 900 volte, e misurando ho visto che senza questo l'attesa prima dell'errore sarebbe
passata da ~10 a ~18 minuti.

Il controllo che distingue il nostro Flask da un servizio estraneo (`GET /config` → il corpo
contiene `config_path`) resta invariato.

| | prima | dopo |
|---|---|---|
| `host=127.0.0.1`, backend nostro | riconosciuto | riconosciuto |
| **`host=localhost`, backend nostro** | **mai riconosciuto** | riconosciuto |
| servizio estraneo sulla porta | `false` | `false` |
| nessuno in ascolto | `false` | `false` |

## Verifica

Non ho potuto costruire il bundle Tauri. Ho estratto `is_our_backend()` dal file com'è, l'ho
compilata con `rustc` nelle due versioni e messa alla prova contro un finto backend che
risponde `config_path` e contro un servizio estraneo che risponde con un errore, con il
server in ascolto sia su `127.0.0.1` sia su `0.0.0.0`. Sono i quattro casi della tabella.

Indipendente dalle altre PR aperte: nessuna tocca `tauri/`.
