### PR TITLE
Un modello lento non deve interrompere la generazione: TimeoutError è un OSError, non un URLError

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,26 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — Un modello lento interrompeva la generazione dei template (`llm_template_bank.py`)
+
+Il timeout di lettura di `urllib` scade **dentro** `getresponse()` e solleva `TimeoutError`,
+che deriva da `OSError` e **non** da `urllib.error.URLError`. I due `except` intercettavano
+`(urllib.error.URLError, KeyError, IndexError)`: una singola generazione lenta — normale con
+un modello locale su CPU o molto quantizzato — non consumava un tentativo, propagava e
+fermava tutta l'esecuzione, buttando i template già scritti.
+
+Segnalato da **@p3pp01** con Gemma servito da Ollama, sulla PR #20.
+
+Ora si intercetta `OSError`, che è la classe base sia di `URLError` sia di `TimeoutError`, e
+copre per giunta la connessione rifiutata quando il server locale non è avviato. Il messaggio
+d'errore stampa anche il tipo dell'eccezione, che era l'informazione che mancava per capirlo.
+
+Test: `tests/test_backend_llm_timeout.py` sostituisce `urlopen` con quattro errori di rete
+(timeout, timeout come `OSError`, connessione rifiutata, host irraggiungibile) e verifica che
+la chiamata **ritorni `None`** invece di propagare, su entrambi i backend e su `call_llm()`.
+Senza la correzione i test danno 7 errori.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/data_pipeline/llm_template_bank.py
+++ b/src/data_pipeline/llm_template_bank.py
@@ -159,8 +159,14 @@ def call_local_openai(prompt, retries=3):
             print("  risposta vuota dal modello locale")
         except urllib.error.HTTPError as e:
             print(f"  HTTP {e.code}: {e.read().decode()[:200]}")
-        except (urllib.error.URLError, KeyError, IndexError) as e:
-            print(f"  errore: {e}")
+        # OSError e non urllib.error.URLError: un modello locale lento fa scadere il timeout
+        # DENTRO getresponse(), e quello e' un TimeoutError, che deriva da OSError e NON da
+        # URLError. Intercettando la sola URLError una singola generazione lenta interrompeva
+        # tutta l'esecuzione invece di far scattare il tentativo successivo (segnalato da
+        # @p3pp01 con Gemma via Ollama). OSError e' la classe base di entrambe, quindi copre
+        # anche la connessione rifiutata quando il server locale non e' avviato.
+        except (OSError, KeyError, IndexError) as e:
+            print(f"  errore: {type(e).__name__}: {e}")
         time.sleep(2 * (attempt + 1))
     return None
 
@@ -186,8 +192,10 @@ def call_gemini(prompt, retries=3):
         except urllib.error.HTTPError as e:
             print(f"  HTTP {e.code}: {e.read().decode()[:200]}")
             time.sleep(2 * (attempt + 1))
-        except (urllib.error.URLError, KeyError, IndexError) as e:
-            print(f"  errore: {e}")
+        # OSError copre URLError e TimeoutError (vedi la nota in call_local_openai): anche
+        # verso Gemini un timeout di lettura non deve interrompere la generazione.
+        except (OSError, KeyError, IndexError) as e:
+            print(f"  errore: {type(e).__name__}: {e}")
             time.sleep(2 * (attempt + 1))
     return None
 

--- a/tests/test_backend_llm_timeout.py
+++ b/tests/test_backend_llm_timeout.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Un modello lento non deve interrompere la generazione dei template.
+
+Il timeout di lettura di urllib scade DENTRO getresponse() e solleva TimeoutError, che
+deriva da OSError e NON da urllib.error.URLError. Intercettando la sola URLError, una
+generazione lenta -- normale con un modello locale su CPU o molto quantizzato -- fermava
+l'intera esecuzione invece di consumare un tentativo e passare al successivo, buttando i
+template gia' scritti.
+
+Il caso e' stato segnalato da @p3pp01 su Gemma servito da Ollama.
+
+Qui non si parla con nessun server: urlopen viene sostituito da una funzione che solleva
+l'eccezione da provare, e si verifica che la chiamata RITORNI None (nessun template) invece
+di propagare. Nessun dato personale e' coinvolto.
+"""
+
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "data_pipeline"))
+
+import llm_template_bank as tb  # noqa: E402
+
+
+class ErroriDiReteNonInterrompono(unittest.TestCase):
+    """Ogni errore di rete deve diventare "nessun template", non un'eccezione."""
+
+    # (nome del caso, eccezione sollevata da urlopen)
+    CASI = [
+        ("timeout di lettura (il caso segnalato)", TimeoutError("timed out")),
+        ("timeout come socket.timeout", OSError("timed out")),
+        ("connessione rifiutata: server non avviato", ConnectionRefusedError(111, "rifiutata")),
+        ("host irraggiungibile", urllib.error.URLError("nodename nor servname provided")),
+    ]
+
+    def test_backend_locale(self):
+        with mock.patch.object(tb, "LLM_BASE_URL", "http://127.0.0.1:8080/v1"), \
+             mock.patch.object(tb.time, "sleep"):            # niente attese nei test
+            for nome, exc in self.CASI:
+                with self.subTest(nome):
+                    with mock.patch.object(tb.urllib.request, "urlopen", side_effect=exc):
+                        self.assertIsNone(tb.call_local_openai("prompt", retries=2))
+
+    def test_gemini(self):
+        with mock.patch.object(tb, "API_KEY", "chiave-finta"), \
+             mock.patch.object(tb.time, "sleep"):
+            for nome, exc in self.CASI:
+                with self.subTest(nome):
+                    with mock.patch.object(tb.urllib.request, "urlopen", side_effect=exc):
+                        self.assertIsNone(tb.call_gemini("prompt", retries=2))
+
+    def test_call_llm_smista_sul_backend_giusto(self):
+        """call_llm() e' il punto d'ingresso: anche da li' il timeout non deve propagare."""
+        with mock.patch.object(tb, "LLM_BASE_URL", "http://127.0.0.1:8080/v1"), \
+             mock.patch.object(tb.time, "sleep"), \
+             mock.patch.object(tb.urllib.request, "urlopen", side_effect=TimeoutError()):
+            self.assertIsNone(tb.call_llm("prompt", retries=1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Un modello lento non deve interrompere la generazione (TimeoutError e' un OSError)

Il timeout di lettura di urllib scade DENTRO getresponse() e solleva TimeoutError, che
deriva da OSError e NON da urllib.error.URLError. I due except intercettavano
(urllib.error.URLError, KeyError, IndexError), quindi una singola generazione lenta --
normale con un modello locale su CPU o molto quantizzato -- non consumava un tentativo:
propagava e fermava tutta l'esecuzione, buttando i template gia' scritti.

Segnalato da @p3pp01 sulla PR #20, con Gemma servito da Ollama.

Ora si intercetta OSError, classe base sia di URLError sia di TimeoutError, e per giunta
copre la connessione rifiutata quando il server locale non e' avviato. Il messaggio stampa
anche il tipo dell'eccezione: era l'informazione che mancava per diagnosticarlo.

Il test sostituisce urlopen con quattro errori di rete e verifica che la chiamata RITORNI
None invece di propagare, su entrambi i backend e su call_llm(). Senza la correzione da'
7 errori; con la correzione la suite passa (38 test).


---

Grazie a @p3pp01 per la segnalazione sulla #20: il caso e' esattamente quello descritto.
