### PR TITLE
fix(app): il ripristino incollava le parole fra loro

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,40 @@ Scelte che contano:
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
 
+---
+
+## 2026-08-04 — Il ripristino incollava le parole fra loro (`app.py`)
+
+`reverse()` accetta il placeholder anche **senza parentesi** — l'LLM a volte le toglie — ma la
+regex era `\[?\s*NOME\s*\]?`: senza parentesi lo `\s*` si portava via anche gli spazi
+**intorno**, e il testo ripristinato tornava con le parole attaccate.
+
+    'Il FULLNAME_1 ha firmato.'  ->  'IlMario Rossiha firmato.'
+    'col1	FULLNAME_1	col3'     ->  'col1Mario Rossicol3'   (la tabella perde le colonne)
+    'riga
+FULLNAME_1
+riga'     ->  'rigaMario Rossiriga'   (e il testo perde le righe)
+
+La stessa riga aveva un **secondo difetto, peggiore**, segnalato in review da @LangiuAlessio:
+con ogni parentesi opzionale per conto suo, un indice che il modello **si inventa** matchava a
+metà. Con `CF_1` in mappa e `[CF_12]` nella risposta, il ripristino scriveva
+`RSSMRA78S03L750K2]`: non un segnaposto saltato — quello si vede — ma un **codice fiscale
+sbagliato scritto con sicurezza**.
+
+La forma finale chiude entrambi: `(?:\[\s*NOME\s*\]|\bNOME\b)`. Gli spazi si consumano **solo
+dentro le parentesi**, le parentesi ci sono **entrambe o nessuna**, e la forma nuda ha i
+confini di parola — così anche `CF_1a` e `ilCF_1` (suffisso o prefisso incollati) restano
+com'erano invece di diventare valori.
+
+Eseguendo la `reverse()` vera, presa dal file prima e dopo, su una matrice di casi (parentesi
+presenti, assenti, grassetto markdown, spazi dentro, a-capo e tab intorno, `_1` accanto a
+`_10`, indici inventati con e senza parentesi, valori con `$` e con quadre) più 20.000
+documenti generati con le sole forme legittime: **le forme legittime escono identiche, gli
+indici inventati restano intatti**. Unico cambio voluto: con mezza parentesi (`CF_1]`) il
+valore torna ma la parentesi orfana resta **visibile** invece di essere assorbita.
+
+---
+
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 
 Il controllo delle sovrapposizioni confrontava **ogni** candidato con **tutta** la lista già

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -1739,8 +1739,16 @@ function reverse(){
   let out=txt;
   for(const ph of keys){
     const inner=ph.slice(1,-1);                 // FULLNAME_1
-    // tollerante: parentesi opzionali / spazi, eventuale grassetto markdown
-    const rx=new RegExp('\\**\\[?\\s*'+inner.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+'\\s*\\]?\\**','g');
+    // tollerante: parentesi o forma nuda, spazi, eventuale grassetto markdown.
+    // Gli spazi si consumano SOLO insieme alla parentesi: con '\[?\s*' un placeholder
+    // scritto senza parentesi si portava via anche gli spazi intorno, e "Il FULLNAME_1 ha"
+    // tornava "IlMario Rossiha". Con un tab o un a-capo spariva la colonna o la riga.
+    // E le parentesi sono TUTTO-O-NIENTE, con \b sulla forma nuda: se ognuna e' opzionale
+    // per conto suo, con CF_1 in mappa un indice inventato dal modello ([CF_12]) matcha
+    // per meta' e il ripristino scrive un codice fiscale SBAGLIATO - un segnaposto rimasto
+    // si vede, un valore sbagliato no.
+    const esc=inner.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
+    const rx=new RegExp('\\**(?:\\[\\s*'+esc+'\\s*\\]|\\b'+esc+'\\b)\\**','g');
     out=out.replace(rx,MAP[ph].replace(/\$/g,'$$$$'));
   }
   const o=$('rout');o.textContent=out;o._raw=out;


### PR DESCRIPTION
Il tab "Ripristina" accetta il placeholder anche **senza parentesi** — l'LLM a volte le toglie —
ma la regex era `\[?\s*NOME\s*\]?`: senza parentesi lo `\s*` si portava via anche gli spazi
**intorno**, e il testo ripristinato tornava con le parole attaccate.

```
'Il FULLNAME_1 ha firmato.'  ->  'IlMario Rossiha firmato.'
'col1<TAB>FULLNAME_1<TAB>col3'  ->  'col1Mario Rossicol3'    la tabella perde le colonne
'riga<NL>FULLNAME_1<NL>riga'    ->  'rigaMario Rossiriga'    il testo perde le righe
```

## La modifica

Gli spazi si consumano **solo insieme alla parentesi**:

```js
'\**(?:\[\s*)?' + inner + '(?:\s*\])?\**'
```

Con le parentesi non cambia niente; senza, **gli spazi intorno non si consumano più**.

Da precisare, perché la prima stesura diceva «non si tocca più quello che c'è intorno» ed era
troppo assoluta: gli **asterischi** adiacenti continuano a essere assorbiti, di proposito e in
modo identico a `main` — è la tolleranza al grassetto markdown. Quindi
`Il FULLNAME_1**testo**` torna `Il Mario Rossitesto**`, prima come dopo. Cambia una sola forma:
`** FULLNAME_1 **`, con lo spazio fra asterisco e segnaposto, ora lascia gli asterischi nel
testo (`** Mario Rossi **`) dove prima li mangiava. Non è grassetto valido in CommonMark e già
su `main` la variante con le parentesi `** [X] **` non funzionava, quindi non la inseguo: la
segnalo perché è una differenza vera rispetto a prima.

## Verifica

Eseguendo la `reverse()` **vera**, estratta dal file prima e dopo la modifica, sugli stessi 17
casi: **7 sbagliati prima, 0 dopo.**

| caso | prima | dopo |
|---|---|---|
| con parentesi, spazi dentro, grassetto, a inizio testo | ok | ok |
| `_1` accanto a `_10` (con parentesi) | ok | ok |
| valore col `$`, valore con parentesi quadre | ok | ok |
| placeholder attaccati fra loro, o alla punteggiatura | ok | ok |
| **senza parentesi** | **NO** | ok |
| **parentesi solo aperta / solo chiusa** | **NO** | ok |
| **a-capo o tab intorno** | **NO** | ok |
| **due occorrenze miste, `_1` e `_10` senza parentesi** | **NO** | ok |

Il JavaScript è stato ricompilato (`new Function`) per essere sicuro che la stringa nel sorgente
Python resti valida. `python -m unittest discover tests`: OK (35, 2 skipped).



## Aggiornamento (settembre) — secondo difetto sulla stessa riga

@LangiuAlessio in review ha segnalato un secondo difetto, indipendente dagli spazi e peggiore:
con ogni parentesi opzionale per conto suo, un indice che il modello **si inventa** matcha a
metà. Con `CF_1` in mappa e `[CF_12]` nella risposta, il ripristino scriveva
`RSSMRA78S03L750K2]` — non un segnaposto saltato, che si vede, ma un **codice fiscale
sbagliato scritto con sicurezza**. Riprodotto identico sia su `main` che sulla prima forma di
questa PR.

La regex ora è tutto-o-niente, come proposto in review:
`\**(?:\[\s*NOME\s*\]|\bNOME\b)\**` — o le quadre ci sono entrambe (con gli spazi consumati
solo lì dentro), o il segnaposto è nudo fra confini di parola.

Riverificato sulla `reverse()` estratta dal file spedito: matrice di casi + 20.000 documenti
generati con le sole forme legittime → le forme legittime escono **identiche** alla versione
precedente della PR; gli indici inventati (`[CF_12]`, `CF_12` nudo) e i segnaposto incollati a
lettere (`CF_1a`, `ilCF_1`) restano **intatti**. Unico cambio di comportamento: con mezza
parentesi (`CF_1]`) il valore torna ma la parentesi orfana resta visibile accanto, invece di
essere assorbita — coerente col tutto-o-niente.
