### PR TITLE
fix(app): la carta con la scadenza attaccata restava in chiaro

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,46 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — La carta con la scadenza attaccata restava in chiaro (`detectors.py`)
+
+Il modo normale di scrivere una carta è numero **e scadenza di seguito**. Il detector
+`CREDITCARDNUMBER` è avido e ingloba il mese, il Luhn fallisce sulla sequenza allungata, e
+`strict=True` scarta tutto: il numero resta **in chiaro** nel documento anonimizzato.
+
+    'Carta 4111 1111 1111 1111 12/26'  ->  nessun match
+    'PAN 4111-1111-1111-1111 12/26'    ->  nessun match
+    'Carta 4111 1111 1111 1111 scadenza 12/26'  ->  trovata (basta una parola in mezzo)
+
+Quando il Luhn fallisce si riprova tagliando la coda, con tre vincoli che la tengono stretta:
+il taglio deve cadere su un **separatore già presente**, quel che resta fuori dev'essere fra
+**due e quattro cifre**, e deve **somigliare a una scadenza** (mese fra 1 e 12). Le lunghezze
+provate, dalla più lunga, sono le stesse che accetta `luhn_ok` (19…13): se la lista si ferma
+prima, di un PAN di 17 cifre se ne coprono 16 e l'ultima resta leggibile **accanto al
+segnaposto**, che è peggio di non mascherare affatto.
+
+Il minimo di due cifre non è un dettaglio: una cifra sola supera «mese fra 1 e 12» nove volte
+su dieci, e da sola faceva quasi raddoppiare i falsi positivi sui numeri di 17 cifre.
+
+Misure su PAN **sintetici** col Luhn calcolato apposta: 8.400 numeri, lunghezze da 13 a 19,
+tre spaziature (compatta, spazi, trattini), quattro code (`12/26`, `12 26`, `1226`, `03/28`).
+
+| | main | dopo |
+|---|---:|---:|
+| PAN con la scadenza attaccata, in chiaro | 65,8% (5.524/8.400) | **0** |
+| PAN **senza** scadenza attaccata, in chiaro (controllo) | 0 | **0** |
+| falsi positivi, 16 cifre + 1 (15.000 numeri di pratica) | 9,79% | **9,79%** |
+| falsi positivi, 16 cifre + 2 | 9,70% | 10,97% |
+| falsi positivi, 16 cifre + 3 | 10,27% | 11,40% |
+| match su **120.911 testi reali** (Ai4Privacy) | 891 | **891, span identiche** |
+
+Sul corpus reale non cambia niente: stesse 891 span, **zero differenze** su 120.911 testi. Il
+costo si paga solo dove il Luhn ha già fallito, quindi sulla prosa è nel rumore; su un documento
+fitto di numeri lunghi (estratto conto, tabulato) è dell'ordine del 20%, non zero.
+
+`tests/test_carta_scadenza.py` copre i due modi di sbagliare del taglio; due dei cinque test
+falliscono su `main`.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/app/detectors.py
+++ b/src/app/detectors.py
@@ -267,6 +267,38 @@ def detect_iban(text):
     return [e for e in ents if e["end"] > e["start"]]
 
 
+# Dalla piu' lunga: le stesse lunghezze che accetta luhn_ok, cosi' un PAN non viene
+# tagliato a una lunghezza piu' corta che passa il Luhn per caso (con 17 fuori dalla
+# lista, di un PAN di 17 cifre se ne coprivano 16 e l'ultima restava in chiaro).
+_CARD_LEN = (19, 18, 17, 16, 15, 14, 13)
+_CARD_CODA = 4                     # cifre di coda ammesse: la scadenza, "12/26" o "12 26"
+
+
+def _card_scadenza(coda):
+    """La coda deve somigliare a una scadenza: due-quattro cifre, col mese fra 1 e 12.
+    E' il vincolo che tiene bassi i falsi positivi: senza, un numero lungo qualsiasi
+    trova per caso un prefisso che passa il Luhn. Una sola cifra non e' mai una
+    scadenza, e ammetterla faceva passare 9 code su 10."""
+    return 2 <= len(coda) <= 4 and 1 <= int(coda[:2]) <= 12
+
+
+def _card_senza_scadenza(text, start, end):
+    """La scadenza attaccata al numero ("4111 1111 1111 1111 12/26") entra nel match:
+    il Luhn fallisce, strict lo scarta e la carta resta IN CHIARO. Qui si riprova
+    tagliando la coda, ma solo su un separatore gia' presente e solo se quel che resta
+    fuori e' un mese plausibile."""
+    s = text[start:end]
+    d = [i for i, c in enumerate(s) if c.isdigit()]
+    for n in _CARD_LEN:
+        if not 0 < len(d) - n <= _CARD_CODA:
+            continue
+        taglio = d[n - 1] + 1
+        if (s[taglio] in " .-" and _card_scadenza(re.sub(r"\D", "", s[taglio:]))
+                and luhn_ok(s[:taglio])):
+            return start + taglio, True
+    return end, False
+
+
 def detect_regex(text):
     """Entita' della rete regex. validated=True solo quando il checksum passa."""
     ents = detect_iban(text)
@@ -279,6 +311,8 @@ def detect_regex(text):
                 if end <= start:
                     continue
             ok = validator(m.group(0)) if validator else False
+            if not ok and label == "CREDITCARDNUMBER":
+                end, ok = _card_senza_scadenza(text, start, end)
             if validator and strict and not ok:
                 continue
             ents.append({

--- a/tests/test_carta_scadenza.py
+++ b/tests/test_carta_scadenza.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Carta con la scadenza attaccata — `detectors._card_senza_scadenza()`.
+
+Il modo normale di scrivere una carta è numero **e scadenza di seguito**: il detector è
+avido, ingloba il mese, il Luhn fallisce sulla sequenza allungata e `strict` scarta tutto,
+lasciando il PAN in chiaro. Quando il Luhn fallisce si riprova tagliando la coda.
+
+I due modi di sbagliare del taglio, ed è il secondo quello grave:
+
+  - tagliare dove non si doveva  -> nasce un falso positivo su un numero lungo qualsiasi;
+  - tagliare troppo corto        -> esce un `[CREDITCARDNUMBER_1]` che copre solo una parte
+                                    del PAN e le cifre restanti sono leggibili accanto al
+                                    segnaposto. Peggio che non mascherare, perché l'utente
+                                    crede di aver finito.
+
+Tutti i numeri sono SINTETICI, con il Luhn calcolato apposta. `4111 1111 1111 1111` è il
+PAN di test riservato già usato dal resto del repo.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+import detectors  # noqa: E402
+
+CARTA = "4111 1111 1111 1111"          # PAN di test riservato
+PAN17 = "60112222333344447"            # 17 cifre, Luhn valido, sintetico
+# 16 cifre col Luhn valido, ma è un numero di pratica. Scelto perché con le code qui sotto
+# il numero INTERO non è a sua volta Luhn-valido: solo così il taglio viene davvero tentato
+# ed è la guardia a doverlo respingere. (Una coda di due zeri conserva sempre il Luhn, per
+# quello non compare: sarebbe un caso irraggiungibile, non un test.)
+NON_CARTA = "9010000000000009"
+
+
+def carte(testo):
+    return [testo[e["start"]:e["end"]] for e in detectors.detect_regex(testo)
+            if e["label"] == "CREDITCARDNUMBER"]
+
+
+class CartaConScadenza(unittest.TestCase):
+    def test_scadenza_attaccata_il_pan_esce_intero(self):
+        for coda in ("12/26", "12 26", "1226", "03/28"):
+            for pan in (CARTA, CARTA.replace(" ", "-"), CARTA.replace(" ", "")):
+                testo = "Pagamento con carta %s %s." % (pan, coda)
+                self.assertEqual(carte(testo), [pan], testo)
+
+    def test_senza_scadenza_niente_cambia(self):
+        for pan in (CARTA, CARTA.replace(" ", "-"), CARTA.replace(" ", "")):
+            testo = "Carta %s intestata al ricorrente." % pan
+            self.assertEqual(carte(testo), [pan], testo)
+
+    def test_il_pan_non_viene_tagliato_a_meta(self):
+        """17 cifre: se la lista delle lunghezze si ferma a 16, l'ultima resta in chiaro."""
+        testo = "Carta %s 12/26 intestata." % PAN17
+        self.assertEqual(carte(testo), [PAN17], testo)
+
+    def test_una_cifra_sola_non_e_una_scadenza(self):
+        """Coda di una cifra: senza il vincolo passa 9 volte su 10 e nasce un falso positivo."""
+        testo = "Rif. pratica %s 9 del fascicolo." % NON_CARTA
+        self.assertEqual(carte(testo), [], testo)
+
+    def test_mese_fuori_scala(self):
+        for coda in ("13", "99"):
+            testo = "Rif. %s %s del fascicolo." % (NON_CARTA, coda)
+            self.assertEqual(carte(testo), [], testo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Il modo normale di scrivere una carta è numero **e scadenza di seguito**. Il detector
`CREDITCARDNUMBER` è avido e ingloba il mese, il Luhn fallisce sulla sequenza allungata, e
`strict=True` scarta tutto: il numero resta **in chiaro** nel documento anonimizzato.

    'Carta 4111 1111 1111 1111 12/26'  ->  nessun match
    'PAN 4111-1111-1111-1111 12/26'    ->  nessun match
    'Carta 4111 1111 1111 1111 scadenza 12/26'  ->  trovata (basta una parola in mezzo)

## La modifica

Quando il Luhn fallisce si riprova tagliando la coda, con tre vincoli che la tengono stretta:

1. il taglio deve cadere su un **separatore già presente**;
2. quel che resta fuori dev'essere fra **due e quattro cifre**;
3. e deve **somigliare a una scadenza**: mese fra 1 e 12.

Le lunghezze provate, dalla più lunga, sono le stesse che accetta `luhn_ok` (19…13).

## Due cose che avevo sbagliato nella prima stesura

**Il numero di esempio.** Usavo `4539 1488 0343 6467`: Luhn valido e in un intervallo Visa
realmente emesso. Non ho prova che corrisponda a una carta esistente, ma non ho modo di
escluderlo, e non è un valore da pubblicare. Ora è `4111 1111 1111 1111`, il PAN di test
riservato che il repo già usa in `TASSONOMIA_TAG.md`, nella legenda dei tag e in
`test_detector_formats.py`. Gli esempi si comportano identici.

**La coda di una cifra sola.** `len(coda) <= 4` accettava anche una cifra: `int("9")` sta fra
1 e 12, quindi nove code su dieci passavano per «mese». Su numeri di 17 cifre che non sono
carte i falsi positivi salivano dal 9,79% di `main` al **17,85%**, quasi il doppio, mentre il
corpo della PR dichiarava +1,2 punti. Con `2 <= len(coda) <= 4` tornano a **9,79%**, esattamente
il livello di `main`, **senza perdere un solo caso di recall**.

**E una lacuna.** La lista si fermava a 16 saltando 17 e 18, con il commento «17 e 18 non
esistono». Ma `luhn_ok` accetta 13…19 e la regex pure, quindi `main` già tratta come carta un
numero di 17 cifre col Luhn valido — e con 17 fuori dalla lista, di quel PAN se ne coprivano 16
e **l'ultima cifra restava leggibile accanto al segnaposto**. Per questo prodotto è il modo
peggiore di sbagliare: l'utente vede `[CREDITCARDNUMBER_1]` e conclude di aver finito. Con le
lunghezze allineate a `luhn_ok`, i PAN di 17 cifre passano da **398/1200 a 1200/1200**.

Il ramo `19`, per inciso, non era raggiungibile: la regex si ferma a 19 cifre e la guardia ne
pretendeva 20.

## Verifica

PAN **sintetici** col Luhn calcolato apposta: 8.400 numeri, lunghezze da 13 a 19, tre
spaziature (compatta, spazi, trattini), quattro code (`12/26`, `12 26`, `1226`, `03/28`).

| | main | questa PR come stava | ora |
|---|---:|---:|---:|
| PAN con la scadenza attaccata, in chiaro | 65,8% | 10,8% | **0** |
| PAN **senza** scadenza attaccata (controllo) | 0 | 0 | **0** |
| falsi positivi, 16 cifre + 1 (15.000 numeri) | 9,79% | 17,85% | **9,79%** |
| falsi positivi, 16 cifre + 2 | 9,70% | 10,97% | 10,97% |
| falsi positivi, 16 cifre + 3 | 10,27% | 11,40% | 11,40% |
| match su **120.911 testi reali** (Ai4Privacy) | 891 | 891 | **891, span identiche** |

Sul corpus reale: **zero differenze di span** fra `main` e questa PR su 120.911 testi.

`tests/test_carta_scadenza.py`, nuovo, copre i due modi di sbagliare del taglio — tagliare dove
non si doveva (falso positivo) e tagliare troppo corto (mezzo PAN in chiaro). **Due dei cinque
test falliscono su `main`.** Suite completa: OK.

Una nota sul costo, perché la prima stesura diceva «invariato»: il taglio si tenta quando il
Luhn ha già fallito, e il Luhn fallisce su circa il 90% dei candidati, quindi quel percorso è
il caso normale, non l'eccezione. Sulla prosa il delta resta nel rumore; su 2 MB di tabulato
numerico è dell'ordine del 20%.
