### PR TITLE
fix(app): l'ora perdeva i minuti, e la data non deve pagarne il prezzo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,56 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — L'ora perdeva i minuti (`detectors.py`)
+
+`TIME` è il tag più debole della valutazione indipendente della issue #18 (69,4%) e l'unico
+senza una regex ad affiancare il modello. Il modello **taglia i minuti** e la metà che resta
+finisce in chiaro accanto al placeholder:
+
+    'Ingresso ore 18:28'  ->  'Ingresso ore [TIME_1], uscita ore 18[TIME_2]30.'
+
+La forma coi due punti è chiusa (0-23 : 0-59, secondi opzionali) e si presta a una regex
+deterministica.
+
+**Il punto non è accettato.** `10.30` ha la stessa forma di `versione 1.30`, `capitolo 3.15`,
+`euro 10.30` e delle coordinate: ammettendolo la recall sale ma compaiono falsi positivi su
+metà delle frasi di prova. È il formato più fragile per il modello (28% di fallimenti misurati)
+e resta scoperto: senza contesto non è distinguibile.
+
+`TIME` sta in **`SOFT_REGEX_LABELS`**, come `DATE`, ed è il punto su cui regge tutto il resto.
+Una data spesso **include** l'ora, e in un timestamp ISO (`2026-03-15T10:30:00`) la data la
+trova solo il modello, in un'unica span: se `TIME` avesse la priorità della rete regex
+scalzerebbe quella span in fusione e lascerebbe `2026-03-` **in chiaro**, la data del documento
+sotto un segnaposto che dice il contrario. Da soft perde contro il modello e vince solo dove
+nessuno reclama l'ora.
+
+Misure con il **modello vero**, sulla pipeline completa (`detect_model` + `detect_regex` +
+`_merge`), su 120 frasi della forma «il DD/MM/AAAA HH:MM», che è come si scrive una convocazione:
+
+| | main | dopo |
+|---|---:|---:|
+| ora intera lasciata in chiaro | 45/120 | **0/120** |
+| pezzi di data lasciati in chiaro | 0/120 | **0/120** |
+| `2026-03-15T10:30:00` | `[DATE]` | **`[DATE]`** |
+| recall su 6.000 ore isolate | — | **6.000/6.000** |
+| costo su 2 MB | 0,74 s | 0,83 s |
+
+**Falsi positivi: 6 su 16** frasi senza ora, tutti della forma `h:mm` con l'ora a una cifra —
+scale catastali (`Scala 1:25`), proporzioni, diluizioni, riferimenti (`Giovanni 3:16`,
+`normativa 4:12`) e coordinate sessagesimali (`12:30:15`). Non si tolgono senza contesto, e la
+direzione dell'errore è quella accettabile per un anonimizzatore: mascherare in più è
+reversibile, lasciare in chiaro no. La forma col punto (`versione 1.30`, `euro 10.30`,
+`45.4642`) non produce match, per costruzione.
+
+**Limite dichiarato**: l'intervallo scritto col trattino attaccato (`10:30-11:45`) non viene
+riconosciuto — le due guardie si annullano a vicenda. Con il trattino spaziato (`10:30 - 11:45`)
+funziona.
+
+`tests/test_ora.py` copre la forma, il rifiuto del punto, le ore fuori scala e — con `app.py`
+importabile — la fusione contro una `DATE` del modello. Sulla versione senza `TIME` soft quel
+test fallisce, e mostra `2026-03-15T10:30:00` che diventa `TIME '15T10:30:00'`.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/app/detectors.py
+++ b/src/app/detectors.py
@@ -183,12 +183,25 @@ DETECTORS = [
                 r"(?:0?[1-9]|1[0-2])[/.\-](?:19|20)\d{2}"
                 r"(?:\s+\d{1,2}[:.]\d{2})?(?!\d)"),
      None, True),
+    # ORA: il modello taglia i minuti ("09:50" -> "09:", "14:30" -> "14") e la meta'
+    # che resta finisce in chiaro accanto al placeholder. La forma coi due punti e'
+    # chiusa (0-23 : 0-59, secondi opzionali) e si presta a una regex deterministica.
+    # NON si accetta il punto ("10.30"): li' la forma e' la stessa di "versione 1.30",
+    # "capitolo 3.15", "euro 10.30" e delle coordinate.
+    # Sta in SOFT_REGEX_LABELS, come DATE: due punti fra due numeri non sono una prova.
+    # E' quello che tiene insieme il caso difficile, la data che INCLUDE l'ora: sul
+    # timestamp "2026-03-15T10:30:00" il modello marca tutto come DATE, e se TIME avesse
+    # la priorita' della rete regex scalzerebbe quella span lasciando "2026-03-" IN
+    # CHIARO. Da soft perde contro il modello e vince solo dove nessuno reclama l'ora.
+    ("TIME",
+     re.compile(r"(?<![\d.:/-])(?:[01]?\d|2[0-3]):[0-5]\d(?::[0-5]\d)?(?!\d|[.:/-]\d)"),
+     None, True),
 ]
 
 # Label della rete regex SENZA validatore forte: la forma da sola non basta a dire
 # "e' certamente questo campo". In _merge non ereditano la priorita' della rete regex,
 # cosi' il modello puo' sovrascriverle.
-SOFT_REGEX_LABELS = {"DATE"}
+SOFT_REGEX_LABELS = {"DATE", "TIME"}
 
 # Punteggiatura che chiude la frase e non fa parte dell'URL: "vedi https://x.it/pagina."
 _URL_TRAIL = ".,;:!?)]}»\"'"

--- a/tests/test_ora.py
+++ b/tests/test_ora.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""`TIME`: la regex dell'ora, e il motivo per cui sta in `SOFT_REGEX_LABELS`.
+
+Il modello taglia i minuti (`09:50` -> `09:`) e la metà che resta finisce in chiaro
+accanto al segnaposto: da qui la regex. Ma una data **include** spesso l'ora, e in un
+timestamp ISO (`2026-03-15T10:30:00`) la data la trova solo il modello, in un'unica span.
+Se `TIME` avesse la priorità della rete regex scalzerebbe quella span in fusione e
+lascerebbe `2026-03-` **in chiaro**: la data del documento, sotto un placeholder che dice
+il contrario. Da soft perde contro il modello e vince solo dove nessuno reclama l'ora.
+
+Due punti fra due numeri non sono comunque una prova, e i falsi positivi qui sotto sono
+dichiarati, non nascosti: per un anonimizzatore mascherare in più è l'errore reversibile.
+
+Tutti i valori sono SINTETICI.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+import detectors  # noqa: E402
+
+
+def ore(testo):
+    return [testo[e["start"]:e["end"]]
+            for e in detectors.detect_regex(testo) if e["label"] == "TIME"]
+
+
+def _carica_app():
+    """Importa app coi pesi finti: qui il modello vero non serve.
+
+    Tre accorgimenti, tutti necessari:
+    - il finto transformers va messo in sys.modules, non con patch("transformers.
+      pipeline"): un `from transformers import pipeline` (app.py riga 66) su un
+      _LazyModule NON passa dall'attributo patchato e prende la funzione vera;
+    - la voce si sostituisce e ripristina A MANO: patch.dict(sys.modules) al
+      ripristino fa clear()+update() dell'intero sys.modules, buttando via anche
+      l'app appena importata (e ricaricando numpy);
+    - PII_MODEL_DIR (l'override che app.py stesso documenta) puntato a una cartella
+      esistente: senza, il controllo del modello mancante fa sys.exit(2) durante
+      l'import - un SystemExit che l'except qui sotto non cattura.
+    """
+    if "app" in sys.modules:
+        return sys.modules["app"]
+    finto = MagicMock()
+    finto.pipeline.return_value = MagicMock(return_value=[])
+    vero = sys.modules.get("transformers")
+    sys.modules["transformers"] = finto
+    prima = os.environ.get("PII_MODEL_DIR")
+    os.environ["PII_MODEL_DIR"] = str(ROOT / "tests")
+    try:
+        import app as pii_app
+    finally:
+        if vero is not None:
+            sys.modules["transformers"] = vero
+        else:
+            del sys.modules["transformers"]
+        if prima is not None:
+            os.environ["PII_MODEL_DIR"] = prima
+        else:
+            del os.environ["PII_MODEL_DIR"]
+    return pii_app
+
+
+try:                                    # torch/transformers/flask/fitz presenti?
+    APP = _carica_app()
+except Exception:                       # noqa: BLE001 - qualunque import mancante
+    APP = None
+
+
+class Ora(unittest.TestCase):
+    def test_riconosce_la_forma_coi_due_punti(self):
+        self.assertEqual(ore("Ingresso ore 18:28, uscita 19:30."), ["18:28", "19:30"])
+        self.assertEqual(ore("Accesso alle 09:50:12."), ["09:50:12"])
+        self.assertEqual(ore("Riunione dalle 8:00 alle 16:45."), ["8:00", "16:45"])
+
+    def test_il_punto_non_e_accettato(self):
+        """`10.30` ha la stessa forma di `versione 1.30` ed `euro 10.30`."""
+        for frase in ("versione 1.30 del programma", "euro 10.30 di spesa",
+                      "capitolo 3.15", "coordinate 45.4642, 9.1900"):
+            self.assertEqual(ore(frase), [], frase)
+
+    def test_ore_e_minuti_fuori_scala(self):
+        for frase in ("codice 24:00", "codice 25:30", "codice 10:60", "codice 99:99"):
+            self.assertEqual(ore(frase), [], frase)
+
+    def test_time_e_soft(self):
+        """La guardia che impedisce all'ora di scalzare una data del modello."""
+        self.assertIn("TIME", detectors.SOFT_REGEX_LABELS)
+
+
+@unittest.skipIf(APP is None, "app.py non importabile (torch/flask/fitz assenti)")
+class OraControDataInFusione(unittest.TestCase):
+    """Il caso che conta: la data la vede solo il modello, l'ora anche la regex."""
+
+    def test_la_time_non_scalza_la_date_del_modello(self):
+        testo = "Deposito telematico: 2026-03-15T10:30:00 (ricevuta PEC)."
+        i = testo.index("2026")
+        data = {"label": "DATE", "start": i, "end": i + len("2026-03-15T10:30:00"),
+                "score": 1.0, "validated": False, "source": "modello"}
+        tenute = APP._merge([data] + detectors.detect_regex(testo), testo)
+        span = [(e["label"], testo[e["start"]:e["end"]]) for e in tenute]
+        self.assertIn(("DATE", "2026-03-15T10:30:00"), span,
+                      "la data del modello e' stata spezzata dall'ora: %r" % span)
+        self.assertNotIn("TIME", [l for l, _ in span])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`TIME` è il tag più debole della valutazione indipendente della issue #18 (69,4%) e l'unico
senza una regex ad affiancare il modello. Il modello **taglia i minuti** e la metà che resta
finisce in chiaro accanto al segnaposto:

    'Ingresso ore 18:28, uscita ore 19:30.'  ->  'Ingresso ore [TIME_1], uscita ore 18[TIME_2]30.'

La forma coi due punti è chiusa (0-23 : 0-59, secondi opzionali) e si presta a una regex
deterministica. **Il punto non è accettato**: `10.30` ha la stessa forma di `versione 1.30`,
`euro 10.30` e delle coordinate decimali.

## Il punto che conta: `TIME` è soft

`TIME` sta in `SOFT_REGEX_LABELS`, come `DATE`. Non è un dettaglio di stile, è ciò su cui regge
tutto il resto. Una data spesso **include** l'ora, e in un timestamp ISO la data la trova solo
il modello, in un'unica span: se `TIME` avesse la priorità della rete regex scalzerebbe quella
span in fusione e lascerebbe un pezzo di data **in chiaro**.

## Cosa avevo sbagliato

Nella prima stesura `TIME` non era soft, e al suo posto avevo messo un filtro in fondo a
`detect_regex()` che scartava le `TIME` cadute dentro una `DATE`, motivandolo così: «senza, in
fusione l'ora vincerebbe e la data resterebbe in chiaro».

Rimisurando **con il modello vero** sulla pipeline completa, quella motivazione non regge e il
filtro fa danno due volte.

**Uno.** Il pericolo che previene non si verifica mai. Su 120 frasi «il DD/MM/AAAA HH:MM» i
pezzi di data lasciati in chiaro sono 0/120 **sia con sia senza** il filtro: la `DATE` della
regex è soft e non sopravvive comunque a un frammento del modello a punteggio pieno.

**Due.** In cambio, il filtro annullava proprio la correzione. Su quelle stesse 120 frasi l'ora
restava intera in chiaro **45 volte su 120, esattamente come su `main`**. Togliendo il solo
filtro: **0/120**.

E soprattutto il filtro viveva dentro `detect_regex()`, che per definizione vede solo metà dei
candidati: le `DATE` del **modello** non le conosce. Da lì una regressione vera, che `main` non
ha:

```
'Deposito telematico: 2026-03-15T10:30:00 (ricevuta PEC).'
   main               ->  'Deposito telematico: [DATE] (ricevuta PEC).'
   questa PR com'era  ->  'Deposito telematico: 2026-03-[TIME] (ricevuta PEC).'

'Accesso registrato il 2026-03-15T09:05 dal sistema.'
   questa PR com'era  ->  'Accesso registrato il [DATE]-03-[TIME] dal sistema.'
```

Nella seconda il segnaposto `[DATE_1]` copre il solo `2026` e **il mese resta scritto**.

Mettere `TIME` fra le label soft risolve entrambe le cose alla radice, e il diff è **più corto**
di prima: il filtro sparisce.

## Verifica

Con il modello vero (`rizzo-pii-0.3B`) sulla pipeline completa `detect_model` + `detect_regex`
+ `_merge`:

| | main | questa PR com'era | ora |
|---|---:|---:|---:|
| ora intera in chiaro, 120 frasi «il DD/MM/AAAA HH:MM» | 45/120 | 45/120 | **0/120** |
| pezzi di data in chiaro | 0/120 | 0/120 | **0/120** |
| `2026-03-15T10:30:00` | `[DATE]` | `2026-03-[TIME]` | **`[DATE]`** |
| recall su 6.000 ore isolate | — | 6.000/6.000 | **6.000/6.000** |
| costo su 2 MB | 0,74 s | — | 0,83 s |

**Falsi positivi: 6 su 16** frasi senza ora — e il corpo precedente diceva 0, che era falso.
Sono tutti della forma `h:mm` con l'ora a una cifra: `Scala 1:25` e le proporzioni delle
planimetrie, le diluizioni, i riferimenti (`Giovanni 3:16`, `normativa 4:12`) e le coordinate
sessagesimali (`12:30:15`). Non li tolgo: senza contesto non sono separabili, e per un
anonimizzatore mascherare in più è l'errore reversibile. Ma vanno dichiarati, non nascosti.

**Limite**: l'intervallo col trattino attaccato (`10:30-11:45`) non viene riconosciuto, le due
guardie si annullano a vicenda. Col trattino spaziato funziona.

`tests/test_ora.py`, nuovo: forma, rifiuto del punto, ore fuori scala, e — con `app.py`
importabile — la fusione contro una `DATE` del modello. Sulla versione senza `TIME` soft due
test falliscono, e il secondo mostra `2026-03-15T10:30:00` che diventa `TIME '15T10:30:00'`.
Suite completa: OK.

Non tocca `_CARD_LEN` né `_card_senza_scadenza`: nessun conflitto con #68.
