### PR TITLE
Codice fiscale omocodico: riconoscimento, sintetico e test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,46 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — Codice fiscale omocodico: riconosciuto dalla rete regex, prodotto dal sintetico
+
+Un codice fiscale **omocodico** finiva in chiaro nel testo anonimizzato.
+
+Quando due persone otterrebbero lo stesso codice, l'Agenzia delle Entrate ne differenzia uno
+sostituendo le cifre con una lettera a partire da destra (`0=L 1=M 2=N 3=P 4=Q 5=R 6=S 7=T 8=U
+9=V`) e ricalcolando il carattere di controllo. Quello che ne esce è un codice fiscale valido, e
+sui documenti compare come qualsiasi altro. In Italia i casi sono circa 24.000, con circa 1.400
+nuovi ogni anno, concentrati proprio negli atti anagrafici e fiscali.
+
+Il detector `CF` pretendeva cifre in posizione fissa
+(`[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]`), quindi un codice omocodico non diventava
+nemmeno candidato. `cf_ok()` lo avrebbe validato senza modifiche, ma non veniva mai chiamato.
+
+**1. Detector** (`app.py`). Una seconda voce `CF` in `DETECTORS` accetta `[\dLMNPQRSTUV]` nelle
+sette posizioni numeriche. È l'unica voce `CF` con `strict=True`: sulla forma ordinaria si continua
+a redigere anche quando il checksum fallisce (comportamento invariato), mentre la forma allargata da
+sola non basta a decidere, perché una parola di sedici lettere può combaciare. Lì si redige solo con
+il checksum valido.
+
+**2. Sintetico** (`generate_synthetic_pii.py`). `codice_fiscale()` accetta `omocodia=n`, cioè quante
+cifre sostituire, e `cf_piece()` ne produce una quota (`OMOCODIA_RATE = 0.05`). La quota non imita
+la frequenza reale: a quella frequenza il modello non ne incontrerebbe nessuno. Il carattere di
+controllo si calcola dopo la sostituzione, come fa l'Agenzia.
+
+Il punto cieco stava anche a monte del detector: il generatore non aveva mai prodotto un codice
+omocodico, quindi il training non ne conteneva e nessun benchmark del progetto poteva accorgersene.
+Il `CF` 567/567 della valutazione indipendente in #18 è misurato su una distribuzione che esclude il
+caso che fallisce.
+
+**3. Test** (`tests/test_cf_omocodia.py`). Dieci test senza dipendenze esterne, che coprono le sette
+profondità di sostituzione, l'ordine da destra, la tabella di conversione e il fatto che la forma
+ordinaria si comporti esattamente come prima. Il checksum è riverificato da un'implementazione
+scritta nel test e non importata dal generatore, altrimenti direbbe solo che il generatore concorda
+con se stesso. I detector vengono letti da `app.py` con `ast` invece che importati: `app.py`
+costruisce la pipeline del modello a import-time, e importarlo vorrebbe dire scaricare i pesi per
+provare una regex.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -320,6 +320,17 @@ DETECTORS = [
     ("CF",
      re.compile(r"\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b"),
      cf_ok, False),
+    # CF omocodico. Quando due persone otterrebbero lo stesso codice, l'Agenzia
+    # delle Entrate sostituisce una o piu' cifre con una lettera partendo da
+    # destra (0=L 1=M 2=N 3=P 4=Q 5=R 6=S 7=T 8=U 9=V) e RICALCOLA il carattere
+    # di controllo. La forma sopra pretende cifre in posizione fissa, quindi un
+    # codice omocodico non diventa nemmeno candidato e resta in chiaro.
+    # Qui la forma da sola non basta a decidere (una parola di 16 lettere puo'
+    # combaciare), percio' strict=True: si redige solo se il checksum passa.
+    ("CF",
+     re.compile(r"\b[A-Za-z]{6}[\dLMNPQRSTUV]{2}[A-Za-z][\dLMNPQRSTUV]{2}"
+                r"[A-Za-z][\dLMNPQRSTUV]{3}[A-Za-z]\b", re.IGNORECASE),
+     cf_ok, True),
     ("IBAN",
      re.compile(r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b"),
      iban_ok, True),

--- a/src/data_pipeline/generate_synthetic_pii.py
+++ b/src/data_pipeline/generate_synthetic_pii.py
@@ -223,11 +223,37 @@ def _name_code(s):
         code = (c + _vow(s) + list("XXX"))[:3]
     return "".join(code)
 
-def codice_fiscale(given, surname, sex, year, month, day, city):
+# Omocodia. Se due persone ottengono lo stesso codice, l'Agenzia delle Entrate ne
+# differenzia uno sostituendo le cifre con una lettera, PARTENDO DA DESTRA, e
+# ricalcolando il carattere di controllo. Le sette posizioni numeriche del corpo
+# sono anno (6,7), giorno (9,10) e la parte numerica del codice catastale (12,13,14).
+# La tabella salta I e O perche' si confondono con 1 e 0.
+OMOCODIA_MAP = str.maketrans("0123456789", "LMNPQRSTUV")
+OMOCODIA_POS = (14, 13, 12, 10, 9, 7, 6)
+
+# Quota di CF omocodici nel sintetico. Nella popolazione reale sono una rarita'
+# (~24.000 casi), ma qui la frequenza non serve a imitare la realta': serve a far
+# vedere al modello la forma. A frequenza reale non ne incontrerebbe nessuno.
+OMOCODIA_RATE = 0.05
+
+
+def _apply_omocodia(body, n):
+    """Sostituisce con la lettera corrispondente le n cifre piu' a destra del corpo."""
+    chars = list(body)
+    for pos in OMOCODIA_POS[:n]:
+        chars[pos] = chars[pos].translate(OMOCODIA_MAP)
+    return "".join(chars)
+
+
+def codice_fiscale(given, surname, sex, year, month, day, city, omocodia=0):
+    """omocodia = quante cifre sostituire (0 = codice ordinario, max 7).
+    Il carattere di controllo si calcola DOPO la sostituzione, come fa l'Agenzia."""
     belfiore = CITIES[city][0]
     dd = day + 40 if sex == "F" else day
     body = (_surname_code(surname) + _name_code(given) +
             f"{year % 100:02d}" + MONTH_LETTERS[month - 1] + f"{dd:02d}" + belfiore)
+    if omocodia:
+        body = _apply_omocodia(body, omocodia)
     tot = sum((ODD[ch] if i % 2 == 0 else _even_val(ch)) for i, ch in enumerate(body))
     return body + chr(ord("A") + tot % 26)
 
@@ -282,7 +308,8 @@ def role(label):
 def cf_piece():
     g, s, sex = _person()
     _, (d, m, y) = _date()
-    return [(codice_fiscale(g, s, sex, y, m, d, random.choice(CITY_NAMES)), "CF")]
+    n = random.randint(1, 7) if random.random() < OMOCODIA_RATE else 0
+    return [(codice_fiscale(g, s, sex, y, m, d, random.choice(CITY_NAMES), omocodia=n), "CF")]
 
 def address():
     city = random.choice(CITY_NAMES)

--- a/tests/test_cf_omocodia.py
+++ b/tests/test_cf_omocodia.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""Codice fiscale omocodico: generazione sintetica e riconoscimento nell'app.
+
+L'omocodia e' la procedura con cui l'Agenzia delle Entrate differenzia due codici
+fiscali identici: sostituisce le cifre con una lettera partendo da destra
+(0=L 1=M 2=N 3=P 4=Q 5=R 6=S 7=T 8=U 9=V) e ricalcola il carattere di controllo.
+Il codice che ne esce e' un codice fiscale valido a tutti gli effetti.
+
+I detector di `src/app/app.py` vengono letti dal sorgente con `ast` invece che
+importati: `app.py` costruisce la pipeline del modello a import-time, quindi
+importarlo qui vorrebbe dire scaricare 0.3B di pesi per provare una regex.
+"""
+
+import ast
+import random
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "data_pipeline"))
+
+import generate_synthetic_pii as gen
+
+
+# --------------------------------------------------------------------------- #
+# Verificatore di checksum indipendente.
+# Riscritto qui dalla specifica e non importato dal generatore: se lo prendessimo
+# in prestito da lui, il test direbbe solo che il generatore concorda con se stesso.
+# --------------------------------------------------------------------------- #
+_ODD = {"0": 1, "1": 0, "2": 5, "3": 7, "4": 9, "5": 13, "6": 15, "7": 17, "8": 19,
+        "9": 21, "A": 1, "B": 0, "C": 5, "D": 7, "E": 9, "F": 13, "G": 15, "H": 17,
+        "I": 19, "J": 21, "K": 2, "L": 4, "M": 18, "N": 20, "O": 11, "P": 3, "Q": 6,
+        "R": 8, "S": 12, "T": 14, "U": 16, "V": 10, "W": 22, "X": 25, "Y": 24, "Z": 23}
+
+
+def cf_checksum_ok(code):
+    code = code.strip().upper()
+    if len(code) != 16 or not code.isalnum():
+        return False
+    total = 0
+    for i, ch in enumerate(code[:15]):
+        if i % 2 == 0:
+            if ch not in _ODD:
+                return False
+            total += _ODD[ch]
+        else:
+            total += int(ch) if ch.isdigit() else ord(ch) - 65
+    return chr(65 + total % 26) == code[15]
+
+
+# --------------------------------------------------------------------------- #
+# I detector CF veri, estratti da app.py senza importarlo.
+# --------------------------------------------------------------------------- #
+def _load_cf_detectors():
+    """[(regex compilata, strict), ...] per le voci CF di DETECTORS in app.py."""
+    tree = ast.parse((ROOT / "src" / "app" / "app.py").read_text(encoding="utf-8"))
+    detectors = next(
+        node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", None) == "DETECTORS" for t in node.targets)
+    )
+    out = []
+    for entry in detectors.elts:
+        label, call, _validator, strict = entry.elts
+        if label.value != "CF":
+            continue
+        flags = 0
+        for flag in call.args[1:]:
+            flags |= getattr(re, flag.attr)
+        out.append((re.compile(call.args[0].value, flags), strict.value))
+    return out
+
+
+CF_DETECTORS = _load_cf_detectors()
+
+
+def app_would_redact(text):
+    """True se la rete regex dell'app sostituirebbe `text` come CF.
+
+    Riproduce la sola regola di `detect_regex`: con strict=True il match si scarta
+    quando il checksum fallisce, con strict=False si redige comunque.
+    """
+    for rx, strict in CF_DETECTORS:
+        match = rx.search(text)
+        if not match:
+            continue
+        if strict and not cf_checksum_ok(match.group(0)):
+            continue
+        return True
+    return False
+
+
+def make_cf(omocodia=0, seed=0):
+    rnd = random.Random(seed)
+    city = rnd.choice(gen.CITY_NAMES)
+    return gen.codice_fiscale("Mario", "Rossi", "M", 1985, 6, 12, city, omocodia=omocodia)
+
+
+class OmocodiaGeneration(unittest.TestCase):
+    def test_ordinary_code_is_unchanged(self):
+        code = make_cf(omocodia=0)
+        self.assertTrue(cf_checksum_ok(code))
+        self.assertRegex(code, r"^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$")
+
+    def test_every_substitution_depth_stays_valid(self):
+        for n in range(1, 8):
+            with self.subTest(sostituzioni=n):
+                code = make_cf(omocodia=n)
+                self.assertTrue(cf_checksum_ok(code),
+                                f"checksum non ricalcolato per {n} sostituzioni: {code}")
+
+    def test_substitution_runs_right_to_left(self):
+        ordinary = make_cf(omocodia=0)
+        for n in range(1, 8):
+            code = make_cf(omocodia=n)
+            changed = [i for i in range(15) if code[i] != ordinary[i]]
+            self.assertEqual(sorted(changed), sorted(gen.OMOCODIA_POS[:n]),
+                             f"posizioni sbagliate con {n} sostituzioni")
+
+    def test_substituted_characters_follow_the_table(self):
+        ordinary = make_cf(omocodia=0)
+        code = make_cf(omocodia=7)
+        for pos in gen.OMOCODIA_POS:
+            self.assertEqual(code[pos], "LMNPQRSTUV"[int(ordinary[pos])])
+
+    def test_generator_emits_some_omocodic_codes(self):
+        random.seed(20260803)
+        codes = [gen.cf_piece()[0][0] for _ in range(2000)]
+        omocodic = [c for c in codes if not c[6:8].isdigit() or not c[12:15].isdigit()]
+        self.assertTrue(omocodic, "nessun CF omocodico in 2000 estrazioni")
+        for code in codes:
+            self.assertTrue(cf_checksum_ok(code), f"CF non valido: {code}")
+
+
+class OmocodiaDetection(unittest.TestCase):
+    def test_app_has_a_detector_for_the_omocodic_shape(self):
+        self.assertGreaterEqual(len(CF_DETECTORS), 2,
+                                "manca il detector per la forma omocodica")
+
+    def test_ordinary_code_is_still_redacted(self):
+        self.assertTrue(app_would_redact(f"C.F. {make_cf(omocodia=0)} residente in Roma"))
+
+    def test_omocodic_code_is_redacted(self):
+        for n in range(1, 8):
+            code = make_cf(omocodia=n)
+            with self.subTest(sostituzioni=n, cf=code):
+                self.assertTrue(app_would_redact(f"C.F. {code} residente in Roma"),
+                                f"CF omocodico lasciato in chiaro: {code}")
+
+    def test_malformed_code_of_the_same_shape_is_not_redacted(self):
+        """La forma omocodica da sola non basta: senza checksum non si redige.
+
+        Serve a tenere onesto l'allargamento della regex — una parola di sedici
+        lettere che combacia con la forma non deve diventare un CF.
+        """
+        code = make_cf(omocodia=7)
+        wrong = code[:15] + ("A" if code[15] != "A" else "B")
+        self.assertFalse(cf_checksum_ok(wrong))
+        self.assertFalse(app_would_redact(f"riferimento {wrong} in atti"))
+
+    def test_ordinary_code_with_broken_checksum_is_still_redacted(self):
+        """Comportamento storico invariato: sulla forma ordinaria si redige comunque."""
+        code = make_cf(omocodia=0)
+        wrong = code[:15] + ("A" if code[15] != "A" else "B")
+        self.assertFalse(cf_checksum_ok(wrong))
+        self.assertTrue(app_would_redact(f"C.F. {wrong} in atti"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Chiude #55.

La rete regex e checksum lascia passare i codici fiscali omocodici. Il detector `CF` pretende cifre
in posizione fissa, quindi il codice non diventa nemmeno candidato, e `cf_ok()`, che lo validerebbe
senza modifiche, non viene mai chiamato. Riproduzione e contesto nella issue.

Tre commit separati, così puoi prenderne una parte sola.

**`fix(app)`** aggiunge una seconda voce `CF` a `DETECTORS`, che accetta `[\dLMNPQRSTUV]` nelle sette
posizioni numeriche. È l'unica voce `CF` con `strict=True`: la forma allargata da sola non basta a
decidere, perché una parola di sedici lettere può combaciare, quindi lì si redige solo con il
checksum valido. Sulla forma ordinaria il comportamento è invariato, compreso il fatto che si rediga
anche quando il checksum fallisce.

**`feat(data)`** dà a `codice_fiscale()` il parametro `omocodia=n` e fa produrre a `cf_piece()` una
quota di codici omocodici (`OMOCODIA_RATE = 0.05`). Il carattere di controllo si calcola dopo la
sostituzione, come fa l'Agenzia. La quota non imita la frequenza reale, che nel training si
tradurrebbe in nessun esempio. Questo è l'unico commit con impatto sui dati: se preferisci decidere
tu la quota, o rimandarlo, si stacca da solo.

**`test`** aggiunge `tests/test_cf_omocodia.py`: dieci test, nessuna dipendenza esterna, 13 ms.
Coprono le sette profondità di sostituzione, l'ordine da destra, la tabella di conversione, e due
casi che presidiano il comportamento esistente sulla forma ordinaria.

## Verifica

Sul codice attuale i test falliscono su tutte e sette le profondità di sostituzione; con la fix
passano. I due test che presidiano il comportamento esistente passano in entrambi gli stati, quindi
la modifica non tocca quello che già funzionava.

```
$ python -m unittest discover -s tests
Ran 15 tests in 0.013s

OK
```

## Due scelte che vale la pena spiegare

Il checksum è riverificato da un'implementazione scritta dentro il test invece che importata dal
generatore. Prendendola in prestito, il test direbbe soltanto che il generatore concorda con se
stesso.

I detector si leggono da `app.py` con `ast` invece di importare il modulo. `app.py` costruisce la
pipeline del modello a import-time, quindi importarlo in un test vorrebbe dire scaricare i pesi per
provare una regex. Se la rete regex venisse estratta in un modulo suo, come propone la #19, questa
parte del test si riduce a un import.
