### PR TITLE
fix(app): la targa scritta col trattino (AB-123-CD) restava in chiaro

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,49 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — La targa scritta col trattino restava in chiaro (`app.py`)
+
+Il detector TARGA ammetteva come separatore **solo lo spazio** (`\s?`), quindi `AB-123-CD` —
+la forma dei moduli, dei gestionali e degli export — non veniva vista dalla regex. Senza la
+rete regex resta il solo modello, che su quella forma sbaglia i confini:
+
+    HK-105-NS  ->  "...ha registrato HK-[TARGA_1]0[TARGA_2]-[TARGA_3] alle ore..."
+
+Il documento resta insieme **leggibile** (la coppia di lettere sopravvive) e **non
+ripristinabile** (il dizionario non ricompone la targa).
+
+Su 120 documenti con targa col trattino, contesti presi dallo stress test (`analyze()`,
+modello `rizzo-pii-0.3B`): **8 targhe intere in chiaro e 20 sbriciolate come sopra** — il
+23% — contro **0 e 0** dopo la modifica. Le forme `AB123CD` e `AB 123 CD` erano e restano a 0.
+
+Con `src/training/evaluate_targa_stress.py` sullo stress test (300 righe, 200 targhe,
+tre varianti identiche tranne la forma), modello+regex:
+
+| forma | prima | dopo |
+|---|---:|---:|
+| `AB123CD` | R 1,000 · F1 0,800 | invariata |
+| `AB 123 CD` | R 1,000 · F1 0,800 | invariata |
+| **`AB-123-CD`** | **R 0,280 · F1 0,165** | **R 1,000 · F1 0,800** |
+| mix delle tre (come il baseline) | R 0,910 · P 0,593 · F1 0,718 | **R 1,000 · P 0,667 · F1 0,800** |
+
+Sale anche la precisione, perché le span sbagliate del modello vengono sostituite da quella
+esatta della regex.
+
+Falsi positivi: **0 match nuovi** su 120.911 testi reali di Ai4Privacy (tutte le lingue) e su
+100.000 atti legali sintetici senza targa; 0 entità di altri tag toccate su 20.000 documenti;
+costo di scansione invariato. Sullo stress test i documenti con falso positivo restano
+100/100 sul mix e sulle forme compatta e a gruppi; sulla variante tutta col trattino passano
+da 70/100 a 100/100, perché i codici a forma di targa col trattino ora vengono redatti come
+già oggi lo sono quelli compatti (`PR450AB`). La regex non distingue una targa da un codice
+che ne ha la forma in nessuna delle due scritture, e per un anonimizzatore sovra-redigere è
+la direzione sicura.
+
+Limite: `\b` tratta il trattino come confine, quindi una forma di targa **dentro** un codice
+più lungo col trattino (`PROT-2024-AB-123-CD-XY`) viene ritagliata. Nei 120.911 testi reali
+non se ne trova nessuna.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -337,8 +337,11 @@ DETECTORS = [
      re.compile(r"(?:€|EUR|euro)\s?\d{1,3}(?:[.\s]\d{3})*(?:,\d{2})?"
                 r"|\d{1,3}(?:\.\d{3})*,\d{2}\s?(?:€|EUR|euro)", re.IGNORECASE),
      None, True),
+    # il trattino e' un separatore quanto lo spazio ("AB-123-CD" nei moduli e negli
+    # export): senza, la targa scritta cosi' non viene vista da nessuno dei due lati,
+    # perche' nemmeno il modello la riconosce, e resta in chiaro.
     ("TARGA",
-     re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b"),
+     re.compile(r"\b[A-Za-z]{2}[\s-]?\d{3}[\s-]?[A-Za-z]{2}\b"),
      None, True),
     # URL: tre forme, dalla piu' esplicita alla piu' rischiosa.
     #   1) con schema (http/https/ftp)     -> sempre un URL


### PR DESCRIPTION
Il detector TARGA ammette come separatore **solo lo spazio**:

```python
re.compile(r"\b[A-Za-z]{2}\s?\d{3}\s?[A-Za-z]{2}\b")
```

Così `AB-123-CD` — la forma dei moduli, dei gestionali e degli export — non viene vista
dalla regex. Resta il solo modello, che su quella forma sbaglia i confini:

```
HK-105-NS  ->  "...ha registrato HK-[TARGA_1]0[TARGA_2]-[TARGA_3] alle ore [TIME_1]"
```

Il risultato è insieme **leggibile** (la coppia di lettere sopravvive) e **non
ripristinabile** (il dizionario non ricompone la targa).

## La modifica

Una riga: `\s?` → `[\s-]?`, sui due separatori.

## Misure

**End-to-end** (`analyze()`, modello `rizzo-pii-0.3B`), 120 documenti per forma, contesti
presi dai template dello stress test (quindi non visti in training):

| forma | prima | dopo |
|---|---|---|
| `AB123CD` | 0 in chiaro | 0 |
| `AB 123 CD` | 0 in chiaro | 0 |
| **`AB-123-CD`** | **8 intere in chiaro + 20 sbriciolate su 120 (23%)** | **0 + 0** |

**Con `src/training/evaluate_targa_stress.py`** (lo stress test del repo, 300 righe e 200
targhe per variante; le tre varianti sono identiche tranne la forma della targa), modello+regex:

| forma | prima | dopo |
|---|---:|---:|
| `AB123CD` | R 1,000 · F1 0,800 | invariata |
| `AB 123 CD` | R 1,000 · F1 0,800 | invariata |
| **`AB-123-CD`** | **R 0,280 · F1 0,165** | **R 1,000 · F1 0,800** |
| mix delle tre (come `targa_stress_baseline.json`) | R 0,910 · P 0,593 · F1 0,718 | **R 1,000 · P 0,667 · F1 0,800** |

Sale anche la **precisione**: le span sbagliate del modello vengono sostituite da quella
esatta della regex.

**Falsi positivi**

- **0 match nuovi su 120.911 testi reali** di Ai4Privacy (tutte le lingue): la vecchia e la
  nuova regex trovano esattamente le stesse 67 stringhe;
- 0 nuovi su 100.000 atti legali sintetici senza targa (`generate_synthetic_pii.py`);
- su 20.000 documenti: **0 entità perse e 0 entità di altri tag toccate** (CF, IBAN, PIVA,
  carta, telefono, importi identici); l'unica differenza è la targa col trattino;
- 21 codici amministrativi italiani veri (CIG, CUP, matricola INPS, codice catastale, ATECO, VIN, protocollo
  AOO, `art. 2-bis`, `legge 241/90`, R.G., polizza `12-345-678`, ISO `IT-MI-001`, DPCM
  `24-10-2020`): **nessuno** viene catturato in più;
- costo di scansione invariato.

Sullo stress test i documenti con falso positivo restano 100/100 sul mix e sulle forme
compatta e a gruppi; sulla **variante tutta col trattino passano da 70/100 a 100/100**, perché
i codici a forma di targa col trattino ora vengono redatti come già oggi lo sono quelli
compatti (`PR450AB`). La regex non distingue una targa da un codice che ne ha la forma in
nessuna delle due scritture, e per un anonimizzatore sovra-redigere è la direzione sicura.

**Limite dichiarato**: `\b` tratta il trattino come confine, quindi una forma di targa
*dentro* un codice più lungo col trattino (`PROT-2024-AB-123-CD-XY`) viene ritagliata. Nei
120.911 testi reali non se ne trova nessuna. Se preferisci evitarlo, basta sostituire `\b`
con `(?<![\w-])` / `(?![\w-])`: stessa recall sulle tre forme, e toglie anche un falso
positivo che c'è già oggi (`YW198EC` dentro `K7-90-YW198EC-1`). Non l'ho messo qui perché
cambierebbe anche il comportamento sulla forma compatta, fuori dallo scopo di questa PR.

## Rapporto con le altre PR

`#58` sposta il blocco `DETECTORS` in `src/app/detectors.py` **riportando questa regex
invariata**, quindi non risolve il caso. Le due modifiche sono indipendenti nel merito ma
toccano le stesse righe: se `#58` viene mergiata prima, questa resta una riga da riportare
in `detectors.py` e la aggiorno io. Nessun'altra PR aperta tocca il detector TARGA.
