### PR TITLE
fix(data): il secondo frammento dell'augment cadeva dentro il primo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,37 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — Augment: il secondo frammento cadeva dentro il primo (`augment_real_pii.py`)
+
+`augment()` ricalcolava i confini di frase **dopo ogni inserimento**. Ma `sentence_boundaries()`
+considera confine ogni `.` o `;` etichettato `O`, e i frammenti ne contengono: il punto di
+`P.IVA`, di `prot. n.`, di `C.F.`. Così il secondo frammento veniva inserito **dentro** il
+primo, spezzandolo:
+
+    frammento: 'R . G . n . 15592 / 2018'
+    risultato: '... settembre 6º , 1961 R . G . n . IBAN IT31A9653013434814655221101 15592 / 2018'
+
+Le etichette BIO restano valide — l'entità non viene tagliata — ma il contesto sì: il modello
+vede «P.» seguito da un IBAN e impara l'associazione sbagliata, proprio sui tag che l'augment
+serve a insegnare.
+
+Ora le posizioni si scelgono **una volta sola** sul testo originale e si inserisce da destra a
+sinistra, così gli indici già scelti restano validi.
+
+Misurato su 40000 righe generate dalle frasi reali italiane di Ai4Privacy, verificando che i
+token di ogni frammento inserito restino contigui nella riga prodotta:
+
+| | prima | dopo |
+|---|---:|---:|
+| frammenti spezzati, k=2 | 9,87% | **0** |
+| frammenti spezzati, k=3 | 14,04% | **0** |
+| righe con almeno un frammento spezzato (`--max-inject 2`, il default) | 9,67% | **0** |
+
+Numero di frammenti inseriti, lunghezze e validità BIO invariati (0 anomalie). Per avere
+effetto va rigenerato l'augment: `python src/data_pipeline/augment_real_pii.py -n 40000`.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/data_pipeline/augment_real_pii.py
+++ b/src/data_pipeline/augment_real_pii.py
@@ -82,12 +82,16 @@ def sentence_boundaries(labels, tokens):
 
 
 def augment(tokens, labels, k):
-    """Inserisce k frammenti in posizioni di confine casuali (o in coda se non ce ne sono)."""
+    """Inserisce k frammenti in posizioni di confine casuali (o in coda se non ce ne sono).
+
+    Le posizioni si scelgono UNA volta sul testo originale e si inserisce da destra a
+    sinistra. Ricalcolarle dopo ogni inserimento fa cadere il frammento successivo dentro
+    il precedente: il punto di "P.IVA" o di "prot. n." e' un confine per la regola.
+    """
     toks, labs = list(tokens), list(labels)
-    for _ in range(k):
+    spots = sentence_boundaries(labs, toks) or [len(toks)]
+    for pos in sorted((random.choice(spots) for _ in range(k)), reverse=True):
         s_tok, s_lab = snippet_tokens(random.choice(INJECTION_SNIPPETS))
-        spots = sentence_boundaries(labs, toks)
-        pos = random.choice(spots) if spots else len(toks)
         toks[pos:pos] = s_tok
         labs[pos:pos] = s_lab
     return toks, labs


### PR DESCRIPTION
`augment()` ricalcola i confini di frase **dopo ogni inserimento**. Ma `sentence_boundaries()`
considera confine ogni `.` o `;` etichettato `O`, e i frammenti ne contengono: il punto di
`P.IVA`, di `prot. n.`, di `R.G. n.`. Così il secondo frammento finisce **dentro** il primo e
lo spezza:

```
frammento: 'R . G . n . 15592 / 2018'
risultato: '... settembre 6º , 1961 R . G . n . IBAN IT31A9653013434814655221101 15592 / 2018'
```

Le etichette BIO restano valide — l'entità non viene tagliata — ma il contesto sì: il modello
vede «R.G. n.» seguito da un IBAN, e impara l'associazione sbagliata proprio sui tag che
l'augment serve a insegnare.

## La modifica

Le posizioni si scelgono **una volta sola** sul testo originale e si inserisce da destra a
sinistra, così gli indici già scelti restano validi. Quattro righe, nessuna euristica.

## Misure

Chiamando la `augment()` vera sulle frasi reali italiane di Ai4Privacy e verificando che i
token di ogni frammento inserito restino contigui nella riga prodotta (40000 righe per giro):

| | prima | dopo |
|---|---:|---:|
| frammenti spezzati, k=2 | 9,87% (7892/80000) | **0** |
| frammenti spezzati, k=3 | 14,04% (16853/120000) | **0** |
| righe con almeno un frammento spezzato, `--max-inject 2` (il default) | 9,67% (3867/40000) | **0** |
| frammenti inseriti diversi da k, o `len(tokens) != len(labels)` | 0 | 0 |
| sequenze BIO non valide | 0 | 0 |

La distribuzione delle posizioni di inserimento non cambia (il file esiste per variarle):
stessi decili prima e dopo.

Per avere effetto va rigenerato l'augment:
`python src/data_pipeline/augment_real_pii.py -n 40000`.

`build_validation.py` usa `snippet_tokens` e `sentence_boundaries` ma inserisce un solo
frammento per riga: non è toccato.

Indipendente dalle altre PR aperte: nessuna tocca `augment_real_pii.py`.
