### PR TITLE
perf(app): _merge() era quadratica, 111 s su un documento lungo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,34 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
+
+Il controllo delle sovrapposizioni confrontava **ogni** candidato con **tutta** la lista già
+tenuta, e `analyze()` chiama `_merge()` una volta sull'**intero documento**, non per chunk.
+Il costo esplode dopo l'inferenza, quando l'utente crede di aver finito (issue #61):
+
+| entità nel documento | prima | dopo |
+|---:|---:|---:|
+| 5.000 | 1,14 s | **0,025 s** |
+| 20.000 | 21,25 s | **0,181 s** |
+| 40.000 | 111,35 s | **0,398 s** |
+| 100.000 | non misurata (ore) | **2,08 s** |
+
+Le entità tenute sono per costruzione ordinate e non sovrapposte, quindi un candidato può
+accavallarsi solo con i due vicini: una ricerca binaria li trova subito.
+
+Comportamento invariato, verificato confrontando l'output della funzione intera fra vecchia e
+nuova implementazione: **60.000 casi casuali** (span sovrapposti, annidati, densi, punteggi
+tutti uguali per far contare la stabilità del `sorted`, 64.822 candidati di lunghezza zero) e
+**48 casi costruiti** (lista vuota, lunghezza zero dentro e fuori un altro span, candidati
+identici, stesso `start`, annidamento nei due ordini, adiacenti, sovrapposti di un carattere)
+→ **0 output diversi**.
+
+Non risolve da solo la issue #61: lì il grosso è l'inferenza su CPU. Questo è il pezzo che
+resta lento anche dopo.
+
+---
+
 ## 2026-06-30 — Porta del backend 5000 → 5005 (conflitto AirPlay su macOS)
 
 Gli utenti macOS vedevano una **pagina bianca**: la porta **5000** è occupata di default

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -43,6 +43,7 @@ Preferenze di anonimizzazione (precedenza): campo nella richiesta > CLI --exclud
   --no-mapping > env PII_EXCLUDE_TAGS/PII_MAPPING > prefs.json > default
 """
 
+import bisect
 import os
 import re
 import secrets
@@ -443,8 +444,15 @@ def _merge(cands, text):
     )
     kept = []
     for e in order:
-        if all(e["end"] <= k["start"] or e["start"] >= k["end"] for k in kept):
-            kept.append(e)
+        # kept resta ordinata per start e senza sovrapposizioni: allora un candidato puo'
+        # accavallarsi solo con i due vicini, che la ricerca binaria trova subito. Il
+        # confronto con TUTTA kept era O(n^2): su un documento con 40.000 entita' (una chat
+        # esportata di qualche MB) erano 111 s spesi qui, dopo l'inferenza.
+        i = bisect.bisect_right(kept, e["start"], key=lambda k: k["start"])
+        if (i and kept[i - 1]["end"] > e["start"]) or \
+           (i < len(kept) and kept[i]["start"] < e["end"]):
+            continue
+        kept.insert(i, e)
     # niente spazi inglobati nei placeholder (il modello a volte include lo spazio iniziale)
     for e in kept:
         while e["start"] < e["end"] and text[e["start"]].isspace():


### PR DESCRIPTION
> **Nota sulle altre PR**: `#49` cambia la *chiave di ordinamento* di `_merge`, questa il
> *controllo di sovrapposizione* poco sotto. Ho fatto il merge vero delle due: l'unico conflitto
> è la **riga di `import`** (entrambe ne aggiungono una nello stesso punto), il corpo di
> `_merge` si fonde pulito. Con `#57`, `#58` e `#35` il merge è pulito.

`_merge()` scarta le sovrapposizioni confrontando **ogni** candidato con **tutta** la lista già
tenuta:

```python
for e in order:
    if all(e["end"] <= k["start"] or e["start"] >= k["end"] for k in kept):
        kept.append(e)
```

È O(n²), e `analyze()` lo chiama **una volta sull'intero documento**, non per chunk. Su un testo
lungo (la chat esportata della issue #61) il costo esplode *dopo* l'inferenza, quando l'utente
crede di aver finito:

| entità nel documento | prima | dopo |
|---:|---:|---:|
| 5.000 | 1,14 s | **0,025 s** |
| 20.000 | 21,25 s | **0,181 s** |
| 40.000 | 111,35 s | **0,398 s** |
| 100.000 | non misurata (ore) | **2,08 s** |

## La modifica

Le entità tenute sono per costruzione ordinate e non sovrapposte: un candidato può accavallarsi
solo con i due vicini, che una ricerca binaria trova subito. Otto righe, nessun cambio di
comportamento.

## Verifica

L'output deve essere **identico**, non equivalente. Confronto della funzione intera (selezione +
taglio degli spazi + ordinamento finale) fra vecchia e nuova implementazione:

- **60.000 casi casuali**: span sovrapposti, annidati, densi, punteggi tutti uguali (per far
  contare la stabilità del `sorted`), sorgenti e `validated` misti, **64.822 candidati di
  lunghezza zero** → **0 output diversi**;
- **48 casi costruiti**: lista vuota, span di lunghezza zero dentro e fuori un altro span,
  candidati identici, stesso `start`, annidamento nei due ordini, adiacenti che non si
  sovrappongono, sovrapposti di un carattere, tre copie dello stesso span → **0 output diversi**;
- **123 documenti con il modello vero** (`analyze()` intera: testo anonimizzato, dizionario e
  segmenti) → **0 output diversi**; su uno di quelli, 9.052 candidati, `_merge` passa da 1,92 s
  a 0,035 s.

Ho provato anche la variante ovvia — una `bytearray` delle posizioni gia' coperte, piu' corta e
piu' veloce — e **non e' equivalente**: 4.462 casi su 60.000 danno un risultato diverso. Un
candidato di lunghezza zero, nell'implementazione attuale, blocca i candidati che lo
attraversano; con la maschera non blocca niente perche' non copre nessun byte. Differenza
piccola e forse innocua, ma questa PR non e' il posto per deciderlo: qui il comportamento resta
identico.

Non risolve la issue #61 da sola: lì il grosso è l'inferenza su CPU (è quello che `#33` affronta
con ONNX). Questo è il pezzo che resta lento *anche* dopo, ed è puro tempo sprecato.
