### PR TITLE
fix(data): i sintetici scrivevano il nome solo come "Nome Cognome" (issue #40)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,39 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — I sintetici scrivevano il nome in un ordine solo (issue #40)
+
+`full_name()` e `role()` producevano **sempre** `Nome Cognome`: su 20.000 chiamate, 100%.
+Ma negli atti, nei moduli e nelle intestazioni il nome si scrive anche `Cognome Nome`
+(«Egr. Rossi Mario»), e il modello quell'ordine non lo ha mai visto.
+
+Effetto misurato su `rizzo-pii-0.3B` con `analyze()`, stessi nomi e stesse frasi, cambiato
+solo l'ordine — «in chiaro» = almeno metà del nome ancora leggibile dopo l'anonimizzazione:
+
+| | `Mario Rossi` | `Rossi Mario` |
+|---|---:|---:|
+| frasi con appellativo (`Egr.`, `Spett.le`, `Gentile`) | 2,5% (8/320) | **27,8% (89/320)** |
+| frasi senza appellativo | 0,0% (0/640) | **4,2% (27/640)** |
+
+    'Egr. Coppola Dario'   ->  'Egr. Coppola [FULLNAME_1],'
+    'Brambilla Ilaria'     ->  'Brambilla [FULLNAME_1], residente in [STREET_1]...'
+
+Ora il 30% dei nomi sintetici esce in ordine invertito (`INVERTED_NAME_P`), con le label
+`SURNAME`/`GIVENNAME` scambiate di conseguenza — la tassonomia non cambia, `normalize_labels()`
+li fonde in `FULLNAME` in entrambi i casi. Non 50%: nella prosa l'ordine diretto resta il più
+frequente, l'inverso domina solo in intestazioni ed elenchi.
+
+Verificato sul generatore: 70,3% / 29,7% su 20.000 nomi, 0 label scambiate su 5.000, e su
+20.000 documenti 0 sequenze BIO non valide e 0 offset sbagliati. **Per avere effetto serve
+rigenerare i sintetici e riaddestrare** (come per la fix `PROVINCE`):
+
+```powershell
+python src/data_pipeline/generate_synthetic_pii.py -n 200000 --out dataset/synthetic/synthetic_pii_it_200k.jsonl
+python src/training/train_pii.py --type full
+```
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/data_pipeline/generate_synthetic_pii.py
+++ b/src/data_pipeline/generate_synthetic_pii.py
@@ -271,13 +271,23 @@ def _date():
     d, m, y = random.randint(1, 28), random.randint(1, 12), random.randint(1955, 2005)
     return f"{d:02d}/{m:02d}/{y}", (d, m, y)
 
-def full_name():
+# Negli atti, nei moduli e nelle intestazioni il nome si scrive anche COGNOME NOME
+# ("Egr. Rossi Mario"). Generandone un ordine solo il modello impara quello: sull'altro
+# lascia in chiaro meta' nome (issue #40).
+INVERTED_NAME_P = 0.3
+
+def _name_pieces():
     g, s, _ = _person()
+    if random.random() < INVERTED_NAME_P:
+        return [(s, "SURNAME"), (" ", None), (g, "GIVENNAME")]
     return [(g, "GIVENNAME"), (" ", None), (s, "SURNAME")]
 
+def full_name():
+    return _name_pieces()
+
 def role(label):
-    g, s, _ = _person()
-    return [(f"{g} {s}", label)]   # nome intero taggato col ruolo legale
+    # nome intero taggato col ruolo legale, stesso mix di ordini
+    return [("".join(v for v, _ in _name_pieces()), label)]
 
 def cf_piece():
     g, s, sex = _person()


### PR DESCRIPTION
Chiude (lato dati) la issue #40.

`full_name()` e `role()` producono **sempre** `Nome Cognome`: su 20.000 chiamate, 100%. Ma
negli atti, nei moduli e nelle intestazioni il nome si scrive anche `Cognome Nome`
(«Egr. Rossi Mario»), e il modello quell'ordine non lo ha mai visto in training.

## Misura

`analyze()` con `rizzo-pii-0.3B`, stessi 80 nomi e stesse frasi, cambiato **solo** l'ordine.
«in chiaro» = almeno metà del nome ancora leggibile dopo l'anonimizzazione:

| | `Mario Rossi` | `Rossi Mario` |
|---|---:|---:|
| frasi con appellativo (`Egr.`, `Spett.le`, `Gentile`) | 2,5% (8/320) | **27,8% (89/320)** |
| frasi senza appellativo | 0,0% (0/640) | **4,2% (27/640)** |

```
'Egr. Coppola Dario'  ->  'Egr. Coppola [FULLNAME_1],'
'Brambilla Ilaria'    ->  'Brambilla [FULLNAME_1], residente in [STREET_1] [BUILDINGNUM_1]...'
```

L'appellativo peggiora le cose ma non è la causa: senza, l'ordine invertito perde comunque il
4,2% contro lo 0,0%. Ripetuto con un secondo gruppo di 60 nomi diversi: 2,9% vs 31,2% con
appellativo, 0,0% vs 7,1% senza — stessa conclusione, numeri di poco peggiori.

## La modifica

Il 30% dei nomi esce in ordine invertito (`INVERTED_NAME_P`), con le label `SURNAME`/`GIVENNAME`
scambiate di conseguenza. Tassonomia invariata: `normalize_labels()` li fonde in `FULLNAME` in
entrambi i casi. Non 50% perché nella prosa l'ordine diretto resta il più frequente; l'inverso
domina in intestazioni ed elenchi.

## Verifica

| | prima | dopo |
|---|---|---|
| ordine su 20.000 `full_name()` | 100% Nome-Cognome | 70,3% / 29,7% |
| ordine su 20.000 `role()` | 100% Nome-Cognome | 70,1% / 27,2% |
| label scambiate (5.000 nomi) | 0 | 0 |
| sequenze BIO non valide (20.000 documenti) | 0 | 0 |
| offset entità sbagliati (20.000 documenti) | 0 | 0 |
| `tests/` | 5 passed | 5 passed |

Generatore eseguito end-to-end (`-n 300`): 0 anomalie nel file prodotto.

**Per avere effetto serve rigenerare i sintetici e riaddestrare**, come per la fix `PROVINCE`:
`python src/data_pipeline/generate_synthetic_pii.py -n 200000 --out dataset/synthetic/synthetic_pii_it_200k.jsonl`.
Non ho la GPU per il run grande, quindi il guadagno sul modello riaddestrato non è misurato
qui: quello che è misurato è che l'ordine oggi manca del tutto e che su quell'ordine il modello
lascia in chiaro.

Nessun consumatore assume l'ordine: `TAG_MAP` manda `GIVENNAME` e `SURNAME` entrambi a
`FULLNAME` in `train_pii.py`, `build_subset.py`, `evaluate_pii.py` e `contribute_dataset.py`.

Lasciato fuori di proposito: `generate_targa_it.full_name_piece()` compone il nome per conto
suo (`f"{given} {surname}"`). Quel dataset non è tra i `SYNTH_PATHS` del training, quindi l'ho
lasciato stare per non allargare la PR a un secondo file; se lo vuoi allineato lo faccio.

Nessun conflitto con le altre PR aperte sullo stesso file (#56, #28, #15): verificato con
`git merge-tree`, 0 conflitti con ciascuna.
