### PR TITLE
fix(data): nelle tabelle a colonne il cognome resta in chiaro

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,42 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-04 — Nelle tabelle il cognome resta in chiaro (`generate_synthetic_pii.py`)
+
+Un elenco esportato da un gestionale o da Excel tiene **nome e cognome in colonne separate**.
+Su una tabella di sei righe, con `analyze()` e il modello `rizzo-pii-0.3B`, i valori che
+restano leggibili sono:
+
+| separatore | colonne separate | nome e cognome nella stessa cella |
+|---|---:|---:|
+| tab | 7,9% (38/480) | 0/240 |
+| virgola | 12,9% (62/480) | 0/240 |
+| **punto e virgola** (il default di Excel italiano) | **17,1%** (82/480) | 0/240 |
+
+I numeri sono la somma di quattro semi: su un seme solo oscillano molto (2,5-15% col tab),
+il contrasto con la cella unica no — quello è zero su tutti.
+
+Il taglio esiste già nei sintetici ma è **raro**: su 20.000 esempi, `nome SEP cognome` compare
+714 volte contro le 3.767 di `cognome SEP nome` (che gli elenchi producono da soli), e col
+punto e virgola solo 216. Tre template a colonne portano il primo caso a 4.236 e il punto e
+virgola a 2.003.
+
+**Il caso col TAB resta scoperto, e questo generatore non può chiuderlo.** `TOKEN_RE` scarta
+gli spazi, quindi una riga separata da tab diventa la stessa sequenza di token di
+`Cognome Nome` e il tab non arriva mai al training: la prima riga della tabella qui sopra —
+il 7,9% — non è raggiungibile da nessun template. Per chiuderla servirebbe normalizzare i tab
+in `analyze()` prima di passare il testo al modello, che è un'altra modifica e un altro file.
+Le altre due righe (12,9% e 17,1%) sono quelle che i template nuovi possono spostare.
+
+Nella tabella dei pagamenti l'importo va **fra virgolette**: `{AMOUNT}` contiene sempre la
+virgola decimale (`€ 62.880,00`), quindi senza sarebbero cinque campi sotto un'intestazione di
+quattro — ed è anche ciò che scrive un export CSV vero.
+
+Verificato sui record dei tre template nuovi: 0 sequenze BIO non valide, 0 `I-` incoerenti,
+0 righe con un numero di campi diverso dall'intestazione; generatore eseguito end-to-end, 0
+anomalie. **Per avere effetto serve rigenerare i sintetici e riaddestrare.**
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/data_pipeline/generate_synthetic_pii.py
+++ b/src/data_pipeline/generate_synthetic_pii.py
@@ -311,6 +311,16 @@ def _name_pieces():
 def full_name():
     return _name_pieces()
 
+# Un elenco esportato da un gestionale o da Excel tiene nome e cognome in COLONNE
+# separate: fra i due c'e' un separatore, non uno spazio. Nei sintetici quella forma e'
+# rara (714 occorrenze su 20.000 esempi, e col punto e virgola solo 216) e sul separatore
+# il modello perde il cognome: vedi i template in fondo.
+def given_piece():
+    return [(_person()[0], "GIVENNAME")]
+
+def surname_piece():
+    return [(_person()[1], "SURNAME")]
+
 def role(label):
     # nome intero taggato col ruolo legale, stesso mix di ordini
     return [("".join(v for v, _ in _name_pieces()), label)]
@@ -601,6 +611,7 @@ SLOTS = {
     "CIG": cig_piece, "CUP": cup_piece, "POLIZZA": polizza_piece,
     "MATRICOLA": matricola_piece,
     "NAMELIST": name_list, "ORGLIST": org_list, "MIXEDLIST": mixed_list,
+    "GIVEN": given_piece, "SURNAME": surname_piece,
 }
 
 # --------------------------------------------------------------------------- #
@@ -677,6 +688,38 @@ TEMPLATES = [
     "Allegato A - anagrafica:\n{MIXEDLIST}",
     "{NAMELIST}",
     "{ORGLIST}",
+
+    # Tabelle esportate da un gestionale o da Excel: nome e cognome in colonne separate.
+    # Su tabelle di sei righe (480 nomi per configurazione, quattro semi) il modello
+    # lascia in chiaro il 7,9% dei nomi col TAB, il 12,9% con la virgola e il 17,1% col
+    # punto e virgola, che e' il separatore di Excel italiano. Con nome e cognome nella
+    # stessa cella: zero. Il separatore resta un token (TOKEN_RE tiene la punteggiatura e
+    # scarta gli spazi), quindi qui il modello vede davvero "cognome dopo un punto e
+    # virgola". Il caso col TAB, invece, questo generatore NON puo' esprimerlo: TOKEN_RE
+    # scarta gli spazi, quindi una riga separata da tab diventa la stessa sequenza di
+    # token di "Cognome Nome" e il tab non arriva mai al training. Il 7,9% misurato col
+    # tab resta quindi scoperto: per chiuderlo servirebbe normalizzare i tab in analyze()
+    # prima di passare il testo al modello, che e' un'altra modifica e un altro file.
+    "Elenco dei ricorrenti allegato al ricorso.\n"
+    "nome;cognome;codice fiscale;email\n"
+    "{GIVEN};{SURNAME};{CF};{EMAIL}\n"
+    "{GIVEN};{SURNAME};{CF};{EMAIL}\n"
+    "{GIVEN};{SURNAME};{CF};{EMAIL}",
+
+    # L'importo va fra virgolette: {AMOUNT} contiene sempre la virgola decimale
+    # ("EUR 62.880,00"), quindi senza sarebbero cinque campi sotto un'intestazione
+    # di quattro. E' esattamente cio' che scrive un export CSV vero.
+    "Riepilogo dei pagamenti disposti.\n"
+    "nome,cognome,iban,importo\n"
+    "{GIVEN},{SURNAME},{IBAN},\"{AMOUNT}\"\n"
+    "{GIVEN},{SURNAME},{IBAN},\"{AMOUNT}\"\n"
+    "{GIVEN},{SURNAME},{IBAN},\"{AMOUNT}\"",
+
+    "Registro delle presenze.\n"
+    "cognome;nome;telefono\n"
+    "{SURNAME};{GIVEN};{PHONE}\n"
+    "{SURNAME};{GIVEN};{PHONE}\n"
+    "{SURNAME};{GIVEN};{PHONE}",
 ]
 
 SLOT_RE = re.compile(r"\{(\w+)\}")


### PR DESCRIPTION
Un elenco esportato da un gestionale o da Excel tiene **nome e cognome in colonne separate**.
Su una tabella di sei righe, con `analyze()` e il modello `rizzo-pii-0.3B`, i valori che
restano leggibili:

| separatore | colonne separate | nome e cognome nella stessa cella |
|---|---:|---:|
| tab | 7,9% (38/480) | 0/240 |
| virgola | 12,9% (62/480) | 0/240 |
| **punto e virgola** (il default di Excel italiano) | **17,1%** (82/480) | 0/240 |

480 nomi per casella, somma di quattro semi. Su un seme solo il numero oscilla parecchio
(col tab fra 2,5% e 15%); il contrasto con la cella unica invece è stabile — zero su tutti.

```
nome;cognome;email
Mario;Rossi;mario.rossi@studio.it
  ->  [FULLNAME_1];Rossi;[EMAIL_1]
```

Le email e i telefoni no: quelli li prende la rete regex. Perde solo i nomi, e solo quando il
cognome sta in una colonna sua.

## La modifica

Due slot (`{GIVEN}`, `{SURNAME}`) e tre template a colonne. Il taglio non è assente dai
sintetici, è **raro**: su 20.000 esempi `nome SEP cognome` compare 714 volte contro le 3.767 di
`cognome SEP nome` — quest'ultima la producono già gli elenchi — e col punto e virgola solo 216.
Coi tre template il primo caso passa a 4.236 e il punto e virgola a 2.003.

## Il caso col TAB resta scoperto, e va detto

Scrivevo «le colonne col TAB non servono». È vero che `TOKEN_RE` scarta gli spazi e che una riga
separata da tab diventa la stessa sequenza di token di `Cognome Nome` — ma proprio per questo il
tab **non arriva mai al training**, e la prima riga della tabella qui sopra, il 7,9%, non è
raggiungibile da nessun template di questo generatore. Non è che non serve: è che non si può
fare da qui. Chiuderla vorrebbe dire normalizzare i tab in `analyze()` prima di passare il testo
al modello — un'altra modifica, un altro file. Le due righe che i template nuovi possono
davvero spostare sono la virgola (12,9%) e il punto e virgola (17,1%).

## L'importo va fra virgolette

`{AMOUNT}` contiene sempre la virgola decimale (`€ 62.880,00`), quindi la tabella dei pagamenti
separata da virgole produceva **cinque campi sotto un'intestazione di quattro**, in tutte le
righe. In una PR il cui unico contributo è il realismo del dato è un difetto che conta. Ora
l'importo è fra virgolette, che è anche ciò che scrive un export CSV vero:

```
nome,cognome,iban,importo
Cosimo,Vitale,IT83V3759607538544255146085,"€ 208.170,00"
```

## Verifica

| | esito |
|---|---|
| record dai 3 template nuovi (3.000) | 0 BIO non valide, 0 `I-` incoerenti, 0 offset sbagliati |
| righe della tabella a virgole (1.500) | 0 con un numero di campi diverso dall'intestazione |
| generatore end-to-end (`-n 300`) | 0 anomalie nel file prodotto |
| `python -m unittest discover tests` | OK (35, 2 skipped) |
| merge con le PR aperte sullo stesso file | pulito con #29, #22, #25, #21, #65, #67 (#27 e #15 sono già in conflitto con main da sole) |

**Per avere effetto serve rigenerare i sintetici e riaddestrare**, come per le fix `PROVINCE` e
`Cognome Nome`. Il guadagno sul modello riaddestrato non è misurato qui: quello che è misurato è
la perdita di oggi e la rarità della forma nei dati.

