### PR TITLE
Ispettore delle contribuzioni: errori duri (uscita ≠ 0) e quanta informazione porta il file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ modelli in `models/<versione>/`, artefatti dei run in `experiments/<run>/`, doc 
 - `validate_checksums.py` — ricalcola i checksum CF/IBAN/PIVA; **blueprint della rete regex+checksum**
   da affiancare al modello in produzione.
 - `inspect_ai4privacy.py` (conteggi lingue/tag), `inspect_lengths.py` (lunghezze), `inspect_no_iban.py`.
+- `inspect_contribution.py` — ispeziona un `.jsonl` **contribuito**: errori duri (token, offset,
+  BIO, checksum, tassonomia letta da `TAG_MAP`/`TAG_FINALI`; uscita ≠ 0, quindi vale da cancello)
+  e quanta informazione porta — **strutture distinte** (template + sequenza delle label), righe
+  per struttura, duplicati. La struttura e non lo scheletro: lo scheletro punisce i template che
+  etichettano ogni valore iniettato. Con `--json` si ispeziona in serie una coda di PR.
 
 **App di anonimizzazione locale — `src/app/` (+ packaging in `docs/BUILD.md`):**
 - `server_config.py` — **configurazione host/porta** (+ `prefs.json` con tag esclusi e stato del

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,46 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — Ispezionare una contribuzione: `src/inspect/inspect_contribution.py`
+
+Le Pull Request di dati arrivano più in fretta di quanto si riesca a leggerle, e l'unica cosa che
+il nome del file dichiara — il numero di righe — non dice se il contributo insegna qualcosa.
+Chi revisiona non ha modo di distinguere un file piccolo e ricco da uno grande e ripetitivo senza
+rifare la misura a mano, file per file. Il nuovo ispettore la fa in pochi secondi e con `--json`
+si esegue su tutta la coda, che così si può **ordinare per informazione invece che per peso**.
+
+Fa due cose che separate non bastano:
+
+1. **Errori duri.** Ricalcola tutto da zero — tokenizzazione (la regex del formato), offset delle
+   entità, coerenza BIO (`I-` senza `B-`), entità sovrapposte, checksum CF/PIVA/IBAN/Luhn, lingua,
+   caratteri non latini — senza fidarsi dello script che ha generato il file. **Uscita ≠ 0**, così
+   vale da cancello in uno script. La tassonomia ammessa si **legge dal repo** (`TAG_FINALI` e
+   `TAG_GREZZI` di `contribute_dataset.py`, `TAG_MAP` di `train_pii.py`) con una regex e non con un
+   `import`: una lista scritta a mano qui resterebbe indietro in silenzio e bloccherebbe contributi
+   corretti — aggiungere forme sotto un tag esistente (CIG, CUP, polizza, matricola → `DOCID`)
+   tocca solo quella mappa. Con un `import` servirebbero torch e transformers, che con
+   l'ispezione di un `.jsonl` non c'entrano nulla e non stanno nella CI dei test.
+
+2. **Informazione.** Quante cose diverse contiene: **strutture distinte** (template di origine +
+   sequenza delle label), righe per struttura, quota di righe nelle dieci più frequenti, testi
+   duplicati, composizione per label. Facoltativa la sovrapposizione dei testi con contribuzioni
+   già unite (`--contro FILE`, `--confronta` che le scarica).
+
+La grana è la struttura e non lo scheletro (testo con le entità sostituite dalle label), e la
+ragione è misurata: **lo scheletro punisce i template migliori.** Un template di bolletta in cui
+ogni valore iniettato è etichettato produce 1 solo scheletro su 500 righe; un atto che contiene un
+nome di tribunale non etichettato ne produce 343, perché basta che cambi quel nome. Ordinando per
+scheletri il secondo sembra quattro volte più ricco del primo, ed è il contrario. Lo scheletro
+resta come ripiego dichiarato per i file senza `template_id`.
+
+La memoria non dipende dal peso del file: dei testi si tengono impronte da 8 byte.
+
+Test: `tests/test_inspect_contribution.py`, 19 casi. Per **ogni** tipo di errore duro c'è un file
+che lo contiene e si pretende che venga contato — un controllo che accetta tutto è peggio di
+nessun controllo, perché fa credere che la coda sia stata verificata. Un test costruisce il caso
+bolletta/atto e verifica i due numeri (1 scheletro contro 3, una struttura ciascuno).
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/inspect/inspect_contribution.py
+++ b/src/inspect/inspect_contribution.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Ispeziona un file di contribuzione .jsonl: e' valido, e porta informazione o volume?
+
+    python src/inspect/inspect_contribution.py FILE.jsonl
+    python src/inspect/inspect_contribution.py FILE.jsonl --json        # per la coda
+    python src/inspect/inspect_contribution.py FILE.jsonl --contro ALTRO.jsonl
+
+Perche' serve, e a chi. Sul dataset comunitario le Pull Request di dati si accumulano piu' in
+fretta di quanto si riesca a leggerle, e il numero di righe -- l'unica cosa che il nome del file
+dichiara -- non dice se un contributo insegna qualcosa: 200.000 righe scritte da pochi template
+ripetono la stessa struttura centinaia di volte, e a valle costano download e tempo di training
+senza portare varieta'. Chi revisiona non ha modo di distinguerle da un file piccolo e ricco
+senza rifare la misura a mano, file per file. Questo script la fa in pochi secondi, e con --json
+si esegue su tutta la coda per ordinarla.
+
+Due cose insieme, perche' separate non bastano:
+
+  1. ERRORI DURI: ricalcola tutto da zero -- tokenizzazione, offset, coerenza BIO, checksum,
+     tassonomia -- senza fidarsi dello script che ha generato il file. Un file che sbaglia qui
+     non va unito: le label sbagliate insegnano al modello a sbagliare, e una label fuori
+     tassonomia diventa in silenzio una classe nuova (train_pii.py costruisce l'elenco DAI
+     DATI). Con errori duri l'uscita e' 1, cosi' vale da cancello in uno script.
+
+  2. INFORMAZIONE: quante cose DIVERSE contiene. La grana giusta e' la STRUTTURA -- template di
+     origine piu' sequenza delle label -- non il testo: i valori cambiano sempre per costruzione,
+     quindi "0 duplicati" e' vero anche in un file che ripete una frase sola.
+
+Sulla differenza fra struttura e scheletro (il testo con le entita' sostituite dalla label) c'e'
+una misura da tenere presente, perche' e' controintuitiva: lo scheletro PUNISCE i template
+migliori. Un template di bolletta in cui ogni valore iniettato e' etichettato produce 1 solo
+scheletro su 500 righe; un atto che contiene un nome di tribunale NON etichettato ne produce
+343, perche' basta che cambi quel nome. Ordinando per scheletri distinti il secondo sembra
+quattro volte piu' ricco del primo, ed e' il contrario. Percio' qui la struttura si usa quando
+il file porta template_id, e lo scheletro resta come ripiego dichiarato per i file che non ce
+l'hanno.
+
+Sola lettura: non modifica nulla, non carica nulla, e senza --confronta non tocca la rete.
+La memoria non dipende dal peso del file: dei testi si tengono solo impronte brevi.
+"""
+import argparse
+import hashlib
+import io
+import json
+import re
+import statistics
+import sys
+import unicodedata
+import urllib.parse
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", write_through=True)
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO_ID = "rizzoaiacademy/anonimizzazione-testi-italiano"
+
+# la stessa tokenizzazione dichiarata dal formato (docs/FORMATO_DATI.md) e usata da
+# generate_synthetic_pii.to_bio(): se i token del file non si riproducono con questa, le
+# bio_labels non sono allineate a niente di verificabile.
+TOKEN_RE = re.compile(r"\w+|[^\w\s]", re.UNICODE)
+
+# Ripiego se le fonti nel repo non sono leggibili (file eseguito fuori dall'albero).
+TAG_DI_SCORTA = {
+    "FULLNAME", "AGE", "GENDER", "DATE", "TIME", "STREET", "BUILDINGNUM", "ZIPCODE", "CITY",
+    "PROVINCE", "EMAIL", "TELEPHONENUM", "CF", "PIVA", "ID_DOC", "IBAN", "CREDITCARDNUMBER",
+    "AMOUNT", "TARGA", "ORG", "DOCID", "CATASTO",
+}
+
+
+def tassonomia():
+    """Le label ammesse, LETTE dal repo invece di riscritte qui.
+
+    Una lista scritta a mano in questo file resterebbe indietro in silenzio: aggiungere forme
+    nuove sotto un tag esistente (CIG, CUP, polizza, matricola -> DOCID) tocca solo TAG_MAP, e
+    l'ispettore le segnalerebbe come fuori tassonomia pur essendo corrette -- cioe' bloccherebbe
+    contributi buoni, che e' il danno peggiore per uno strumento di revisione.
+
+    Si legge con una regex e non con un import: train_pii.py importa torch e transformers, che
+    non c'entrano nulla con l'ispezione di un .jsonl e non sono installati nella CI dei test;
+    contribute_dataset.py, importato, carica il .env e semina il generatore casuale.
+    """
+    ammesse, fonti = set(), []
+    contrib = ROOT / "src" / "data_pipeline" / "contribute_dataset.py"
+    if contrib.is_file():
+        testo = contrib.read_text(encoding="utf-8")
+        for nome in ("TAG_FINALI", "TAG_GREZZI"):
+            m = re.search(nome + r"\s*=\s*\{(.*?)\}", testo, re.S)
+            if m:
+                ammesse |= set(re.findall(r'"([A-Z0-9_]+)"', m.group(1)))
+                fonti.append(f"{nome} da contribute_dataset.py")
+    train = ROOT / "src" / "training" / "train_pii.py"
+    if train.is_file():
+        m = re.search(r"^TAG_MAP\s*=\s*\{(.*?)^\}", train.read_text(encoding="utf-8"), re.S | re.M)
+        if m:
+            corpo = re.sub(r"#[^\n]*", "", m.group(1))          # via i commenti
+            ammesse |= set(re.findall(r'"([A-Z0-9_]+)"\s*:', corpo))
+            ammesse |= set(re.findall(r':\s*"([A-Z0-9_]+)"', corpo))
+            fonti.append("TAG_MAP da train_pii.py")
+    if not ammesse:
+        return TAG_DI_SCORTA, ["lista di scorta interna (fonti del repo non leggibili)"]
+    return ammesse, fonti
+
+
+# --- checksum: gli stessi del repo, ricalcolati qui per non importare nulla ---------------
+_ODD = {"0": 1, "1": 0, "2": 5, "3": 7, "4": 9, "5": 13, "6": 15, "7": 17, "8": 19, "9": 21,
+        "A": 1, "B": 0, "C": 5, "D": 7, "E": 9, "F": 13, "G": 15, "H": 17, "I": 19, "J": 21,
+        "K": 2, "L": 4, "M": 18, "N": 20, "O": 11, "P": 3, "Q": 6, "R": 8, "S": 12, "T": 14,
+        "U": 16, "V": 10, "W": 22, "X": 25, "Y": 24, "Z": 23}
+
+
+def cf_ok(c):
+    c = c.replace(" ", "").upper()
+    if len(c) != 16:
+        return False
+    try:
+        t = sum((_ODD[ch] if i % 2 == 0 else (int(ch) if ch.isdigit() else ord(ch) - 65))
+                for i, ch in enumerate(c[:15]))
+    except KeyError:
+        return False
+    return chr(65 + t % 26) == c[15]
+
+
+def piva_ok(p):
+    p = p.replace(" ", "")
+    if len(p) != 11 or not p.isdigit():
+        return False
+    t = 0
+    for i, c in enumerate(map(int, p[:10])):
+        t += c if i % 2 == 0 else (c * 2 - 9 if c * 2 > 9 else c * 2)
+    return (10 - t % 10) % 10 == int(p[10])
+
+
+def iban_ok(i):
+    i = i.replace(" ", "").upper()
+    if not re.fullmatch(r"IT\d{2}[A-Z]\d{22}", i):
+        return False
+    r = i[4:] + i[:4]
+    return int("".join(str(ord(c) - 55) if c.isalpha() else c for c in r)) % 97 == 1
+
+
+def luhn_ok(n):
+    if any(c not in " -." for c in n if not c.isdigit()):
+        return False
+    d = [int(c) for c in n if c.isdigit()][::-1]
+    if len(d) < 12:
+        return False
+    return sum(x if i % 2 == 0 else (x * 2 - 9 if x * 2 > 9 else x * 2)
+               for i, x in enumerate(d)) % 10 == 0
+
+
+CHECKSUM = {"CF": cf_ok, "PIVA": piva_ok, "TAXNUM": piva_ok, "IBAN": iban_ok,
+            "CREDITCARDNUMBER": luhn_ok}
+
+
+def impronta(testo):
+    """Impronta breve. Su un file da un milione di righe i testi interi non stanno in memoria,
+    e per contare i distinti bastano 8 byte per riga."""
+    return hashlib.blake2b(testo.encode(), digest_size=8).digest()
+
+
+def primo_non_latino(testo):
+    """Un modello locale piccolo o molto quantizzato infila ideogrammi nella prosa italiana:
+    se il template e' passato, quel carattere e' in ogni riga che lo usa."""
+    for ch in testo:
+        if ch.isalpha():
+            try:
+                if "LATIN" not in unicodedata.name(ch):
+                    return ch
+            except ValueError:
+                return ch
+    return None
+
+
+def struttura(rec):
+    """template_id + sequenza delle label: la grana su cui si misura la varieta'."""
+    labels = "|".join(e["label"] for e in sorted(rec["entities"], key=lambda e: e["start"]))
+    return impronta(f"{rec.get('template_id')}#{labels}")
+
+
+def scheletro(rec):
+    """Il testo con ogni entita' sostituita dalla sua label (ripiego senza template_id)."""
+    testo, pezzi, pos = rec["source_text"], [], 0
+    for e in sorted(rec["entities"], key=lambda e: e["start"]):
+        if e["start"] < pos:
+            continue
+        pezzi.append(testo[pos:e["start"]])
+        pezzi.append("{" + e["label"] + "}")
+        pos = e["end"]
+    pezzi.append(testo[pos:])
+    return impronta(" ".join("".join(pezzi).split()))
+
+
+def ispeziona(path, ammesse):
+    """Un solo passaggio sul file. Ritorna un dizionario di numeri e un Counter di errori."""
+    errori, label = Counter(), Counter()
+    strutture, scheletri, testi = Counter(), Counter(), set()
+    n = con_template_id = lung_tot = ent_tot = 0
+    lung_max = 0
+    for numero, riga in enumerate(open(path, encoding="utf-8"), 1):
+        if not riga.strip():
+            continue
+        try:
+            r = json.loads(riga)
+        except json.JSONDecodeError as e:
+            errori[f"JSON non valido (riga {numero}): {e.msg}"] += 1
+            continue
+        n += 1
+        testo = r.get("source_text")
+        if not isinstance(testo, str):
+            errori["source_text mancante o non testo"] += 1
+            continue
+        for campo in ("language", "tokens", "bio_labels", "entities"):
+            if campo not in r:
+                errori[f"campo mancante: {campo}"] += 1
+        if r.get("language") != "it":
+            errori[f"language != it: {r.get('language')!r}"] += 1
+        if r.get("tokens") is not None and TOKEN_RE.findall(testo) != r["tokens"]:
+            errori["tokens non riproducibili dalla regex del formato"] += 1
+        if len(r.get("tokens") or []) != len(r.get("bio_labels") or []):
+            errori["len(tokens) != len(bio_labels)"] += 1
+
+        entita = r.get("entities") or []
+        for e in entita:
+            if testo[e["start"]:e["end"]] != e["value"]:
+                errori["offset dell'entita' incoerente col testo"] += 1
+            if e["label"] not in ammesse:
+                errori[f"label fuori tassonomia: {e['label']}"] += 1
+            label[e["label"]] += 1
+            verifica = CHECKSUM.get(e["label"])
+            if verifica and not verifica(e["value"]):
+                errori[f"checksum non valido ({e['label']})"] += 1
+        ordinate = sorted(entita, key=lambda e: e["start"])
+        for a, b in zip(ordinate, ordinate[1:]):
+            if a["end"] > b["start"]:
+                errori["entita' sovrapposte"] += 1
+
+        atteso = None
+        for lab in r.get("bio_labels") or []:
+            if lab == "O":
+                atteso = None
+                continue
+            if not re.fullmatch(r"[BI]-\S+", lab):
+                errori[f"label BIO malformata: {lab}"] += 1
+                atteso = None
+                continue
+            if lab.startswith("I-") and atteso != lab[2:]:
+                errori["I- senza B- dello stesso tag"] += 1
+            atteso = lab[2:]
+
+        bad = primo_non_latino(testo)
+        if bad:
+            errori[f"carattere non latino nel testo: {bad!r}"] += 1
+
+        testi.add(impronta(testo))
+        scheletri[scheletro(r)] += 1
+        if r.get("template_id") is not None:
+            con_template_id += 1
+            strutture[struttura(r)] += 1
+        lung_tot += len(testo)
+        lung_max = max(lung_max, len(testo))
+        ent_tot += len(entita)
+
+    grana = "struttura" if con_template_id == n and n else "scheletro"
+    gruppi = strutture if grana == "struttura" else scheletri
+    conteggi = sorted(gruppi.values(), reverse=True) or [0]
+    return {
+        "righe": n,
+        "grana": grana,
+        "grana_plurale": "strutture" if grana == "struttura" else "scheletri",
+        "gruppi_distinti": len(gruppi),
+        "righe_per_gruppo_mediana": statistics.median(conteggi),
+        "righe_per_gruppo_max": conteggi[0],
+        "quota_nei_10_gruppi_piu_frequenti": (sum(conteggi[:10]) / n) if n else 0,
+        "scheletri_distinti": len(scheletri),
+        "testi_duplicati": n - len(testi),
+        "entita": sum(label.values()),
+        "label_distinte": len(label),
+        "label": dict(label.most_common()),
+        "lunghezza_media": (lung_tot / n) if n else 0,
+        "lunghezza_max": lung_max,
+        "entita_per_riga": (ent_tot / n) if n else 0,
+        "righe_senza_template_id": n - con_template_id,
+        "errori_duri": sum(errori.values()),
+    }, errori, testi
+
+
+def impronte_di(path):
+    with open(path, encoding="utf-8") as f:
+        return {impronta(json.loads(r)["source_text"]) for r in f if r.strip()}
+
+
+def impronte_dal_dataset(quanti=3):
+    """Le impronte dei testi di alcune contribuzioni GIA' unite, per misurare le
+    sovrapposizioni: un file che ripete righe gia' presenti non aggiunge niente."""
+    api = f"https://huggingface.co/api/datasets/{REPO_ID}"
+    with urllib.request.urlopen(api, timeout=60) as r:
+        siblings = [s["rfilename"] for s in json.load(r).get("siblings", [])]
+    out = {}
+    for nome in [f for f in siblings if f.endswith(".jsonl")][:quanti]:
+        url = (f"https://huggingface.co/datasets/{REPO_ID}/resolve/main/"
+               f"{urllib.parse.quote(nome)}")
+        try:
+            with urllib.request.urlopen(url, timeout=300) as resp:
+                righe = resp.read().decode().splitlines()
+            out[nome] = {impronta(json.loads(r)["source_text"]) for r in righe if r.strip()}
+        except Exception as e:                       # rete, non correttezza del file
+            out[nome] = e
+    return out
+
+
+def stampa(path, m, errori, fonti):
+    print(f"file: {path}")
+    print(f"tassonomia: {len(m['_ammesse'])} label ammesse ({'; '.join(fonti)})")
+    print()
+    print(f"ERRORI DURI: {m['errori_duri']}")
+    if errori:
+        for k, v in errori.most_common(15):
+            print(f"  {v:>7} x {k}")
+        if len(errori) > 15:
+            print(f"  (e altri {len(errori) - 15} tipi di errore)")
+    else:
+        print("  nessuno.")
+    print()
+    print("INFORMAZIONE")
+    print(f"  righe: {m['righe']}")
+    print(f"  {m['grana_plurale']} distinte: {m['gruppi_distinti']}"
+          f"  ({100 * m['gruppi_distinti'] / max(m['righe'], 1):.1f}% delle righe)")
+    if m["grana"] == "scheletro":
+        print(f"    grana di ripiego: {m['righe_senza_template_id']} righe non portano "
+              f"template_id (lo scheletro sottostima i template che etichettano tutto)")
+    else:
+        print(f"  scheletri distinti: {m['scheletri_distinti']} (per confronto)")
+    print(f"  righe per {m['grana']}: mediana "
+          f"{m['righe_per_gruppo_mediana']:.0f}, max {m['righe_per_gruppo_max']}")
+    print(f"  quota di righe nelle 10 {m['grana_plurale']} piu' frequenti: "
+          f"{100 * m['quota_nei_10_gruppi_piu_frequenti']:.0f}%")
+    print(f"  testi duplicati nel file: {m['testi_duplicati']}")
+    print()
+    print(f"COMPOSIZIONE  ({m['entita']} entita' su {m['label_distinte']} label, "
+          f"{m['entita_per_riga']:.1f} per riga; testo medio {m['lunghezza_media']:.0f} "
+          f"caratteri, max {m['lunghezza_max']})")
+    for k, v in list(m["label"].items())[:8]:
+        print(f"  {k:20s} {v:7d}  {100 * v / max(m['entita'], 1):5.1f}%")
+    rare = list(m["label"].items())[-4:]
+    if len(m["label"]) > 12:
+        print(f"  ... meno rappresentate: {', '.join(f'{k} ({v})' for k, v in rare)}")
+
+
+def sintesi(m):
+    """Le due righe da incollare nel corpo della Pull Request: sono quelle che permettono a chi
+    revisiona di giudicare senza rifare la misura."""
+    return (f"{m['righe']} righe, **{m['gruppi_distinti']} {m['grana_plurale']} distinte** "
+            f"(max {m['righe_per_gruppo_max']} righe per {m['grana']}), "
+            f"{m['entita']} entita' su {m['label_distinte']} label, "
+            f"{m['testi_duplicati']} testi duplicati, {m['errori_duri']} errori di validita'.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("path", help="il file .jsonl da ispezionare")
+    ap.add_argument("--contro", metavar="FILE",
+                    help="misura la sovrapposizione dei testi con un altro file locale")
+    ap.add_argument("--confronta", action="store_true",
+                    help="scarica alcune contribuzioni gia' unite e misura le sovrapposizioni")
+    ap.add_argument("--json", action="store_true",
+                    help="stampa i numeri come JSON (per ispezionare una coda di PR)")
+    args = ap.parse_args()
+
+    if not Path(args.path).is_file():
+        sys.exit(f"ERRORE: file inesistente: {args.path}")
+
+    ammesse, fonti = tassonomia()
+    m, errori, mie = ispeziona(args.path, ammesse)
+    m["_ammesse"] = sorted(ammesse)
+
+    sovrapposizioni = {}
+    if args.contro:
+        altre = impronte_di(args.contro)
+        sovrapposizioni[args.contro] = len(mie & altre)
+    if args.confronta:
+        for nome, altre in impronte_dal_dataset().items():
+            sovrapposizioni[nome] = (f"non scaricato ({altre})"
+                                     if isinstance(altre, Exception) else len(mie & altre))
+
+    if args.json:
+        fuori = {k: v for k, v in m.items() if k != "_ammesse"}
+        fuori["errori"] = dict(errori.most_common())
+        fuori["sovrapposizioni"] = sovrapposizioni
+        fuori["sintesi"] = sintesi(m)
+        print(json.dumps(fuori, ensure_ascii=False, indent=1))
+    else:
+        stampa(args.path, m, errori, fonti)
+        if sovrapposizioni:
+            print("\nSOVRAPPOSIZIONE dei testi con altri file")
+            for nome, quanti in sovrapposizioni.items():
+                print(f"  {nome.split('/')[-1]}: {quanti}")
+        print(f"\nSINTESI (da incollare nella PR)\n  {sintesi(m)}")
+
+    # uscita 1 SOLO sugli errori duri: la soglia oltre la quale un contributo e' troppo
+    # ripetitivo e' una decisione di chi mantiene il progetto, non di questo script.
+    return 1 if m["errori_duri"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_inspect_contribution.py
+++ b/tests/test_inspect_contribution.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+"""L'ispettore delle contribuzioni: respinge i file guasti e misura la varieta'.
+
+Un controllo che accetta tutto e' peggio di nessun controllo, perche' fa credere che la coda
+sia stata verificata. Quindi qui, per ogni tipo di errore duro, si costruisce un file che lo
+contiene e si pretende che venga contato -- non basta che i file buoni passino.
+
+La parte sulla varieta' verifica la misura controintuitiva su cui si regge lo strumento: lo
+SCHELETRO (testo con le entita' sostituite dalla label) sottostima proprio i template migliori,
+quelli che etichettano ogni valore iniettato, e per questo la grana usata e' la STRUTTURA.
+
+Tutti i valori sono SINTETICI: i codici fiscali e gli IBAN qui sotto hanno checksum validi ma
+non appartengono a nessuno.
+"""
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "inspect"))
+
+import inspect_contribution as ic  # noqa: E402
+
+TOKEN = ic.TOKEN_RE.findall
+
+
+def riga(testo, entita, template_id=1):
+    """Una riga valida: token e BIO ricalcolati dal testo, come fa il formato."""
+    tokens = TOKEN(testo)
+    bio = ["O"] * len(tokens)
+    # posizione di ogni token nel testo, per assegnare le label agli indici giusti
+    pos, offsets = 0, []
+    for t in tokens:
+        i = testo.index(t, pos)
+        offsets.append((i, i + len(t)))
+        pos = i + len(t)
+    for e in entita:
+        primo = True
+        for k, (a, b) in enumerate(offsets):
+            if a >= e["start"] and b <= e["end"]:
+                bio[k] = ("B-" if primo else "I-") + e["label"]
+                primo = False
+    return {"source_text": testo, "language": "it", "template_id": template_id,
+            "entities": entita, "tokens": tokens, "bio_labels": bio}
+
+
+def ent(testo, valore, label):
+    i = testo.index(valore)
+    return {"value": valore, "label": label, "start": i, "end": i + len(valore)}
+
+
+# checksum validi e verificati: la lettera di controllo di RSSMRA85M01H501 e' Q, non Z --
+# la Z e' l'errore che si trova negli esempi scritti a mano, ed e' il caso invalido qui sotto.
+CF_VALIDO = "RSSMRA85M01H501Q"
+CF_NON_VALIDO = "RSSMRA85M01H501Z"
+IBAN_VALIDO = "IT60X0542811101000000123456"
+
+
+def buona(nome="Mario", tid=1):
+    t = f"Il ricorrente {nome} Rossi, C.F. {CF_VALIDO}, chiede il bonifico su {IBAN_VALIDO}."
+    return riga(t, [ent(t, nome, "GIVENNAME"), ent(t, "Rossi", "SURNAME"),
+                    ent(t, CF_VALIDO, "CF"), ent(t, IBAN_VALIDO, "IBAN")], tid)
+
+
+def scrivi(righe):
+    f = tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, encoding="utf-8")
+    for r in righe:
+        f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    f.close()
+    return f.name
+
+
+def ispeziona(righe):
+    m, errori, _ = ic.ispeziona(scrivi(righe), ic.tassonomia()[0])
+    return m, errori
+
+
+class FileValido(unittest.TestCase):
+
+    def test_nessun_errore_e_numeri_giusti(self):
+        m, errori = ispeziona([buona("Mario"), buona("Giulia"), buona("Anna")])
+        self.assertEqual(dict(errori), {})
+        self.assertEqual(m["errori_duri"], 0)
+        self.assertEqual(m["righe"], 3)
+        self.assertEqual(m["entita"], 12)
+        self.assertEqual(m["testi_duplicati"], 0)
+
+    def test_i_duplicati_veri_si_contano(self):
+        m, _ = ispeziona([buona("Mario"), buona("Mario")])
+        self.assertEqual(m["testi_duplicati"], 1)
+
+    def test_la_tassonomia_si_legge_dal_repo(self):
+        ammesse, fonti = ic.tassonomia()
+        self.assertIn("CF", ammesse)          # tag finale
+        self.assertIn("GIVENNAME", ammesse)   # label grezza rimappata da TAG_MAP
+        self.assertIn("CIG", ammesse)         # forma aggiunta sotto DOCID: il caso della deriva
+        self.assertTrue(any("train_pii" in f or "contribute_dataset" in f for f in fonti),
+                        "la tassonomia deve venire dal repo, non da una lista scritta a mano")
+
+
+class ErroriDuri(unittest.TestCase):
+    """Ogni errore che rende un file inutilizzabile deve essere CONTATO, non ignorato."""
+
+    def test_offset_incoerente(self):
+        r = buona()
+        r["entities"][0]["start"] += 3        # la span non copre piu' il valore
+        _, errori = ispeziona([r])
+        self.assertIn("offset dell'entita' incoerente col testo", errori)
+
+    def test_label_fuori_tassonomia(self):
+        r = buona()
+        r["entities"][0]["label"] = "CREDITCARD"   # il refuso classico di CREDITCARDNUMBER
+        _, errori = ispeziona([r])
+        self.assertTrue(any("fuori tassonomia" in k for k in errori))
+
+    def test_checksum_non_valido(self):
+        t = f"Codice fiscale {CF_NON_VALIDO} del richiedente."
+        r = riga(t, [ent(t, CF_NON_VALIDO, "CF")])        # lettera di controllo sbagliata
+        _, errori = ispeziona([r])
+        self.assertTrue(any("checksum non valido" in k for k in errori))
+
+    def test_token_non_riproducibili(self):
+        r = buona()
+        r["tokens"] = r["tokens"][:-1]
+        _, errori = ispeziona([r])
+        self.assertIn("tokens non riproducibili dalla regex del formato", errori)
+        self.assertIn("len(tokens) != len(bio_labels)", errori)
+
+    def test_bio_i_senza_b(self):
+        r = buona()
+        r["bio_labels"] = ["I-CF"] + ["O"] * (len(r["tokens"]) - 1)
+        _, errori = ispeziona([r])
+        self.assertIn("I- senza B- dello stesso tag", errori)
+
+    def test_entita_sovrapposte(self):
+        t = f"Il ricorrente Mario Rossi paga."
+        e1 = ent(t, "Mario Rossi", "FULLNAME")
+        e2 = ent(t, "Rossi", "SURNAME")
+        _, errori = ispeziona([riga(t, [e1, e2])])
+        self.assertIn("entita' sovrapposte", errori)
+
+    def test_lingua_sbagliata(self):
+        r = buona()
+        r["language"] = "en"
+        _, errori = ispeziona([r])
+        self.assertTrue(any("language != it" in k for k in errori))
+
+    def test_carattere_non_latino(self):
+        t = "Il ricorrente 漢 chiede il pagamento."
+        _, errori = ispeziona([riga(t, [])])
+        self.assertTrue(any("non latino" in k for k in errori))
+
+    def test_json_non_valido(self):
+        f = tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, encoding="utf-8")
+        f.write(json.dumps(buona()) + "\n{non json}\n")
+        f.close()
+        _, errori, _ = ic.ispeziona(f.name, ic.tassonomia()[0])
+        self.assertTrue(any("JSON non valido" in k for k in errori))
+
+    def test_uscita_diversa_da_zero_sui_file_guasti(self):
+        """L'ispettore vale da cancello solo se il codice d'uscita lo dice."""
+        r = buona()
+        r["entities"][0]["label"] = "NONESISTE"
+        argv, out = sys.argv, sys.stdout
+        try:
+            sys.stdout = io.StringIO()          # il rapporto non serve nell'output dei test
+            sys.argv = ["inspect_contribution", scrivi([r])]
+            guasto = ic.main()
+            sys.argv = ["inspect_contribution", scrivi([buona()])]
+            valido = ic.main()
+        finally:
+            sys.argv, sys.stdout = argv, out
+        self.assertEqual(guasto, 1)
+        self.assertEqual(valido, 0)
+
+
+class MisuraDellaVarieta(unittest.TestCase):
+
+    def test_struttura_quando_c_e_template_id(self):
+        m, _ = ispeziona([buona("Mario", 1), buona("Giulia", 1), buona("Anna", 2)])
+        self.assertEqual(m["grana"], "struttura")
+        self.assertEqual(m["gruppi_distinti"], 2)      # due template_id
+        self.assertEqual(m["righe_per_gruppo_max"], 2)
+
+    def test_scheletro_come_ripiego_senza_template_id(self):
+        righe = [buona("Mario"), buona("Giulia")]
+        for r in righe:
+            del r["template_id"]
+        m, _ = ispeziona(righe)
+        self.assertEqual(m["grana"], "scheletro")
+        self.assertEqual(m["righe_senza_template_id"], 2)
+
+    def test_lo_scheletro_sottostima_i_template_che_etichettano_tutto(self):
+        """Il caso misurato che motiva la scelta della struttura.
+
+        Nel template "bolletta" OGNI valore iniettato e' etichettato: righe diverse hanno lo
+        STESSO scheletro, e contando gli scheletri sembra un template povero. Nel template
+        "atto" il nome del tribunale NON e' etichettato: ogni valore diverso crea uno scheletro
+        nuovo, e l'atto sembra piu' ricco. Le strutture dicono la verita': una ciascuno.
+        """
+        bollette, atti = [], []
+        for citta in ("Roma", "Milano", "Napoli"):
+            t = f"Intestatario Mario Rossi, fornitura in {citta}, totale 100,00 EUR."
+            bollette.append(riga(t, [ent(t, "Mario", "GIVENNAME"), ent(t, "Rossi", "SURNAME"),
+                                     ent(t, citta, "CITY"), ent(t, "100,00 EUR", "AMOUNT")], 1))
+        for tribunale in ("Roma", "Milano", "Napoli"):
+            t = f"Tribunale di {tribunale}: il ricorrente Mario Rossi chiede 100,00 EUR."
+            atti.append(riga(t, [ent(t, "Mario", "GIVENNAME"), ent(t, "Rossi", "SURNAME"),
+                                 ent(t, "100,00 EUR", "AMOUNT")], 2))
+
+        b, _ = ispeziona(bollette)
+        a, _ = ispeziona(atti)
+        self.assertEqual(b["scheletri_distinti"], 1, "la bolletta etichetta tutto: 1 scheletro")
+        self.assertEqual(a["scheletri_distinti"], 3, "l'atto lascia il tribunale in chiaro: 3")
+        # la grana usata non si fa ingannare: una struttura per ciascuno
+        self.assertEqual(b["gruppi_distinti"], 1)
+        self.assertEqual(a["gruppi_distinti"], 1)
+
+    def test_sovrapposizione_fra_due_file(self):
+        a = scrivi([buona("Mario"), buona("Giulia")])
+        b = scrivi([buona("Giulia"), buona("Anna")])
+        _, _, mie = ic.ispeziona(a, ic.tassonomia()[0])
+        self.assertEqual(len(mie & ic.impronte_di(b)), 1)
+
+    def test_la_sintesi_contiene_i_numeri_da_incollare(self):
+        m, _ = ispeziona([buona("Mario"), buona("Anna")])
+        s = ic.sintesi(m)
+        self.assertIn("2 righe", s)
+        self.assertIn("strutture distinte", s)
+        self.assertIn("0 errori", s)
+
+
+class FileVuoto(unittest.TestCase):
+
+    def test_non_esplode_e_non_divide_per_zero(self):
+        m, errori = ispeziona([])
+        self.assertEqual(m["righe"], 0)
+        self.assertEqual(m["gruppi_distinti"], 0)
+        self.assertEqual(m["errori_duri"], 0)
+        self.assertIn("0 righe", ic.sintesi(m))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ispezionare una contribuzione: valida e' meta' del giudizio, l'altra meta' e' quanta informazione porta

Le PR di dati arrivano piu' in fretta di quanto si riesca a leggerle, e il numero di righe --
l'unica cosa che il nome del file dichiara -- non dice se il contributo insegna qualcosa:
200.000 righe scritte da pochi template ripetono la stessa struttura centinaia di volte, e a
valle costano download e tempo di training senza portare varieta'. Chi revisiona non ha modo
di distinguerle da un file piccolo e ricco senza rifare la misura a mano, file per file.

src/inspect/inspect_contribution.py fa due cose che separate non bastano:

1. ERRORI DURI, ricalcolati da zero senza fidarsi dello script che ha generato il file:
   tokenizzazione con la regex del formato, offset delle entita', coerenza BIO (I- senza B-),
   entita' sovrapposte, checksum CF/PIVA/IBAN/Luhn, lingua, caratteri non latini. Uscita != 0,
   quindi vale da cancello in uno script. La tassonomia si LEGGE dal repo (TAG_FINALI/TAG_GREZZI
   di contribute_dataset.py, TAG_MAP di train_pii.py) con una regex e non con un import: una
   lista scritta a mano qui resterebbe indietro in silenzio e bloccherebbe contributi corretti,
   perche' aggiungere forme sotto un tag esistente tocca solo quella mappa; e un import
   pretenderebbe torch e transformers, che con un .jsonl non c'entrano e non stanno nella CI.

2. INFORMAZIONE: strutture distinte (template + sequenza delle label), righe per struttura,
   quota di righe nelle dieci piu' frequenti, testi duplicati, composizione per label. Con
   --json gli stessi numeri sono un oggetto, cosi' la coda intera si ispeziona in serie e si
   ordina per informazione invece che per peso. Facoltativa la sovrapposizione con le
   contribuzioni gia' unite (--contro FILE, --confronta che le scarica).

La grana e' la STRUTTURA e non lo scheletro, e la ragione e' misurata: lo scheletro punisce i
template migliori. Un template di bolletta in cui ogni valore iniettato e' etichettato produce
1 solo scheletro su 500 righe; un atto con un nome di tribunale NON etichettato ne produce 343,
perche' basta che cambi quel nome. Ordinando per scheletri il secondo sembra quattro volte piu'
ricco del primo, ed e' il contrario. Lo scheletro resta come ripiego per i file senza
template_id, dichiarato nell'output.

La memoria non dipende dal peso del file: dei testi si tengono impronte da 8 byte.

Test: 19 casi. Per OGNI tipo di errore duro c'e' un file che lo contiene e si pretende che venga
contato -- un controllo che accetta tutto e' peggio di nessun controllo, perche' fa credere che
la coda sia stata verificata. Un test costruisce il caso bolletta/atto e verifica i due numeri
(1 scheletro contro 3, una struttura ciascuno). Suite intera: 54 test, OK.

Provato anche su un file di contribuzione vero da 26.350 righe: 0 errori, 1.054 strutture,
6.615 scheletri, 0 duplicati, 375.900 entita' su 36 label, e i 4.900 codici fiscali del file
(prodotti dal generatore del repo) passano tutti il checksum ricalcolato qui.

CONTRIBUTING dice ora di eseguirlo prima di aprire la PR e di incollare i numeri nel corpo:
dichiarare le strutture permette a chi revisiona di giudicare senza rifare la misura.


---

### Esempio di uscita, sul file di una contribuzione vera

```
ERRORI DURI: 0
  nessuno.

INFORMAZIONE
  righe: 26350
  strutture distinte: 1054  (4.0% delle righe)
  scheletri distinti: 6615 (per confronto)
  righe per struttura: mediana 25, max 25
  quota di righe nelle 10 strutture piu' frequenti: 1%
  testi duplicati nel file: 0

SINTESI (da incollare nella PR)
  26350 righe, 1054 strutture distinte (max 25 righe per struttura), 375900 entita'
  su 36 label, 0 testi duplicati, 0 errori di validita'.
```

E su un file guasto, dove serve davvero:

```
ERRORI DURI: 2
        1 x tokens non riproducibili dalla regex del formato
        1 x label fuori tassonomia: CREDITCARD
```

uscita `1`, quindi si puo' mettere in uno script sulla coda.

### Perche' credo che serva adesso

Sul dataset ci sono **226 Pull Request aperte** e l'ultimo aggiornamento e' dell'**8 luglio**:
la coda cresce di qualche PR al giorno e non si smaltisce. Non manca chi produce dati, manca il
modo di **giudicarli in fretta** — e nessuno unisce un file che non sa valutare. Questo e' il
pezzo che mi sembrava mancasse: `src/inspect/` ha gli ispettori per i dataset di partenza
(`inspect_ai4privacy`, `inspect_lengths`, `inspect_no_iban`), ma niente per un file contribuito.

Se preferite soglie automatiche (rifiutare sotto tot strutture per mille righe) le aggiungo
volentieri, ma non le ho messe: dove sta la soglia e' una decisione vostra, non di uno script.
