### PR TITLE
fix(app): detect IBAN, CF, card and phone in the formats used in real documents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: tests
+
+# Su main e su ogni pull request. Il push e' filtrato su main apposta: senza il
+# filtro un branch aperto nello stesso repo farebbe girare due volte lo stesso
+# job, una per il push e una per la PR.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.11 e' il minimo dichiarato in requirements.txt, 3.14 la piu' recente.
+        python-version: ["3.11", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Nessun pip install: la suite in tests/ gira sulla sola libreria
+      # standard. I generatori di dati (src/data_pipeline/) non hanno
+      # dipendenze e src/app/detectors.py non importa torch/transformers/fitz,
+      # quindi la rete regex+checksum e' verificabile senza il modello.
+      # Installare torch qui costerebbe minuti e gigabyte per zero copertura
+      # in piu': l'inferenza del modello non e' sotto test.
+      - name: unittest discover
+        run: python -m unittest discover -v tests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,46 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 - Rete regex: i formati con cui gli identificativi sono stampati
+
+La rete regex+checksum copriva la **forma compatta** degli identificativi ma non quella
+**stampata sui documenti**, e i due insiemi non coincidono. Un IBAN su una fattura o su una
+carta intestata è scritto a gruppi di quattro (`IT60 X054 2811 …`), un codice fiscale può
+essere **omocodico** (le cifre sostituite da lettere quando due contribuenti collidono), una
+carta è separata anche da punti, un telefono anche da trattini. Nessuno di questi veniva
+rilevato. I **validatori erano già corretti** su tutti quei valori: `iban_ok` normalizza gli
+spazi come prima cosa, `cf_ok` calcola l'omocodia, `luhn_ok` scarta i non-numeri. Erano le
+regex a non passargli mai un caso con i separatori, e su IBAN/PIVA/carta `strict=True`
+significa che **non esiste fallback**: senza checksum il valore resta in chiaro.
+
+Le regex ora accettano i separatori che i validatori già normalizzavano. Sull'IBAN i gruppi
+dopo il primo devono contenere almeno una cifra, altrimenti il match ingloberebbe la parola
+successiva e il mod-97 farebbe cadere tutto; `iban_ok` normalizza ora **gli stessi**
+separatori che la regex ammette, altrimenti il resto non servirebbe a niente. Il CF omocodico
+è una **voce a parte** con `strict=True`, non un allargamento della voce esistente: quella è
+`strict=False` e redige sulla sola forma, e sette posizioni che accettano lettere sarebbero
+troppo generiche per fidarsi. Sulla carta il match termina ora per forza su una cifra, così il
+punto di fine frase non entra nel placeholder.
+
+La rete è stata spostata in **`src/app/detectors.py`**, stesso principio già applicato a
+`pdf_export.py`: nessun import di `torch`/`transformers`/`fitz`, quindi è verificabile in
+isolamento. Prima non lo era, perché importare `app.py` carica il modello. `app.py` ri-esporta
+i nomi, il comportamento pubblico non cambia. Aggiunti `tests/test_detector_formats.py`
+(39 casi, valori sintetici) e una **CI** che esegue `python -m unittest discover tests` senza
+installare nulla. Su 200.000 documenti di `generate_synthetic_pii.py` le entità già rilevate
+restano identiche e le rilevazioni su span non-PII non aumentano; riformattando gli stessi
+identificativi come su un documento vero si passa da 0 a 7.830 IBAN, 24.304 CF e 16.070
+telefoni.
+
+Il costo è che i due separatori aggiunti ereditano l'esposizione che gli altri avevano già,
+e non di più: una sequenza di 13-19 cifre separate da punti diventa candidata carta e supera
+Luhn per caso in circa un caso su dieci (misurato: 493 su 5.000, contro 488 con lo spazio e
+480 col trattino, invariati); un numero amministrativo scritto `0521-123456` viene letto come
+telefono, esattamente come già accadeva per `0521.123456` e `0521 123456`. Nessun impatto sul
+training e nessuna modifica alla tassonomia.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -58,6 +58,10 @@ from flask import (Flask, jsonify, render_template_string, request,
 
 import pdf_export
 import server_config
+# Rete REGEX + CHECKSUM: modulo a parte, senza dipendenze dal modello. I nomi
+# restano importabili da qui (`app.detect_regex`) per non rompere chi li usa.
+from detectors import (DETECTORS, cf_ok, detect_regex, iban_ok,  # noqa: F401
+                       luhn_ok, piva_ok)
 from transformers import pipeline
 
 
@@ -240,150 +244,6 @@ TAG_NAMES = [t[0] for t in TAGS]
 _prefs = server_config.load_prefs()
 EXCLUDED_TAGS = _prefs["excluded_tags"]
 MAPPING_ENABLED = _prefs["mapping_enabled"]
-
-
-# --------------------------------------------------------------------------- #
-# Rete REGEX + CHECKSUM (affianca il modello)
-# --------------------------------------------------------------------------- #
-def iban_ok(s):
-    s = re.sub(r"\s", "", s).upper()
-    if not (15 <= len(s) <= 34):
-        return False
-    r = s[4:] + s[:4]
-    try:
-        n = int("".join(str(ord(c) - 55) if c.isalpha() else c for c in r))
-    except ValueError:
-        return False
-    return n % 97 == 1
-
-
-def piva_ok(p):
-    p = re.sub(r"\D", "", p)
-    if len(p) != 11:
-        return False
-    t = 0
-    for i, c in enumerate(map(int, p[:10])):
-        if i % 2 == 0:
-            t += c
-        else:
-            x = c * 2
-            t += x - 9 if x > 9 else x
-    return (10 - t % 10) % 10 == int(p[10])
-
-
-_CF_ODD = {"0": 1, "1": 0, "2": 5, "3": 7, "4": 9, "5": 13, "6": 15, "7": 17, "8": 19,
-           "9": 21, "A": 1, "B": 0, "C": 5, "D": 7, "E": 9, "F": 13, "G": 15, "H": 17,
-           "I": 19, "J": 21, "K": 2, "L": 4, "M": 18, "N": 20, "O": 11, "P": 3, "Q": 6,
-           "R": 8, "S": 12, "T": 14, "U": 16, "V": 10, "W": 22, "X": 25, "Y": 24, "Z": 23}
-
-
-def cf_ok(c):
-    c = c.strip().upper()
-    if len(c) != 16 or not c.isalnum():
-        return False
-    b = c[:15]
-    try:
-        t = sum((_CF_ODD[ch] if i % 2 == 0
-                 else (int(ch) if ch.isdigit() else ord(ch) - 65))
-                for i, ch in enumerate(b))
-    except KeyError:
-        return False
-    return chr(65 + t % 26) == c[15]
-
-
-def luhn_ok(s):
-    d = re.sub(r"\D", "", s)
-    if not (13 <= len(d) <= 19):
-        return False
-    tot, alt = 0, False
-    for ch in reversed(d):
-        n = int(ch)
-        if alt:
-            n *= 2
-            if n > 9:
-                n -= 9
-        tot += n
-        alt = not alt
-    return tot % 10 == 0
-
-
-# Ogni detector: (label, regex, validatore-o-None, strict).
-#   validatore None  -> match accettato sulla sola forma (validated=False).
-#   strict=True      -> il match si scarta se il checksum FALLISCE (forma troppo generica:
-#                       IBAN/PIVA/carta -> servono i numeri giusti per non avere falsi positivi).
-#   strict=False     -> si redige comunque (forma molto specifica, es. CF: meglio nascondere);
-#                       validated=True solo se il checksum passa (mette il ✓).
-DETECTORS = [
-    ("EMAIL",
-     re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"),
-     None, True),
-    ("CF",
-     re.compile(r"\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b"),
-     cf_ok, False),
-    ("IBAN",
-     re.compile(r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b"),
-     iban_ok, True),
-    ("CREDITCARDNUMBER",
-     re.compile(r"(?<!\d)(?:\d[ \-]?){13,19}(?!\d)"),
-     luhn_ok, True),
-    ("PIVA",
-     re.compile(r"(?<!\d)\d{11}(?!\d)"),
-     piva_ok, True),
-    ("TELEPHONENUM",
-     re.compile(r"(?<![\w.])(?:\+39[\s.]?)?(?:3\d{2}[\s.]?\d{3}[\s.]?\d{3,4}"
-                r"|0\d{1,3}[\s.]?\d{5,8})(?![\w])"),
-     None, True),
-    ("AMOUNT",
-     re.compile(r"(?:€|EUR|euro)\s?\d{1,3}(?:[.\s]\d{3})*(?:,\d{2})?"
-                r"|\d{1,3}(?:\.\d{3})*,\d{2}\s?(?:€|EUR|euro)", re.IGNORECASE),
-     None, True),
-    ("TARGA",
-     re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b"),
-     None, True),
-    # URL: tre forme, dalla piu' esplicita alla piu' rischiosa.
-    #   1) con schema (http/https/ftp)     -> sempre un URL
-    #   2) www.<dominio>                   -> sempre un URL
-    #   3) dominio nudo, ma SOLO con un TLD della lista chiusa qui sotto.
-    # Il dominio nudo generico (r"\w+\.\w{2,}") non si puo' usare: nel legalese
-    # italiano prenderebbe "p.iva", "n.ro", "S.r.l." e simili. Con la lista chiusa
-    # "p.iva" non matcha ("iva" non e' un TLD) e i falsi positivi crollano.
-    # Prezzo del compromesso: un dominio con TLD esotico resta in chiaro.
-    ("URL",
-     re.compile(r"(?:https?|ftp)://[^\s<>\"']+"
-                r"|www\.[A-Za-z0-9\-._~%]+\.[A-Za-z]{2,}(?:/[^\s<>\"']*)?"
-                r"|\b(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?\.)+"
-                r"(?:it|com|net|org|eu|info|io|dev|app|gov|edu|cloud|online|site|blog)"
-                r"\b(?:/[^\s<>\"']*)?", re.IGNORECASE),
-     None, True),
-]
-
-# Punteggiatura che chiude la frase e non fa parte dell'URL: "vedi https://x.it/pagina."
-_URL_TRAIL = ".,;:!?)]}»\"'"
-
-
-def detect_regex(text):
-    """Entita' della rete regex. validated=True solo quando il checksum passa."""
-    ents = []
-    for label, rx, validator, strict in DETECTORS:
-        for m in rx.finditer(text):
-            start, end = m.start(), m.end()
-            if label == "URL":
-                while end > start and text[end - 1] in _URL_TRAIL:
-                    end -= 1
-                if end <= start:
-                    continue
-            ok = validator(m.group(0)) if validator else False
-            if validator and strict and not ok:
-                continue
-            ents.append({
-                "label": label,
-                "start": start,
-                "end": end,
-                "score": 1.0 if ok else 0.9,
-                "validated": ok,
-                "source": "regex",
-            })
-    return ents
 
 
 # --------------------------------------------------------------------------- #

--- a/src/app/detectors.py
+++ b/src/app/detectors.py
@@ -6,13 +6,23 @@ carta di credito, importo, targa, URL).
 Come `pdf_export`, questo modulo lavora solo su stringhe: nessun import di
 torch/transformers/fitz, quindi e' testabile in isolamento e senza il modello.
 `app.py` ne ri-esporta i nomi, il comportamento pubblico non cambia.
+
+Le regex accettano i separatori con cui gli identificativi sono STAMPATI nei
+documenti, non solo la forma compatta: un IBAN su una fattura o su una carta
+intestata e' raggruppato a quattro, una carta di credito e' separata da spazi,
+trattini o punti, un telefono da spazi, punti o trattini. I validatori
+normalizzano gia' i separatori: se la regex non gliene passa mai uno il
+checksum non viene nemmeno interrogato e, dove `strict=True`, il valore resta
+in chiaro senza alcun fallback.
 """
 
 import re
 
 
 def iban_ok(s):
-    s = re.sub(r"\s", "", s).upper()
+    # Si normalizzano gli stessi separatori che la regex ammette: spazio (anche
+    # non-breaking, e gli a-capo del testo estratto da un PDF), punto, trattino.
+    s = re.sub(r"[\s.\-]", "", s).upper()
     if not (15 <= len(s) <= 34):
         return False
     r = s[4:] + s[:4]
@@ -86,18 +96,49 @@ DETECTORS = [
     ("CF",
      re.compile(r"\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b"),
      cf_ok, False),
+    # CF OMOCODICO: quando due contribuenti collidono, l'Agenzia sostituisce le
+    # cifre da destra con una lettera (0->L 1->M 2->N 3->P 4->Q 5->R 6->S 7->T
+    # 8->U 9->V), quindi la forma sopra non lo trova. Voce separata e non classe
+    # allargata sulla precedente: qui la forma da sola e' troppo generica (sette
+    # posizioni che accettano lettere), percio' strict=True e il checksum
+    # diventa obbligatorio. `cf_ok` gia' calcola l'omocodia. La forma canonica
+    # matcha entrambe le voci, ma sullo stesso span: `_merge` tiene il candidato
+    # validato e scarta il duplicato.
+    ("CF",
+     re.compile(r"\b[A-Za-z]{6}[\dLMNPQRSTUVlmnpqrstuv]{2}[A-Za-z]"
+                r"[\dLMNPQRSTUVlmnpqrstuv]{2}[A-Za-z]"
+                r"[\dLMNPQRSTUVlmnpqrstuv]{3}[A-Za-z]\b"),
+     cf_ok, True),
+    # IBAN: forma compatta, oppure raggruppata a quattro come e' stampata su
+    # fatture, carte intestate e home banking. Il gruppo intermedio e quello
+    # finale devono contenere almeno una cifra: senza quel vincolo il match
+    # goloso inghiottirebbe la parola successiva ("...0005 1332 pago"), il
+    # mod-97 fallirebbe e con strict=True l'IBAN si perderebbe del tutto.
     ("IBAN",
-     re.compile(r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b"),
+     re.compile(r"\b[A-Za-z]{2}\d{2}"
+                r"(?:[A-Za-z0-9]{11,30}"
+                r"|[\s.\-][A-Za-z0-9]{4}"
+                r"(?:[\s.\-](?=[A-Za-z0-9]{0,3}\d)[A-Za-z0-9]{4}){1,6}"
+                r"(?:[\s.\-](?=[A-Za-z0-9]{0,3}\d)[A-Za-z0-9]{1,4})?)\b"),
      iban_ok, True),
+    # Carta: al gruppo dei separatori si aggiunge il punto ("4111.1111...").
+    # Qui NON si usa \s: a differenza dell'IBAN il vincolo e' il solo Luhn (una
+    # sequenza qualunque lo supera una volta su dieci) e con l'a-capo una
+    # colonna di numeri in tabella diventerebbe un candidato.
+    # Il match ora finisce per forza su una CIFRA: con il separatore in coda
+    # ("(?:\d[ .\-]?){13,19}") il punto che chiude la frase entrerebbe nello
+    # span e finirebbe dentro il placeholder.
     ("CREDITCARDNUMBER",
-     re.compile(r"(?<!\d)(?:\d[ \-]?){13,19}(?!\d)"),
+     re.compile(r"(?<!\d)\d(?:[ .\-]?\d){12,18}(?!\d)"),
      luhn_ok, True),
     ("PIVA",
      re.compile(r"(?<!\d)\d{11}(?!\d)"),
      piva_ok, True),
+    # Telefono: al gruppo dei separatori si aggiunge il trattino, usatissimo sia
+    # sul cellulare ("333-123-4567") sia sul fisso ("010-2471234").
     ("TELEPHONENUM",
-     re.compile(r"(?<![\w.])(?:\+39[\s.]?)?(?:3\d{2}[\s.]?\d{3}[\s.]?\d{3,4}"
-                r"|0\d{1,3}[\s.]?\d{5,8})(?![\w])"),
+     re.compile(r"(?<![\w.])(?:\+39[\s.\-]?)?(?:3\d{2}[\s.\-]?\d{3}[\s.\-]?\d{3,4}"
+                r"|0\d{1,3}[\s.\-]?\d{5,8})(?![\w])"),
      None, True),
     ("AMOUNT",
      re.compile(r"(?:€|EUR|euro)\s?\d{1,3}(?:[.\s]\d{3})*(?:,\d{2})?"

--- a/src/app/detectors.py
+++ b/src/app/detectors.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+Rete REGEX + CHECKSUM che affianca il modello (EMAIL, TELEFONO, IBAN, CF, PIVA,
+carta di credito, importo, targa, URL).
+
+Come `pdf_export`, questo modulo lavora solo su stringhe: nessun import di
+torch/transformers/fitz, quindi e' testabile in isolamento e senza il modello.
+`app.py` ne ri-esporta i nomi, il comportamento pubblico non cambia.
+"""
+
+import re
+
+
+def iban_ok(s):
+    s = re.sub(r"\s", "", s).upper()
+    if not (15 <= len(s) <= 34):
+        return False
+    r = s[4:] + s[:4]
+    try:
+        n = int("".join(str(ord(c) - 55) if c.isalpha() else c for c in r))
+    except ValueError:
+        return False
+    return n % 97 == 1
+
+
+def piva_ok(p):
+    p = re.sub(r"\D", "", p)
+    if len(p) != 11:
+        return False
+    t = 0
+    for i, c in enumerate(map(int, p[:10])):
+        if i % 2 == 0:
+            t += c
+        else:
+            x = c * 2
+            t += x - 9 if x > 9 else x
+    return (10 - t % 10) % 10 == int(p[10])
+
+
+_CF_ODD = {"0": 1, "1": 0, "2": 5, "3": 7, "4": 9, "5": 13, "6": 15, "7": 17, "8": 19,
+           "9": 21, "A": 1, "B": 0, "C": 5, "D": 7, "E": 9, "F": 13, "G": 15, "H": 17,
+           "I": 19, "J": 21, "K": 2, "L": 4, "M": 18, "N": 20, "O": 11, "P": 3, "Q": 6,
+           "R": 8, "S": 12, "T": 14, "U": 16, "V": 10, "W": 22, "X": 25, "Y": 24, "Z": 23}
+
+
+def cf_ok(c):
+    c = c.strip().upper()
+    if len(c) != 16 or not c.isalnum():
+        return False
+    b = c[:15]
+    try:
+        t = sum((_CF_ODD[ch] if i % 2 == 0
+                 else (int(ch) if ch.isdigit() else ord(ch) - 65))
+                for i, ch in enumerate(b))
+    except KeyError:
+        return False
+    return chr(65 + t % 26) == c[15]
+
+
+def luhn_ok(s):
+    d = re.sub(r"\D", "", s)
+    if not (13 <= len(d) <= 19):
+        return False
+    tot, alt = 0, False
+    for ch in reversed(d):
+        n = int(ch)
+        if alt:
+            n *= 2
+            if n > 9:
+                n -= 9
+        tot += n
+        alt = not alt
+    return tot % 10 == 0
+
+
+# Ogni detector: (label, regex, validatore-o-None, strict).
+#   validatore None  -> match accettato sulla sola forma (validated=False).
+#   strict=True      -> il match si scarta se il checksum FALLISCE (forma troppo generica:
+#                       IBAN/PIVA/carta -> servono i numeri giusti per non avere falsi positivi).
+#   strict=False     -> si redige comunque (forma molto specifica, es. CF: meglio nascondere);
+#                       validated=True solo se il checksum passa (mette il ✓).
+DETECTORS = [
+    ("EMAIL",
+     re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"),
+     None, True),
+    ("CF",
+     re.compile(r"\b[A-Za-z]{6}\d{2}[A-Za-z]\d{2}[A-Za-z]\d{3}[A-Za-z]\b"),
+     cf_ok, False),
+    ("IBAN",
+     re.compile(r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b"),
+     iban_ok, True),
+    ("CREDITCARDNUMBER",
+     re.compile(r"(?<!\d)(?:\d[ \-]?){13,19}(?!\d)"),
+     luhn_ok, True),
+    ("PIVA",
+     re.compile(r"(?<!\d)\d{11}(?!\d)"),
+     piva_ok, True),
+    ("TELEPHONENUM",
+     re.compile(r"(?<![\w.])(?:\+39[\s.]?)?(?:3\d{2}[\s.]?\d{3}[\s.]?\d{3,4}"
+                r"|0\d{1,3}[\s.]?\d{5,8})(?![\w])"),
+     None, True),
+    ("AMOUNT",
+     re.compile(r"(?:€|EUR|euro)\s?\d{1,3}(?:[.\s]\d{3})*(?:,\d{2})?"
+                r"|\d{1,3}(?:\.\d{3})*,\d{2}\s?(?:€|EUR|euro)", re.IGNORECASE),
+     None, True),
+    ("TARGA",
+     re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b"),
+     None, True),
+    # URL: tre forme, dalla piu' esplicita alla piu' rischiosa.
+    #   1) con schema (http/https/ftp)     -> sempre un URL
+    #   2) www.<dominio>                   -> sempre un URL
+    #   3) dominio nudo, ma SOLO con un TLD della lista chiusa qui sotto.
+    # Il dominio nudo generico (r"\w+\.\w{2,}") non si puo' usare: nel legalese
+    # italiano prenderebbe "p.iva", "n.ro", "S.r.l." e simili. Con la lista chiusa
+    # "p.iva" non matcha ("iva" non e' un TLD) e i falsi positivi crollano.
+    # Prezzo del compromesso: un dominio con TLD esotico resta in chiaro.
+    ("URL",
+     re.compile(r"(?:https?|ftp)://[^\s<>\"']+"
+                r"|www\.[A-Za-z0-9\-._~%]+\.[A-Za-z]{2,}(?:/[^\s<>\"']*)?"
+                r"|\b(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?\.)+"
+                r"(?:it|com|net|org|eu|info|io|dev|app|gov|edu|cloud|online|site|blog)"
+                r"\b(?:/[^\s<>\"']*)?", re.IGNORECASE),
+     None, True),
+]
+
+# Punteggiatura che chiude la frase e non fa parte dell'URL: "vedi https://x.it/pagina."
+_URL_TRAIL = ".,;:!?)]}»\"'"
+
+
+def detect_regex(text):
+    """Entita' della rete regex. validated=True solo quando il checksum passa."""
+    ents = []
+    for label, rx, validator, strict in DETECTORS:
+        for m in rx.finditer(text):
+            start, end = m.start(), m.end()
+            if label == "URL":
+                while end > start and text[end - 1] in _URL_TRAIL:
+                    end -= 1
+                if end <= start:
+                    continue
+            ok = validator(m.group(0)) if validator else False
+            if validator and strict and not ok:
+                continue
+            ents.append({
+                "label": label,
+                "start": start,
+                "end": end,
+                "score": 1.0 if ok else 0.9,
+                "validated": ok,
+                "source": "regex",
+            })
+    return ents
+
+

--- a/tests/test_detector_formats.py
+++ b/tests/test_detector_formats.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""Formati reali per la rete regex+checksum di src/app/detectors.py.
+
+Ogni caso e' un identificativo scritto come lo si trova STAMPATO in un
+documento italiano: l'IBAN raggruppato a quattro di una fattura, un codice
+fiscale omocodico, una carta separata da punti, un telefono con i trattini.
+Tutti i valori sono SINTETICI e hanno checksum calcolati apposta.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+import detectors  # noqa: E402
+
+
+def spans(text, label):
+    """Sottostringhe rilevate da detect_regex per quel tag."""
+    return [text[e["start"]:e["end"]]
+            for e in detectors.detect_regex(text) if e["label"] == label]
+
+
+def validated(text, label):
+    """Sottostringhe rilevate E con checksum verificato."""
+    return [text[e["start"]:e["end"]]
+            for e in detectors.detect_regex(text)
+            if e["label"] == label and e["validated"]]
+
+
+# (nome del caso, testo, tag, valore che deve essere rilevato)
+POSITIVI = [
+    # IBAN: mod-97 obbligatorio (strict), quindi la regex deve arrivare al
+    # validatore anche quando il numero e' stampato con i separatori.
+    ("iban_compatto", "Bonifico su IT60X0542811101000000123456 entro il 30/09.",
+     "IBAN", "IT60X0542811101000000123456"),
+    ("iban_gruppi_di_4", "IBAN IT60 X054 2811 1010 0000 0123 456 presso la filiale.",
+     "IBAN", "IT60 X054 2811 1010 0000 0123 456"),
+    ("iban_con_trattini", "IBAN: IT60-X054-2811-1010-0000-0123-456.",
+     "IBAN", "IT60-X054-2811-1010-0000-0123-456"),
+    ("iban_minuscolo", "iban it60x0542811101000000123456 intestato allo studio.",
+     "IBAN", "it60x0542811101000000123456"),
+    ("iban_estero_gruppi", "Accredito su ES91 2100 0418 4502 0005 1332.",
+     "IBAN", "ES91 2100 0418 4502 0005 1332"),
+    # Il testo estratto da un PDF non usa sempre lo spazio semplice.
+    ("iban_spazi_non_breaking",
+     "IBAN IT60\xa0X054\xa02811\xa01010\xa00000\xa00123\xa0456 della filiale.",
+     "IBAN", "IT60\xa0X054\xa02811\xa01010\xa00000\xa00123\xa0456"),
+    ("iban_a_capo_nel_pdf",
+     "Coordinate: IT60 X054 2811\n1010 0000 0123 456 presso la filiale.",
+     "IBAN", "IT60 X054 2811\n1010 0000 0123 456"),
+    # Codice fiscale, forma canonica e forma omocodica (le cifre diventano
+    # 0->L 1->M 2->N 3->P 4->Q 5->R 6->S 7->T 8->U 9->V).
+    ("cf_canonico", "Il sig. Rossi, C.F. RSSMRA85H12F205Y, dichiara.",
+     "CF", "RSSMRA85H12F205Y"),
+    ("cf_omocodia_2_cifre", "Il sig. Rossi, C.F. RSSMRA85H12F2LRE, dichiara.",
+     "CF", "RSSMRA85H12F2LRE"),
+    ("cf_omocodia_1_cifra", "Codice fiscale BNCLCU90A41H50MO del richiedente.",
+     "CF", "BNCLCU90A41H50MO"),
+    ("cf_minuscolo", "codice fiscale rssmra85h12f205y del ricorrente.",
+     "CF", "rssmra85h12f205y"),
+    # Carta di credito: Luhn obbligatorio (strict).
+    ("carta_spazi", "Pagamento con carta 4111 1111 1111 1111.",
+     "CREDITCARDNUMBER", "4111 1111 1111 1111"),
+    ("carta_trattini", "Pagamento con carta 4111-1111-1111-1111.",
+     "CREDITCARDNUMBER", "4111-1111-1111-1111"),
+    ("carta_punti", "Pagamento con carta 4111.1111.1111.1111.",
+     "CREDITCARDNUMBER", "4111.1111.1111.1111"),
+    ("carta_compatta", "Pagamento con carta 4111111111111111.",
+     "CREDITCARDNUMBER", "4111111111111111"),
+    # Telefono.
+    ("cellulare_spazi", "Cell. 333 123 4567 per contatti.",
+     "TELEPHONENUM", "333 123 4567"),
+    ("cellulare_trattini", "Cell. 333-123-4567 per contatti.",
+     "TELEPHONENUM", "333-123-4567"),
+    ("cellulare_prefisso_trattini", "Cell. +39-333-123-4567 per contatti.",
+     "TELEPHONENUM", "+39-333-123-4567"),
+    ("cellulare_prefisso_spazio", "Cell. +39 333 123 4567 per contatti.",
+     "TELEPHONENUM", "+39 333 123 4567"),
+    ("fisso_punti", "Tel. 010.2471234 per contatti.",
+     "TELEPHONENUM", "010.2471234"),
+    ("fisso_trattini", "Tel. 010-2471234 per contatti.",
+     "TELEPHONENUM", "010-2471234"),
+    # Partita IVA.
+    ("piva_nuda", "P.IVA 00743110157 iscritta al registro imprese.",
+     "PIVA", "00743110157"),
+    ("piva_con_prefisso_it", "Partita IVA IT00743110157, sede in Milano.",
+     "PIVA", "00743110157"),
+]
+
+# Valori con la forma giusta ma il checksum sbagliato: dove il detector e'
+# strict devono sparire, e' la ragione per cui strict esiste.
+CHECKSUM_ERRATO = [
+    ("iban_checksum_errato", "IBAN IT61 X054 2811 1010 0000 0123 456.", "IBAN"),
+    ("iban_compatto_checksum_errato", "IBAN IT61X0542811101000000123456.", "IBAN"),
+    ("carta_luhn_errato", "Carta 4111 1111 1111 1112.", "CREDITCARDNUMBER"),
+    ("carta_punti_luhn_errato", "Carta 4111.1111.1111.1112.", "CREDITCARDNUMBER"),
+    ("piva_checksum_errato", "P.IVA 00743110158 del fornitore.", "PIVA"),
+    ("cf_omocodia_checksum_errato", "C.F. RSSMRA85H12F2LRA del ricorrente.", "CF"),
+]
+
+# Testo di un atto che NON contiene PII strutturata: nessuno di questi span
+# deve essere rilevato dai tag validati con checksum.
+NEGATIVI = [
+    ("data_estesa", "Provvedimento emesso il 12.03.2024 dal collegio."),
+    ("date_in_sequenza", "Udienze del 01.02.2024 e 03.04.2025, rinviate."),
+    ("protocollo", "Protocollo n. 2024-000123-456 del registro generale."),
+    ("catasto", "Immobile al Foglio 12, particella 345, sub. 6."),
+    ("piva_come_parola", "La p.iva verra' comunicata in separata sede."),
+    ("numeri_di_riga", "Cfr. pagg. 12-15, punti 3.4.5 e 6.7.8 della memoria."),
+    ("importo_e_articoli", "Ai sensi dell'art. 2043 c.c. per euro 1.250,00."),
+    ("sequenza_lunga_non_luhn", "Codice pratica 1234567890123456789 del 2024."),
+    ("protocollo_con_punti", "Protocollo 2024.0001234.5678 del registro generale."),
+    ("mandato_con_punti", "Mandato n. 12.345.678.901.234 del tesoriere."),
+]
+
+TAG_CON_CHECKSUM = ("IBAN", "CF", "PIVA", "CREDITCARDNUMBER")
+
+
+class DetectorFormatTests(unittest.TestCase):
+    """I formati reali devono arrivare al validatore, non fermarsi alla regex."""
+
+    def test_formati_reali_rilevati(self):
+        for nome, testo, label, atteso in POSITIVI:
+            with self.subTest(nome):
+                self.assertIn(atteso, spans(testo, label))
+
+    def test_checksum_verificato_sui_tag_validati(self):
+        for nome, testo, label, atteso in POSITIVI:
+            if label not in TAG_CON_CHECKSUM:
+                continue
+            with self.subTest(nome):
+                self.assertIn(atteso, validated(testo, label))
+
+    def test_checksum_errato_scartato_dove_strict(self):
+        for nome, testo, label in CHECKSUM_ERRATO:
+            with self.subTest(nome):
+                if label == "CF":
+                    # il CF non e' strict: si redige sulla sola forma, ma senza
+                    # il ✓ del checksum.
+                    self.assertEqual([], validated(testo, label))
+                else:
+                    self.assertEqual([], spans(testo, label))
+
+    def test_nessun_falso_positivo_sul_testo_di_un_atto(self):
+        for nome, testo in NEGATIVI:
+            with self.subTest(nome):
+                trovati = [(e["label"], testo[e["start"]:e["end"]])
+                           for e in detectors.detect_regex(testo)
+                           if e["label"] in TAG_CON_CHECKSUM]
+                self.assertEqual([], trovati)
+
+    def test_nessun_falso_positivo_telefono_su_date_e_richiami(self):
+        # Il trattino tra i gruppi e' l'aggiunta piu' esposta ai falsi positivi:
+        # una data o un richiamo a pagine non deve diventare un numero.
+        for testo in ("Provvedimento emesso il 12.03.2024 dal collegio.",
+                      "Udienze del 01.02.2024 e 03.04.2025, rinviate.",
+                      "Cfr. pagg. 12-15 e 20-24 della memoria."):
+            with self.subTest(testo):
+                self.assertEqual([], spans(testo, "TELEPHONENUM"))
+
+    def test_iban_non_ingoia_la_parola_successiva(self):
+        # La regex raggruppata e' golosa: se assorbe il token dopo l'IBAN il
+        # checksum fallisce e con strict=True il valore si perde del tutto.
+        testo = "Accredito su ES91 2100 0418 4502 0005 1332 come da mandato."
+        self.assertEqual(["ES91 2100 0418 4502 0005 1332"], spans(testo, "IBAN"))
+
+    def test_cf_span_unico_quando_le_due_voci_coincidono(self):
+        # La voce omocodica accetta anche la forma canonica: i candidati sono
+        # due ma sullo STESSO span, cosi' _merge ne tiene uno solo.
+        testo = "C.F. RSSMRA85H12F205Y."
+        trovati = {(e["start"], e["end"])
+                   for e in detectors.detect_regex(testo) if e["label"] == "CF"}
+        self.assertEqual(1, len(trovati))
+
+    def test_modulo_senza_dipendenze_pesanti(self):
+        # E' la premessa della CI: i test dei detector girano senza il modello.
+        # L'import va fatto in un processo pulito, altrimenti l'esito dipende da
+        # cosa hanno gia' importato gli altri file di test.
+        codice = (f"import sys; sys.path.insert(0, {str(ROOT / 'src' / 'app')!r});"
+                  " import detectors;"
+                  " print([m for m in ('torch', 'transformers', 'fitz', 'flask')"
+                  " if m in sys.modules])")
+        out = subprocess.run([sys.executable, "-c", codice],
+                             capture_output=True, text=True, check=True)
+        self.assertEqual("[]", out.stdout.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The regex net now accepts the separators the checksum validators already normalize, so
grouped IBANs, omocodia tax codes, dot separated cards and hyphenated phone numbers reach
their checksum instead of stopping at the pattern. The net also moves to
`src/app/detectors.py` so it can be tested without loading the model, and the repository
gets a CI job that runs the existing `unittest` suite.

## Why

The checksum net is the strongest idea in this project: mod-97, Luhn and the official CF
algorithm give a mathematically certain answer on exactly the identifiers whose leakage
hurts most. The validators are correct on every format below. `iban_ok` strips whitespace as
its first operation, `cf_ok` validates omocodia because it accepts letters in both position
classes, through `_CF_ODD` on the odd ones and `ord(ch) - 65` on the even ones, and `luhn_ok`
drops every non digit. What they never receive is a value with a separator in it, because the
patterns only cover the compact form.

That matters more here than in a tool with a fallback. On `IBAN`, `PIVA` and
`CREDITCARDNUMBER` the detector is `strict=True`, so a candidate that does not reach the
validator is not redacted at all. An IBAN copied from an invoice or a letterhead is
printed in groups of four, and that is the form the pattern did not cover.

The credit card pattern already accepted two separators out of three (space and hyphen,
not the dot). That is the shape of the gap: one field was widened, the others were not.

## Behaviour on `main` (commit 8afce29)

All values below are synthetic, with checksums computed for the purpose.

| Input | Tag | On `main` | Why |
|---|---|---|---|
| `IT60 X054 2811 1010 0000 0123 456` | IBAN | not detected | `\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b` allows no separator, while `iban_ok` starts with `re.sub(r"\s","",s)` |
| `RSSMRA85H12F2LRE` | CF | not detected | the pattern requires `\d{3}` in the Belfiore block, so omocodia (0 becomes L, 1 M, 2 N, ... 9 V) never matches, although `cf_ok` validates it |
| `4111.1111.1111.1111` | CREDITCARDNUMBER | not detected | `(?:\d[ \-]?){13,19}` covers space and hyphen, not the dot |
| `333-123-4567`, `010-2471234` | TELEPHONENUM | not detected | the separator class is `[\s.]?`, without the hyphen |

Two more cases in the same family, both from PDF extracted text and both undetected on
`main` for the same reason: an IBAN whose groups are separated by non breaking spaces, and an
IBAN wrapped across a line. They are why the IBAN separator class is `[\s.\-]` rather than a
literal space.

## What the fix does

Four changes in `src/app/detectors.py`, nothing else.

- **IBAN.** The pattern accepts the compact form or groups of four separated by space, dot
  or hyphen. Groups after the first must contain at least one digit, otherwise the greedy
  match swallows the following word (`... 0005 1332 pago`), mod-97 fails and with
  `strict=True` the IBAN is lost. `iban_ok` now normalizes the same separators the pattern
  accepts, without which the rest would have no effect.
- **CF.** A second `DETECTORS` entry with the same label for the omocodia form, with
  `strict=True` so the checksum is mandatory. Not a widened character class on the existing
  entry: that one is `strict=False` and redacts on shape alone, and seven positions
  accepting letters is too generic to trust without a checksum. The canonical form matches
  both entries on the same span, and `_merge` keeps the validated candidate.
- **Card.** The dot joins the separator class. The match now has to end on a digit: with the
  separator in the repeated group, a card at the end of a sentence pulled the final dot into
  the span and into the placeholder. On `main` the same shape pulled in a trailing space,
  which `_merge` happened to strip.
- **Phone.** The hyphen joins the separator class, both between groups and after the `+39`
  prefix.

No new dependency, no new tag, `TAG_MAP` and the taxonomy untouched, `pdf_export.py`
untouched.

## False positive check

Corpus of 200,000 documents from `src/data_pipeline/generate_synthetic_pii.py` (seeded, so
reproducible), comparing `detect_regex` on `8afce29` against this branch, counting unique
spans that match a gold entity exactly, and detections that overlap no gold entity at all.

Corpus as generated, identifiers in compact form:

| Tag | Gold | `main` | This branch | Delta |
|---|---|---|---|---|
| IBAN | 7830 | 7830 | 7830 | 0 |
| CF | 24304 | 24304 | 24304 | 0 |
| PIVA | 15881 | 15881 | 15881 | 0 |
| TELEPHONENUM | 16070 | 16070 | 16070 | 0 |
| EMAIL | 8032 | 8032 | 8032 | 0 |
| spans matching no gold entity | | 0 | 0 | 0 |

Same corpus, same entities, only reformatted the way a real document prints them (IBAN in
groups of four, CF in omocodia form, phone with hyphens):

| Tag | Gold | `main` | This branch | Delta |
|---|---|---|---|---|
| IBAN | 7830 | 0 | 7830 | +7830 |
| CF | 24304 | 0 | 24304 | +24304 |
| TELEPHONENUM | 16070 | 0 | 16070 | +16070 |
| spans matching no gold entity | | 0 | 0 | 0 |

Nothing already detected is lost, and detections outside the gold entities do not increase.
The generator emits no `CREDITCARDNUMBER`, so the card change is covered by the unit tests
only, not by this corpus.

## What the two new separators cost

They inherit the exposure the other separators already had, and no more. Both numbers are
measured, not estimated.

A run of 13 to 19 digits separated by dots is now a card candidate, and a random one passes
Luhn about once in ten: 493 out of 5000 random 16 digit groups on this branch, against 488
with spaces and 480 with hyphens on `main`, both unchanged. Luhn is the gate that was already
accepted for two separators out of three.

An administrative number written `0521-123456` is now read as a phone number. `main` already
reads `0521.123456` and `0521 123456` that way, so this is the third face of the same
behaviour rather than a new one. The phone detector has no validator, so this is the one place
where the change can add detections on text that is not PII, and the effect is over redaction,
not a leak.

One consequence lands in the reversible dictionary rather than in detection. Placeholder
identity is keyed on the normalized text of the value, so an IBAN written compact in one line
and grouped in another now produces two placeholders where a reader sees one account. On
`main` the grouped form was not detected at all, so the case could not arise. Making the two
spellings share a placeholder means normalizing separators in that key, which lives in
`analyze()` and so cannot be covered by a test that runs without the model. It is left out of
this pull request on purpose.

## Tests and CI

`tests/test_detector_formats.py`, 39 cases in the style of the existing test file
(`unittest`, `sys.path.insert`, no external dependency): real world formats, wrong checksums
that must stay out where the detector is strict, and a negatives block with dates, protocol
numbers, cadastral references and long non Luhn sequences, so the wider separator classes
cannot silently start matching them. 11 of the 39 cases fail on `main`, for 20 failed
assertions; the commit history shows them failing before the fix commit.

`.github/workflows/tests.yml` runs `python -m unittest discover tests` on Python 3.11 (the
floor declared in `requirements.txt`), 3.13 and 3.14, with no `pip install` at all. The suite
has no external dependency: the data generators have none, and `detectors.py` imports neither
torch nor transformers nor fitz. The job finishes in seconds and needs no GPU. No test is
excluded. Push is filtered to `main` so a branch pushed inside the repository does not run the
same job twice.

## On the module split

Extracting the net into `detectors.py` is the same principle already applied to
`pdf_export.py`, whose docstring states that it works only on bytes and a dictionary "quindi
e' testabile in isolamento (nessun import di torch/transformers)". The regex net had the
same need and not yet the same treatment: importing `app.py` loads the model, so no test on
the detectors could run in CI. The first commit is a mechanical move, byte identical apart
from the module docstring, and `app.py` re-exports the names, so `app.detect_regex` still
works for `src/training/evaluate_targa_stress.py`.

Every example in the code, the tests and this description is synthetic, as
`CONTRIBUTING.md` requires.
