### PR TITLE
perf(pdf): anche hard_split() era quadratica

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,48 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — Anche `hard_split()` era quadratica (`pdf_export.py`)
+
+`text_to_pdf()` impagina il testo anonimizzato quando l'input non è un PDF (incolla, `.md`,
+`.txt`). `hard_split()` spezza le "parole" più larghe della riga e a **ogni giro** misurava e
+ricopiava tutta la stringa residua: O(n²) sulla lunghezza della parola. Basta una riga senza
+spazi — un JSON incollato, un base64, una riga di tabella con i soli tab — perché "Scarica PDF
+anonimizzato" diventi inutilizzabile.
+
+Le due colonne sono misurate **nello stesso giro sulla stessa macchina**, mediana di 3; conta
+il rapporto, non i secondi assoluti, e cresce con la lunghezza perché la vecchia è quadratica:
+
+| caratteri di una parola | prima | dopo | |
+|---:|---:|---:|---:|
+| 2.000 | 0,18 s | **0,070 s** | 3x |
+| 8.000 | 3,75 s | **0,434 s** | 9x |
+| 16.000 | 14,36 s | **0,915 s** | 16x |
+| 32.000 | 60,44 s | **1,76 s** | 34x |
+| 128.000 | ~16 min (estrapolata dalla curva) | **7,25 s** | |
+| 1.000.000 | — | **73 s** | |
+
+In una riga larga `width` non entrano più di `cap` caratteri qualunque essi siano: oltre quel
+punto non c'è niente da misurare. Si lavora su un prefisso lungo `cap` e si avanza con un
+indice invece di ricopiare la coda. Sul testo normale si esce dopo una sola misura, come prima:
+lo scarto misurato sta dentro la banda di rumore del banco, che con **lo stesso codice nei due
+bracci** dà +8,4%.
+
+`cap` si ricava dal glifo **più stretto** del repertorio, non da `"l"`. Il testo è già forzato
+in latin-1 poche righe sopra, quindi il repertorio è chiuso e il minimo si misura (191 chiamate,
+0,8 ms una volta per documento). Con `"l"` il conto sbagliava per difetto: in helv l'apostrofo
+misura 2,0055 pt a corpo 10,5 contro i 2,331 di `"l"`, quindi `cap` valeva 209 dove in colonna
+ne entrano 240 — una parola di apostrofi stava dentro la finestra, il ciclo usciva subito e
+accodava tutta la coda su **una riga sola**, larga fino a 2.022 pt su una colonna di 483 in una
+pagina di 595. I caratteri oltre il bordo sparivano dal PDF scaricato senza nessun errore: su
+300 apostrofi se ne rileggevano 269.
+
+Comportamento identico a prima, verificato sulla `text_to_pdf()` vera confrontando il **testo
+estratto** dai due PDF (i byte non sono confrontabili, l'`/ID` è casuale): 444 casi in 11
+alfabeti, compresi quelli dominati dal glifo più stretto, **0 differenze** e **0 righe fuori
+pagina**. `tests/test_pdf_hard_split.py` copre il caso, e con il `cap` calibrato su `"l"`
+fallisce. `smoke_pdf_export.py` 23/23 PASS.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/app/pdf_export.py
+++ b/src/app/pdf_export.py
@@ -492,18 +492,36 @@ def text_to_pdf(text, margin=56.0, fontsize=10.5, leading=15.5):
     def tl(s):
         return fitz.get_text_length(s, fontname="helv", fontsize=fontsize)
 
+    # In una riga larga `width` non entrano piu' di `cap` caratteri, qualunque siano:
+    # oltre quel punto non c'e' niente da misurare. Serve perche' hard_split misurava
+    # e ricopiava TUTTA la stringa residua a ogni giro -> O(n^2): una "parola" senza
+    # spazi (JSON incollato, base64, riga di tabella coi soli tab) da 16.000 caratteri
+    # costava 15 s, da 128.000 un quarto d'ora.
+    # Il conto va fatto sul glifo PIU' STRETTO, non su "l": il testo e' gia' forzato in
+    # latin-1 poche righe sopra, quindi il repertorio e' chiuso e il minimo si misura.
+    # In helv e' l'apostrofo (2,0055 pt a corpo 10,5) contro i 2,331 di "l": con "l" cap
+    # varrebbe 209 dove in colonna ne entrano 240, la finestra ci starebbe, il ciclo
+    # uscirebbe subito e la coda finirebbe tutta su una riga larga oltre il bordo pagina.
+    stretto = min(tl(chr(c)) for c in list(range(32, 127)) + list(range(160, 256)))
+    cap = max(2, int(width / max(stretto, 0.1)) + 2)   # >= 2: con margini assurdi width <= 0
+
     def hard_split(line):
         """Spezza le 'parole' piu' larghe della riga (IBAN, URL...)."""
-        out = []
-        while tl(line) > width and len(line) > 1:
-            k = max(1, int(len(line) * width / tl(line)))
-            while k > 1 and tl(line[:k]) > width:
+        if tl(line) <= width:          # caso normale: la riga ci sta gia', una sola misura
+            return [line]
+        out, i = [], 0
+        while len(line) - i > 1:
+            head = line[i:i + cap]
+            if tl(head) <= width:
+                break
+            k = max(1, int(len(head) * width / tl(head)))
+            while k > 1 and tl(head[:k]) > width:
                 k -= 1
-            while k < len(line) and tl(line[:k + 1]) <= width:
+            while k < len(head) and tl(head[:k + 1]) <= width:
                 k += 1
-            out.append(line[:k])
-            line = line[k:]
-        out.append(line)
+            out.append(head[:k])
+            i += k
+        out.append(line[i:])
         return out
 
     def wrap(par):

--- a/tests/test_pdf_hard_split.py
+++ b/tests/test_pdf_hard_split.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""`hard_split()` non deve mai disegnare oltre il bordo della pagina.
+
+La finestra `cap` serve a non misurare tutta la coda a ogni giro, ma va calibrata sul
+glifo PIU' STRETTO del repertorio: con "l" come riferimento una parola di apostrofi (che
+in helv sono piu' stretti) sta dentro la finestra, il ciclo esce subito e accoda tutta la
+coda su una riga sola. La riga finisce fuori pagina e nel PDF quei caratteri SPARISCONO,
+senza nessun errore: il documento scaricato sembra completo e non lo e'.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+try:
+    import fitz
+    import pdf_export
+except ImportError:  # PyMuPDF assente: e' una dipendenza dell'app, non del training
+    fitz = None
+
+
+@unittest.skipIf(fitz is None, "PyMuPDF non installato")
+class HardSplit(unittest.TestCase):
+    def pagine(self, testo):
+        return fitz.open("pdf", pdf_export.text_to_pdf(testo))
+
+    def test_nessun_carattere_perde_la_pagina(self):
+        # l'apostrofo e' il glifo piu' stretto di helv in latin-1
+        doc = self.pagine("'" * 300)
+        letti = "".join(p.get_text() for p in doc).count("'")
+        doc.close()
+        self.assertEqual(letti, 300, "caratteri persi fuori pagina")
+
+    def test_nessuna_riga_sfora_il_bordo(self):
+        for parola in ("'" * 300, "'ijl" * 225, "l" * 300):
+            doc = self.pagine("Verbale.\n" + parola + "\nFirmato.")
+            fuori = [l["bbox"][2] for p in doc
+                     for b in p.get_text("rawdict")["blocks"]
+                     for l in b.get("lines", []) if l["bbox"][2] > p.rect.width + 0.5]
+            doc.close()
+            self.assertFalse(fuori, "righe oltre il bordo pagina: %r" % fuori)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`text_to_pdf()` impagina il testo anonimizzato quando l'input non è un PDF (incolla, `.md`,
`.txt`). `hard_split()` spezza le "parole" più larghe della riga, e a **ogni giro** misura e
ricopia tutta la stringa che resta:

```python
while tl(line) > width and len(line) > 1:
    k = max(1, int(len(line) * width / tl(line)))     # tl() su tutta la stringa residua
    ...
    line = line[k:]                                    # e una copia, ogni volta
```

È O(n²) sulla lunghezza della parola. Basta una riga senza spazi — un JSON incollato, un
base64, una riga di tabella con i soli tab, un URL lungo — perché "Scarica PDF anonimizzato"
diventi inutilizzabile.

Le due colonne sono misurate **nello stesso giro sulla stessa macchina**, mediana di 3. Conta
il rapporto, non i secondi assoluti, e cresce con la lunghezza perché la vecchia è quadratica:

| caratteri | prima | dopo | |
|---:|---:|---:|---:|
| 2.000 | 0,18 s | **0,070 s** | 3x |
| 8.000 | 3,75 s | **0,434 s** | 9x |
| 16.000 | 14,36 s | **0,915 s** | 16x |
| 32.000 | 60,44 s | **1,76 s** | 34x |
| 128.000 | ~16 min, estrapolata dalla curva | **7,25 s** | |
| 1.000.000 | — | **73 s** | |

Il testo normale, con gli spazi, non cambia — e questa non è una supposizione: misurando
vecchia e nuova sullo stesso input avevo visto prima +27% e poi −6%, cioè rumore. Ho allora
messo **lo stesso identico codice nei due bracci** del banco di prova: lo scarto fra due bracci
identici è **+8,4%**. Il confronto vero cade dentro quella banda, quindi non c'è differenza
misurabile.

## La modifica

Due righe. La prima è la via veloce: se la riga ci sta già — il caso di tutto il testo normale
— si esce dopo **una** misura, esattamente come prima. La seconda è il limite: in una riga larga
`width` non entrano più di `cap` caratteri qualunque siano, quindi oltre quel punto non c'è
niente da misurare — si lavora su un prefisso lungo `cap` e si avanza con un indice invece di
ricopiare la coda.

`cap` si ricava dal glifo **più stretto** del repertorio. Il testo è già forzato in latin-1
poche righe sopra, quindi il repertorio è chiuso e il minimo si misura: 191 chiamate a `tl()`,
0,8 ms una volta per documento.

Questo punto merita una nota, perché nella prima stesura di questa PR era sbagliato e non me
n'ero accorto. Avevo ricavato `cap` da `tl("l")`, dando per scontato che `"l"` fosse il glifo
più stretto. Non lo è: in helv l'apostrofo misura **2,0055 pt** a corpo 10,5 contro i **2,331**
di `"l"`. Con `"l"` il `cap` valeva 209 mentre in colonna ne entrano 240, quindi una parola di
apostrofi stava *dentro* la finestra, il ramo `if tl(head) <= width: break` usciva subito e la
coda finiva tutta su **una riga sola** — larga fino a 2.022 pt su una colonna di 483, in una
pagina di 595. I caratteri oltre il bordo sparivano dal PDF scaricato senza nessun errore: su
300 apostrofi in ingresso se ne rileggevano **269**. Per un PDF anonimizzato è il modo peggiore
di sbagliare, perché sembra completo.

L'argomento di identità che avevo scritto («i due cicli portano `k` al massimo, e `k` non può
raggiungere `cap`») era vero ma parlava solo del ramo che spezza: il ramo che rompeva l'identità
era il `break`, e nel testo non compariva. Anche la batteria di confronti non poteva vederlo,
perché campionava l'alfabeto stretto in modo uniforme e una finestra di 209 caratteri misti non
sta mai nella colonna.

## Verifica

Confronto sulla `text_to_pdf()` **vera** presa da `origin/main` e dal ramo, sul **testo
estratto** dai due PDF — i byte non sono confrontabili, l'`/ID` è casuale:

- **444 casi** in 11 alfabeti, compresi quelli dominati dal glifo più stretto (`'`, `'i`,
  `'ijl`, `'l`, `'`×9+`W`) → **0 differenze** e **0 righe oltre il bordo pagina**. Con il `cap`
  calibrato su `"l"`: 127 differenze e 6 righe fuori pagina;
- **3.300 parole casuali** sul solo `hard_split()`, stesse 11 famiglie → **0 differenze**
  (994 con il `cap` vecchio);
- 300 apostrofi: **300 caratteri su 300** rileggibili nel PDF (269 con il `cap` vecchio);
- **margini degeneri**: con `margin` tale che la riga sia larga 0 o negativa le due versioni si
  comportano allo stesso modo — `cap` è vincolato a >= 2 apposta, senza quel vincolo la nuova
  sollevava `ZeroDivisionError` dove la vecchia reggeva;
- `tests/test_pdf_hard_split.py`, nuovo: nessun carattere perde la pagina, nessuna riga sfora
  il bordo. **Con il `cap` calibrato su `"l"` falliscono entrambi**;
- `python src/app/smoke_pdf_export.py`: **23/23 PASS**; `python -m unittest discover tests`: OK.

Nessuna PR aperta tocca `src/app/pdf_export.py`.
