### PR TITLE
fix(app): il riavvio cancellava il log dell'avvio fallito

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,38 @@ Scelte che contano:
 `Dockerfile.linux` resta quello che era: l'ambiente di **build** dei bundle .deb/AppImage, non
 un modo di far girare l'app. Il `.dockerignore` ora riammette `src/app/` (era `*`, pensato per
 il contesto vuoto di `Dockerfile.linux`, che infatti non fa nessun `COPY`).
+## 2026-08-05 — Il riavvio cancellava il log dell'avvio fallito (`serve.py`)
+
+Quando il backend non parte, lo splash di Tauri scrive *"Vedi il log in
+`%LOCALAPPDATA%\rizzo-pii\backend.log`"* (`lib.rs`). Ma `serve.py` apriva quel file in
+**troncamento** (`"w"`), e il sidecar viene rilanciato: da `retry_backend`, o dall'utente
+che riapre l'app per riprodurre il problema. Il rilancio azzerava il log dell'avvio
+fallito — cioè esattamente quello che il messaggio chiede di andare a leggere. Il lato
+Rust (`tlog`) scrive già in append: fuori linea era solo il lato Python.
+
+Ora il log è in **append**, con un'intestazione datata per avvio (`===== avvio … (pid …)`)
+per distinguere le sessioni, e rotazione su `backend.log.1` oltre 1 MB.
+
+Il controllo della dimensione avviene **solo all'avvio**, quindi non è un tetto sulla singola
+sessione: un backend che gira a lungo scrive quanto vuole. È il ripetersi degli avvii a restare
+limitato — 60 avvii da 60 KB (3,6 MB scritti) lasciano 1,56 MB su disco. Nota che `main`,
+troncando ogni volta, teneva al massimo una sessione; così ne tiene due.
+
+Dopo una rotazione il log fresco dice dove è finito il precedente. Serve: lo splash manda
+l'utente su `backend.log`, e senza quella riga chi arriva subito dopo il superamento della
+soglia non trova la traccia dell'avvio fallito, che la rotazione ha appena spostato in `.1`.
+
+La rotazione è in un `try` suo: se `os.replace` non riesce si accoda al file esistente senza
+perdere niente. Su Windows questo copre anche il caso di un'altra istanza che tiene il file
+aperto (sharing violation); su Linux e macOS `rename` ignora i descrittori aperti, quindi lì la
+rotazione riesce comunque e l'istanza già in esecuzione continua a scrivere sull'inode che ora
+si chiama `.1`.
+
+`tests/test_log_backend.py` (5 test) esegue il **preambolo vero** ritagliato da `serve.py`
+in un `LOCALAPPDATA` usa e getta — il file non è importabile, a import time carica il
+modello. Sul codice di `main` **3 dei 5 falliscono**.
+
+---
 
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 

--- a/src/app/serve.py
+++ b/src/app/serve.py
@@ -17,7 +17,7 @@ Configurazione host/porta:
   4) default 127.0.0.1:5005
 
 NB: la 5000 su macOS e' occupata da AirPlay Receiver (ControlCenter) -\u003e pagina bianca.
-Log:   %LOCALAPPDATA%\\\\rizzo-pii\\\\backend.log
+Log:   %LOCALAPPDATA%\\\\rizzo-pii\\\\backend.log  (in append; oltre 1 MB ruota su backend.log.1)
 
 Il processo esce con codice 76 (EX_PROTOCOL) se la porta e' occupata: Tauri lo
 riconosce e mostra il form di configurazione nello splash screen.
@@ -25,14 +25,33 @@ riconosce e mostra il form di configurazione nello splash screen.
 
 import os
 import sys
+import time
 
 # --- log su file (windowed mode -> niente console) ------------------------- #
+# In APPEND: con "w" il rilancio del sidecar (retry_backend di Tauri, o l'utente che
+# riapre l'app) cancellava il log dell'avvio fallito, cioe' proprio quello che lo
+# splash chiede di andare a leggere quando il backend non parte. Il lato Rust (tlog)
+# gia' scrive in append. Rotazione a 1 MB su .1 perche' il file non cresca all'infinito.
+_LOG_MAX = 1_000_000
 _logdir = os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")), "rizzo-pii")
+_logpath = os.path.join(_logdir, "backend.log")
 try:
     os.makedirs(_logdir, exist_ok=True)
-    _log = open(os.path.join(_logdir, "backend.log"), "w", encoding="utf-8", buffering=1)
+    _ruotato = False
+    try:
+        if os.path.getsize(_logpath) > _LOG_MAX:
+            os.replace(_logpath, _logpath + ".1")
+            _ruotato = True
+    except OSError:
+        pass  # log assente, o non spostabile: si accoda al file esistente
+    _log = open(_logpath, "a", encoding="utf-8", buffering=1)
     sys.stdout = _log
     sys.stderr = _log
+    print(f"\n===== avvio {time.strftime('%Y-%m-%d %H:%M:%S')} (pid {os.getpid()}) =====")
+    if _ruotato:
+        # senza questa riga, chi segue lo splash ("vedi backend.log") non trova la
+        # traccia dell'avvio fallito: la rotazione l'ha appena spostata in .1.
+        print("(il log precedente e' in backend.log.1)")
 except Exception:
     pass  # se non si puo' loggare, si prosegue comunque
 

--- a/tests/test_log_backend.py
+++ b/tests/test_log_backend.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Il log del backend (`serve.py`) deve sopravvivere al riavvio del sidecar.
+
+Quando il backend non parte, lo splash di Tauri dice all'utente di guardare
+`backend.log`. Ma il riavvio del sidecar (`retry_backend`, o l'utente che riapre
+l'app) riapre quel file: se lo apre in troncamento, cancella proprio il log
+dell'avvio fallito che si voleva leggere.
+
+`serve.py` non e' importabile in un test (a import time carica il modello), quindi
+qui si esegue il suo PREAMBOLO vero, ritagliato dal file, in un LOCALAPPDATA usa e
+getta: si testa il codice che viene spedito, non una copia.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVE = ROOT / "src" / "app" / "serve.py"
+
+
+def preambolo():
+    """Le righe di serve.py fino a prima dell'import di server_config."""
+    src = SERVE.read_text(encoding="utf-8")
+    testa = src[:src.index("import server_config")]
+    assert "backend.log" in testa, "il preambolo del log non e' piu' li'"
+    return testa
+
+
+def avvia(testa, home, marcatore):
+    """Un avvio del sidecar: esegue il preambolo e scrive un marcatore nel log."""
+    script = Path(home) / "_avvio.py"
+    script.write_text(testa + "\nprint(%r)\n" % marcatore, encoding="utf-8")
+    env = dict(os.environ, LOCALAPPDATA=home, PYTHONIOENCODING="utf-8")
+    return subprocess.run([sys.executable, str(script)], env=env,
+                          capture_output=True, text=True)
+
+
+def log(home, nome="backend.log"):
+    p = Path(home) / "rizzo-pii" / nome
+    return p.read_text(encoding="utf-8", errors="replace") if p.exists() else None
+
+
+class LogBackend(unittest.TestCase):
+    def setUp(self):
+        self.testa = preambolo()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = self.tmp.name
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_il_riavvio_non_cancella_il_log_precedente(self):
+        avvia(self.testa, self.home, "AVVIO-FALLITO")
+        avvia(self.testa, self.home, "RIAVVIO")
+        testo = log(self.home) or ""
+        self.assertIn("AVVIO-FALLITO", testo, "il log del crash e' stato cancellato")
+        self.assertIn("RIAVVIO", testo)
+
+    def test_ruota_oltre_il_massimo_invece_di_crescere(self):
+        d = Path(self.home) / "rizzo-pii"
+        d.mkdir(parents=True)
+        (d / "backend.log").write_text("VECCHIO\n" + "x" * 1_100_000, encoding="utf-8")
+        avvia(self.testa, self.home, "DOPO-ROTAZIONE")
+        self.assertIn("VECCHIO", log(self.home, "backend.log.1") or "")
+        nuovo = log(self.home) or ""
+        self.assertIn("DOPO-ROTAZIONE", nuovo)
+        self.assertLess(len(nuovo), 10_000, "il log non e' ripartito dopo la rotazione")
+        # lo splash manda l'utente su backend.log: se la traccia e' finita in .1,
+        # il file che il messaggio nomina deve almeno dirglielo
+        self.assertIn("backend.log.1", nuovo)
+
+    def test_tre_avvii_di_fila_nessuno_perso(self):
+        for k in range(3):
+            avvia(self.testa, self.home, "AVVIO-%d" % k)
+        testo = log(self.home) or ""
+        for k in range(3):
+            self.assertIn("AVVIO-%d" % k, testo)
+
+    def test_se_la_rotazione_fallisce_si_logga_lo_stesso(self):
+        # .1 occupato da una cartella non vuota -> os.replace non puo' riuscire
+        d = Path(self.home) / "rizzo-pii"
+        (d / "backend.log.1" / "occupata").mkdir(parents=True)
+        (d / "backend.log").write_text("y" * 1_100_000, encoding="utf-8")
+        r = avvia(self.testa, self.home, "ROTAZIONE-FALLITA")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("ROTAZIONE-FALLITA", log(self.home) or "")
+
+    def test_primo_avvio_crea_la_cartella(self):
+        r = avvia(self.testa, self.home, "PRIMO-AVVIO")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("PRIMO-AVVIO", log(self.home) or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Quando il backend non parte, lo splash dice all'utente di guardare il log:

```rust
// tauri/src-tauri/src/lib.rs:241
"Errore: il backend non si è avviato. Vedi il log in %LOCALAPPDATA%\\rizzo-pii\\backend.log"
```

Ma `serve.py` apriva quel file in **troncamento**:

```python
_log = open(os.path.join(_logdir, "backend.log"), "w", ...)
```

e il sidecar viene rilanciato: da `retry_backend` (`lib.rs:263`, che uccide il figlio e rifà
`spawn_sidecar`), o dall'utente che riapre l'app per riprodurre il problema. Il rilancio
azzerava il log dell'avvio fallito — cioè proprio quello che il messaggio chiede di andare a
leggere. Tocca le issue di avvio #6, #14, #59, #72, dove il log è la sola diagnostica.

Il lato Rust (`tlog`, `lib.rs:24`, che scrive con `.create(true).append(true)` alla riga 29) era
già in append: fuori linea era solo il lato Python.

## Cosa cambia

Log in **append**, intestazione datata per avvio (`===== avvio … (pid …)`) per distinguere le
sessioni, rotazione su `backend.log.1` oltre 1 MB.

Dopo una rotazione il log fresco scrive dove è finito il precedente. Non è cosmetico: lo splash
manda l'utente su `backend.log`, e chi arriva subito dopo il superamento della soglia non ci
troverebbe la traccia dell'avvio fallito, che la rotazione ha appena spostato in `.1` — cioè
proprio il caso che questa PR esiste per evitare.

## Due cose che avevo scritto male

**«Con un tetto di ~2 MB».** Non è un tetto. Il controllo della dimensione avviene solo
all'avvio, quindi la singola sessione cresce senza limite: un backend che gira a lungo lascia un
`backend.log` grande quanto ha scritto. Quello che resta limitato è il **ripetersi degli
avvii** — 60 avvii da 60 KB (3,6 MB scritti) lasciano 1,56 MB su disco. Da notare che `main`,
troncando ogni volta, teneva al massimo una sessione: così ne tiene due.

**«Se `os.replace` non riesce si accoda e basta».** Vero su Windows, dove un'altra istanza che
tiene il file aperto provoca una sharing violation. Su Linux e macOS — entrambi target di build
— `rename` ignora i descrittori aperti: la rotazione riesce, l'`except` non scatta mai, e
l'istanza già in esecuzione continua a scrivere sull'inode che ora si chiama `.1`. Il codice va
bene così (un lock cross-piattaforma non vale il caso), ma la garanzia andava circoscritta.

## Verifica

`serve.py` non è importabile in un test (a import time carica il modello), quindi
`tests/test_log_backend.py` esegue il **preambolo vero ritagliato dal file** in un
`LOCALAPPDATA` usa e getta: si testa il codice che viene spedito, non una copia.

| controllo | main | qui |
|---|---|---|
| il riavvio non cancella il log precedente | ✗ | ✓ |
| 3 avvii di fila, nessuno perso | ✗ | ✓ |
| ruota oltre 1 MB su `.1`, e il log fresco dice dov'è finito | ✗ | ✓ |
| se la rotazione fallisce si logga lo stesso | ✓ | ✓ |
| primo avvio: crea la cartella, esce senza errori | ✓ | ✓ |

**3 dei 5 test falliscono sul codice di `main`** (la stesura precedente diceva 5 controlli e 3 ✗
mentre i test erano 4 e i fallimenti 2: ora la tabella e la suite dicono la stessa cosa).

Suite completa: OK. Merge pulito con #65, #66, #67, #68, #69, #70, #71, #73 una a una e tutte
insieme, con i test verdi sull'albero unito.
