### PR TITLE
fix(app): un file di testo veniva letto con la codifica sbagliata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,70 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — Un file di testo veniva letto con la codifica sbagliata (`app.py`)
+
+`_text_from_bytes()` provava le codifiche in ordine `utf-8-sig`, `utf-16`, `latin-1`. Ma il
+codec `utf-16` **senza BOM accetta qualunque sequenza di lunghezza pari**: un `.txt` o un `.md`
+in latin-1 con un numero pari di byte non arrivava mai al terzo tentativo.
+
+    vero   : "Nicolò: Con atto di citazione l'avvocato Susanna Grassi, nell'interesse..."
+    letto  : "楎潣›潃⁮瑡潴搠⁩楣慴楺湯⁥❬癡潶慣潴匠獵湡慮䜠慲獳Ⱪ渠汥❬湩整敲獳..."
+
+Non è un difetto cosmetico: su un file letto così i rilevatori trovano **zero** entità. Il
+documento non viene anonimizzato, viene reso illeggibile.
+
+Ma anche `utf-8` accetta troppo: il **byte nullo** è un carattere legittimo, quindi in testa
+alla catena si prende gli `utf-16` di testo ASCII e li rende mojibake allo stesso modo. Nessuno
+dei due codec può fare da guardia all'altro.
+
+Il rimedio non è indovinare la codifica: è **togliere i byte nulli dal testo restituito**.
+In un utf-16 latino il byte alto è proprio quello nullo, quindi un file finito su una
+codifica a 8 bit esce `M\0a\0r\0i\0o` — e tolti i nulli il testo torna **esatto**, con le
+PII di nuovo trovabili. Vale anche per i file misti: la parte cinese o greca resta sporca,
+ma il corpo italiano con le PII no.
+
+Riconoscere l'utf-16 contando i byte nulli, invece, sbaglia in entrambe le direzioni, e le
+due versioni che ci ho provato erano **peggio di `main`**: un utf-16 con dentro del cinese
+ne ha pochi e resta mojibake, un file con la testa azzerata ne ha tanti e viene distrutto,
+e una tabella disegnata a cornice (`─`, U+2500) ne ha abbastanza su entrambe le parità da
+mandare in stallo qualunque soglia.
+
+Resta il resto della catena: `utf-16` solo col BOM, e `cp1252` prima di `latin-1` — è quello
+che scrivono Word e il Blocco note italiani, e i due differiscono su euro e virgolette
+tipografiche.
+
+Su 300 atti sintetici, metà con accenti italiani (`letto male` = il round-trip fallisce):
+
+| codifica del file caricato | prima | dopo |
+|---|---:|---:|
+| utf-8, utf-8 col BOM, utf-16 col BOM | 0 | **0** |
+| cp1252 (Windows italiano) | 30,7% | **0** |
+| latin-1 | 30,7% | **0** |
+| **utf-16-le senza BOM** | 50,0% | **0** |
+| **utf-16-be senza BOM** | 100% | **0** |
+
+Su questo corpus `latin-1` e `cp1252` coincidono, perché gli accenti italiani hanno gli stessi
+byte nelle due codifiche: a distinguerle sono l'euro e le virgolette tipografiche, e lì `main`
+sbaglia dove ora si legge bene.
+
+Il metro giusto però non è il round-trip, è **se le PII restano trovabili**. Su 36 file
+costruiti apposta (utf-16 LE e BE di varie lunghezze, bilingui con intestazione cinese, thai
+e a cornice, file a 8 bit con NUL vaganti, teste azzerate, export a record NUL-terminati,
+blob binari, degeneri), contando i casi in cui il testo resta leggibile a schermo ma i
+rilevatori non trovano più nulla — cioè il documento esce in chiaro e l'utente non se ne
+accorge:
+
+| | casi "falso pulito" | PII trovata |
+|---|---:|---:|
+| main | 8 | 17 |
+| dopo | **0** | **30** |
+
+`tests/test_codifiche.py` ritaglia la funzione vera dal sorgente con `ast` — `app.py` non è
+importabile senza torch — e misura la **trovabilità della PII**, non solo il round-trip: utf-16
+senza BOM, contorni non latini, NUL vaganti, teste azzerate, degeneri. Sul codice di `main`
+**4 dei 6 falliscono**.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -506,9 +506,21 @@ def _text_from_bytes(name, data):
         with fitz.open(stream=data, filetype="pdf") as doc:
             return "\n".join(page.get_text() for page in doc)
     if ext in TEXT_EXTS or not ext:
-        for enc in ("utf-8-sig", "utf-16", "latin-1"):
+        # utf-16 solo col BOM: senza, il codec accetta qualunque sequenza di lunghezza pari
+        # e si mangia i .txt a 8 bit. cp1252 prima di latin-1: e' quello che scrivono Word
+        # e il Blocco note italiani, e i due differiscono su euro e virgolette tipografiche.
+        primo = ("utf-16",) if data[:2] in (b"\xff\xfe", b"\xfe\xff") else ()
+        for enc in primo + ("utf-8-sig", "cp1252", "latin-1"):
             try:
-                return data.decode(enc)
+                # Via i byte nulli. Un utf-16 SENZA BOM finisce per forza su una codifica a
+                # 8 bit e il testo esce "M\0a\0r\0i\0o": a schermo non si vede niente (in
+                # HTML il NUL e' invisibile), quindi l'utente legge il documento intero,
+                # non trova segnaposti e conclude che non ci fosse nulla da anonimizzare -
+                # mentre i rilevatori, che lavorano sul testo vero, non trovano niente.
+                # In un utf-16 latino il byte alto e' proprio quello nullo: tolto, il testo
+                # torna esatto e le PII tornano trovabili. Riconoscere l'utf-16 contando i
+                # byte nulli, invece, sbaglia in entrambe le direzioni.
+                return data.decode(enc).replace("\x00", "")
             except UnicodeDecodeError:
                 continue
     raise ValueError(

--- a/tests/test_codifiche.py
+++ b/tests/test_codifiche.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""`_text_from_bytes()`: da quali byte esce un testo su cui i rilevatori funzionano.
+
+Il caso peggiore qui non è il testo illeggibile — quello si vede — ma il testo che resta
+**leggibile a schermo** e sparisce ai rilevatori. Un `.txt` in utf-16 senza BOM finisce
+decodificato a 8 bit e diventa `M\\0a\\0r\\0i\\0o`: in HTML i byte nulli sono invisibili,
+quindi l'utente legge il documento intero, non vede nessun segnaposto e conclude che non ci
+fosse niente da anonimizzare. Il documento esce in chiaro e sembra pulito.
+
+Per questo i test misurano la **trovabilità della PII nel testo restituito**, non solo il
+round-trip: sono due cose diverse ed è la prima che protegge l'utente.
+
+`app.py` non è importabile senza torch/flask/fitz, quindi la funzione vera si ritaglia dal
+sorgente con `ast`: si testa il codice che viene spedito, non una copia.
+
+Tutti i valori sono SINTETICI.
+"""
+
+import ast
+import os
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "src" / "app" / "app.py"
+
+CF = "RSSMRA80A01H501U"
+IBAN = "IT60X0542811101000000123456"
+ATTO = ("TRIBUNALE DI MILANO - Verbale del 15/03/2026.\n"
+        "Ricorrente: Mario Rossi, C.F. %s, IBAN %s.\n" % (CF, IBAN))
+ACCENTI = "Perizia: la proprietà è accertata, perché così risulta.\n" + ATTO
+
+
+def _carica():
+    """`_text_from_bytes` e le sue dipendenze, senza importare tutto app.py."""
+    albero = ast.parse(APP.read_text(encoding="utf-8"))
+    ns = {"os": os, "re": re}
+    for nodo in albero.body:
+        if isinstance(nodo, ast.Assign) and any(
+                getattr(t, "id", "") in ("TEXT_EXTS", "PDF_MAGIC") for t in nodo.targets):
+            exec(compile(ast.Module([nodo], []), "app.py", "exec"), ns)
+        elif isinstance(nodo, ast.FunctionDef) and nodo.name in ("_is_pdf", "_text_from_bytes"):
+            exec(compile(ast.Module([nodo], []), "app.py", "exec"), ns)
+    return ns["_text_from_bytes"]
+
+
+leggi = _carica()
+
+
+def trovabile(dati):
+    """La PII e' ancora trovabile dai rilevatori nel testo restituito?"""
+    testo = leggi("atto.txt", dati)
+    return CF in testo and IBAN in testo
+
+
+class Codifiche(unittest.TestCase):
+    def test_round_trip_su_tutte_le_codifiche(self):
+        for testo in (ATTO * 4, ACCENTI * 3):
+            for enc in ("utf-8", "utf-8-sig", "cp1252", "latin-1",
+                        "utf-16", "utf-16-le", "utf-16-be"):
+                try:
+                    dati = testo.encode(enc)
+                except UnicodeEncodeError:
+                    continue                      # non rappresentabile: non e' un caso
+                self.assertEqual(leggi("atto.txt", dati), testo, "non torna dopo %s" % enc)
+
+    def test_utf16_senza_bom_la_pii_resta_trovabile(self):
+        """Il difetto per cui questa modifica esiste."""
+        for enc in ("utf-16-le", "utf-16-be"):
+            for testo in (ATTO, ATTO * 20, ACCENTI * 3):
+                self.assertTrue(trovabile(testo.encode(enc)), "%s: PII persa" % enc)
+
+    def test_utf16_con_caratteri_fuori_dal_latino(self):
+        """Un allegato bilingue, o una tabella disegnata a cornice: i caratteri sopra
+        U+00FF non hanno il byte alto nullo, ma la parte italiana sì."""
+        for contorno in ("中华人民共和国上海市人民法院 " * 40,     # cinese
+                         "สัญญาระหว่างคู่สัญญา " * 40,           # thai
+                         "─" * 62 + "\n" + "─" * 62):            # cornice
+            for enc in ("utf-16-le", "utf-16-be"):
+                dati = (contorno + "\n" + ATTO * 3).encode(enc)
+                self.assertTrue(trovabile(dati), "%s con %r: PII persa" % (enc, contorno[:8]))
+
+    def test_i_file_a_8_bit_non_vengono_toccati(self):
+        for enc in ("utf-8", "utf-8-sig", "cp1252", "latin-1"):
+            self.assertTrue(trovabile((ATTO * 8).encode(enc)), enc)
+            self.assertTrue(trovabile((ACCENTI * 4).encode(enc)), enc + " accenti")
+        # l'euro e le virgolette tipografiche distinguono cp1252 da latin-1
+        self.assertTrue(trovabile((ATTO + "Importo 1.250,00 €.\n").encode("cp1252")))
+
+    def test_nul_vaganti_e_teste_azzerate(self):
+        """File troncato da un crash, blob binario incollato in cima, export a record
+        fissi NUL-terminati: nessuno di questi deve far perdere il documento."""
+        base = bytearray((ATTO * 8).encode("utf-8"))
+        for quanti in (1, 10, 60):
+            dati = bytearray(base)
+            for i in range(1, 1 + 2 * quanti, 2):
+                dati[i] = 0
+            self.assertTrue(trovabile(bytes(dati)), "%d NUL vaganti" % quanti)
+        self.assertTrue(trovabile(b"\x00" * 700 + (ATTO * 40).encode("utf-8")))
+
+    def test_casi_degeneri_non_sollevano(self):
+        for dati in (b"", b"A", b"AB", b"ABC", b"a\x00", b"\x00a", b"\xef\xbb\xbf",
+                     b"\xff\xfe", b"\xfe\xff", b"\x00" * 64, b"\x89PNG\r\n\x1a\n"):
+            self.assertIsInstance(leggi("atto.txt", dati), str, repr(dati))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_text_from_bytes()` provava le codifiche in ordine `utf-8-sig`, `utf-16`, `latin-1`. Il
problema è che **entrambi i codec accettano troppo**, e nessuno dei due può fare da guardia
all'altro:

- `utf-16` senza BOM accetta **qualunque** sequenza di lunghezza pari, quindi in coda a
  `utf-8` si prendeva i `.txt` a 8 bit;
- `utf-8` accetta il **byte nullo** (è un carattere legittimo), quindi in testa si prende gli
  `utf-16`.

```
vero   : "Nicolò: Con atto di citazione l'avvocato Susanna Grassi, nell'interesse..."
letto  : "楎潣›潃⁮瑡潴搠⁩楣慴楺湯⁥❬癡潶慣潴匠獵湡慮䜠慲獳Ⱪ渠汥❬湩整敲獳..."
```

Il caso peggiore non è questo, che si vede. È l'altro: un `.txt` in utf-16 senza BOM finisce
decodificato a 8 bit e diventa `M\0a\0r\0i\0o`. **I byte nulli in HTML sono invisibili**, quindi
l'utente legge il documento intero, non trova nessun segnaposto e conclude che non ci fosse
niente da anonimizzare — mentre i rilevatori, che lavorano sul testo vero, non hanno trovato
nulla. Il documento esce in chiaro e sembra pulito.

## La modifica

Tre righe di catena e una `.replace()`:

- `utf-16` si prova **solo col BOM** (senza, si mangia i file a 8 bit);
- `cp1252` prima di `latin-1` — è quello che scrivono Word e il Blocco note italiani, e i due
  differiscono su euro e virgolette tipografiche;
- **i byte nulli si tolgono dal testo restituito.**

L'ultimo punto è quello che chiude il buco, ed è più semplice di quanto sembri: in un utf-16
latino il byte alto è proprio quello nullo, quindi tolti i nulli il testo torna **esatto**.
Vale anche per i file misti — la parte cinese o greca resta sporca, ma il corpo italiano con
le PII no.

## Due tentativi che ho buttato, perché erano peggio di `main`

Ci ho provato prima con un riconoscimento dell'utf-16 basato sui byte nulli, in due varianti,
e le ho scartate entrambe dopo averle misurate:

- **densità** (`>1/4 dei byte del primo KB`): rompe gli utf-16 bilingui, perché un allegato
  con l'intestazione in cinese o greco ha pochi byte nulli, e distrugge gli utf-8 con la testa
  azzerata, che ne hanno tanti;
- **parità** (gli zeri sbilanciati su un lato): meglio, ma una tabella disegnata a cornice
  (`─`, U+2500) ha zeri su **entrambe** le parità e manda in stallo qualunque soglia; e un
  export a record fissi NUL-terminati la fa scattare a vuoto.

Contando i casi in cui la PII resta leggibile a schermo ma sparisce ai rilevatori:

| | casi "falso pulito" |
|---|---:|
| main | 8 |
| densità | 26 |
| parità | 6 |
| **questa** | **0** |

Le riporto perché il punto non è che ho cambiato idea, è che **contare i byte nulli non
funziona**: sbaglia in tutte e due le direzioni, e le due volte che ci ho provato il risultato
era peggio di non fare niente.

## Verifica

`_text_from_bytes` ritagliata con `ast` da `origin/main` e da questo ramo, eseguita sugli
stessi byte.

Su 300 atti sintetici, metà con accenti italiani (`letto male` = il round-trip fallisce):

| codifica del file caricato | prima | dopo |
|---|---:|---:|
| utf-8, utf-8 col BOM, utf-16 col BOM | 0 | **0** |
| cp1252 (Windows italiano) | 30,7% | **0** |
| latin-1 | 30,7% | **0** |
| **utf-16-le senza BOM** | 50,0% | **0** |
| **utf-16-be senza BOM** | 100% | **0** |

Su questo corpus `latin-1` e `cp1252` coincidono, perché gli accenti italiani hanno gli stessi
byte nelle due codifiche: a distinguerle sono l'euro e le virgolette tipografiche, e lì `main`
sbaglia dove ora si legge bene.

Su 36 file costruiti apposta (utf-16 LE e BE di varie lunghezze, bilingui con intestazione
cinese, thai e a cornice, file a 8 bit con NUL vaganti, teste azzerate, export a record
NUL-terminati, blob binari, degeneri), col metro che conta davvero:

| | casi "falso pulito" | PII trovata |
|---|---:|---:|
| main | 8 | 17 |
| dopo | **0** | **30** |

`tests/test_codifiche.py`, nuovo, misura la **trovabilità della PII** e non solo il round-trip.
Sul codice di `main` **4 dei 6 falliscono** — e falliscono anche sulle due varianti che ho
scartato, che è il motivo per cui i test sono scritti così.

Suite completa: OK. Merge pulito con #65, #66, #67, #68, #69, #71, #73, #74 una a una e tutte
insieme.
