### PR TITLE
feat(brew): installazione via Homebrew (cask + tap, auto-publish alla…

### DIFF
--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -1,0 +1,99 @@
+name: publish-cask
+
+# A ogni release pubblicata (niente prerelease; una draft "published" fa
+# scattare un solo run), aggiorna la cask Homebrew e la sincronizza nel tap
+# Rizzo-AI-Academy/homebrew-rizzo-pii. Vedi homebrew/README.md.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-cask:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Scarica il DMG macOS del release
+        id: dmg
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/dmg
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" --dir /tmp/dmg \
+            --pattern "*-macOS-arm64.dmg" || true
+          if ls /tmp/dmg/*.dmg >/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "Nessun DMG macOS nella release: cask non aggiornata."
+          fi
+
+      - name: Calcola sha256 e versione, aggiorna e pubblica la cask
+        if: steps.dmg.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.event.release.tag_name }}
+          SHA256_OUT: /tmp/sha256.txt
+        run: |
+          files=(/tmp/dmg/*.dmg)
+          [ "${#files[@]}" -eq 1 ] || { echo "Attesi 1 DMG, trovati ${#files[@]}"; exit 1; }
+          SHA256="$(shasum -a 256 "${files[0]}" | awk '{print $1}')"
+          VERSION="${TAG#v}"
+          python3 - "$VERSION" "$SHA256" <<'EOF'
+          import re, pathlib, sys
+          version, sha256 = sys.argv[1], sys.argv[2]
+          p = pathlib.Path("homebrew/Casks/rizzo-pii.rb")
+          s = p.read_text()
+          s = re.sub(r'version "[^"]*"', f'version "{version}"', s, count=1)
+          s = re.sub(r'sha256 "[^"]*"', f'sha256 "{sha256}"', s, count=1)
+          p.write_text(s)
+          print(f"cask aggiornata: version={version} sha256={sha256}")
+          EOF
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet homebrew/Casks/rizzo-pii.rb; then
+            echo "Cask invariata: niente commit."
+          else
+            git add homebrew/Casks/rizzo-pii.rb
+            git commit -m "chore(brew): cask rizzo-pii v${VERSION} (auto, release ${TAG})"
+            git push origin HEAD:main
+            echo "Cask aggiornata su main."
+          fi
+
+      - name: Sincronizza nel tap homebrew-rizzo-pii
+        if: steps.dmg.outputs.found == 'true'
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_REPO_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "Secret TAP_REPO_TOKEN assente: sync manuale del tap richiesta."
+            exit 0
+          fi
+          VERSION="${TAG#v}"
+          rm -rf /tmp/tap
+          git clone https://github.com/Rizzo-AI-Academy/homebrew-rizzo-pii.git /tmp/tap
+          cd /tmp/tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdir -p Casks
+          cp "$GITHUB_WORKSPACE/homebrew/Casks/rizzo-pii.rb" Casks/rizzo-pii.rb
+          git add Casks/rizzo-pii.rb
+          if git diff --cached --quiet; then
+            echo "Tap gia' aggiornato: niente commit."
+            exit 0
+          fi
+          git commit -m "chore: cask rizzo-pii v${VERSION} (auto, release ${TAG})"
+          git push "https://x-access-token:${TAP_TOKEN}@github.com/Rizzo-AI-Academy/homebrew-rizzo-pii.git" HEAD:main
+          echo "Tap aggiornato."

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 <sub>🪟 **Windows installer** · 🍎 **macOS** (Apple Silicon) · 🐧 **Linux AppImage** — all available now</sub>
 
+<sub>🍺 **macOS via Homebrew**: `brew tap Rizzo-AI-Academy/rizzo-pii && brew install --cask rizzo-pii`</sub>
+
 </div>
 
 **`rizzo-pii:0.3B`** is a lightweight, CPU-friendly, **Italian-first** token-classification

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -132,6 +132,29 @@ Note specifiche di macOS:
 
 ---
 
+## Distribuzione via Homebrew (cask, macOS)
+
+Gli utenti macOS con Homebrew possono installare il `.dmg` rilasciato con un comando:
+
+```bash
+brew tap Rizzo-AI-Academy/rizzo-pii
+brew install --cask rizzo-pii
+```
+
+La cask vive in [`homebrew/Casks/rizzo-pii.rb`](../homebrew/Casks/rizzo-pii.rb) (Apple Silicon
+solo, come il DMG attuale) e Homebrew la legge dal **tap** dedicato
+`Rizzo-AI-Academy/homebrew-rizzo-pii`, dove va copiata in `Casks/`. Setup e flusso completi:
+**[`homebrew/README.md`](../homebrew/README.md)**.
+
+**Auto-publish**: il workflow [`.github/workflows/publish-cask.yml`](../.github/workflows/publish-cask.yml)
+scatta alla **pubblicazione** di una release (niente prerelease), scarica l'asset
+`*-macOS-arm64.dmg`, calcola lo `sha256`, aggiorna `version`/`sha256` nella cask, committa su
+`main` e sincronizza il tap (serve il secret `TAP_REPO_TOKEN`: PAT fine-grained con write sui
+soli contenuti del tap). Se manca il token, o `main` ha la branch protection, la sync è manuale
+(checklist in [`homebrew/README.md`](../homebrew/README.md)).
+
+---
+
 ## PyInstaller + Inno Setup (legacy, browser)
 
 ## Componenti

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,20 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-05 — Installazione macOS via Homebrew (cask + tap personale, auto-publish)
+
+Nuova via di distribuzione per macOS: cask `rizzo-pii` in [`homebrew/Casks/rizzo-pii.rb`](../homebrew/Casks/rizzo-pii.rb)
+(Apple Silicon solo, come il DMG rilasciato), letta da Homebrew tramite il tap
+`Rizzo-AI-Academy/homebrew-rizzo-pii`. Setup e checklist in [`homebrew/README.md`](../homebrew/README.md)
+e [§ "Distribuzione via Homebrew"](BUILD.md).
+
+Il workflow `.github/workflows/publish-cask.yml` automatizza il mantenimento: alla pubblicazione
+di una release scarica il DMG, ricalcola lo `sha256`, aggiorna `version`/`sha256` della cask su
+`main` e sincronizza il tap (richiede il secret `TAP_REPO_TOKEN`; senza, la sync resta manuale).
+Motivazione: il `sha256` cambia a ogni release e un URL `latest` non è accettabile per Homebrew,
+quindi la cask va rigenerata a ogni rilascio — meglio un workflow che un passo manuale da
+dimenticare.
+
 ## 2026-08-03 — `_merge()` era quadratica: 100 s su un documento lungo (`app.py`)
 
 Il controllo delle sovrapposizioni confrontava **ogni** candidato con **tutta** la lista già

--- a/homebrew/Casks/rizzo-pii.rb
+++ b/homebrew/Casks/rizzo-pii.rb
@@ -1,0 +1,20 @@
+cask "rizzo-pii" do
+  version "1.0.0"
+  sha256 "dbc01e6a1890ee114449fc07df12e2150ef5813d81d62d0940c131f29c2db9b2"
+
+  url "https://github.com/Rizzo-AI-Academy/rizzo-pii/releases/download/v#{version}/Rizzo-PII-#{version}-macOS-arm64.dmg"
+  name "Rizzo PII"
+  desc "Local, reversible PII anonymization for Italian legal text"
+  homepage "https://rizzo-ai-academy.github.io/rizzo-pii/"
+
+  livecheck do
+    url "https://github.com/Rizzo-AI-Academy/rizzo-pii/releases"
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  # Apple Silicon only: the released DMG is arm64 (see build_mac.sh). When an
+  # x86_64 build is published, add an `on_intel` URL branch here.
+  app "Rizzo PII.app"
+end

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,52 @@
+# Homebrew (cask) — installazione macOS
+
+La cask `rizzo-pii` è il file [`Casks/rizzo-pii.rb`](Casks/rizzo-pii.rb) di questa cartella:
+**qui vive la versione da pubblicare**. Homebrew non legge le cask da questo repo: ci vuole un
+**tap** dedicato (`Rizzo-AI-Academy/homebrew-rizzo-pii`), che contiene la stessa cask in
+`Casks/rizzo-pii.rb`. La sincronizzazione è automatica via workflow (vedi sotto).
+
+## Installazione (per gli utenti)
+
+```bash
+brew tap Rizzo-AI-Academy/rizzo-pii
+brew install --cask rizzo-pii
+```
+
+Nota: la cask attuale è **solo per Apple Silicon** (arm64), come il DMG rilasciato.
+
+## Setup del tap (una volta, admin dell'org)
+
+1. Creare il repo **`Rizzo-AI-Academy/homebrew-rizzo-pii`** (il nome deve iniziare con
+   `homebrew-`) con un README minimo.
+2. Copiare la cask: `mkdir Casks && cp homebrew/Casks/rizzo-pii.rb Casks/rizzo-pii.rb` (la prima
+   volta, finché il workflow non esiste, la sync è manuale).
+3. Aggiungere il secret **`TAP_REPO_TOKEN`** alle Actions del repo `rizzo-pii`: un fine-grained
+   PAT con permesso **Contents: Read and write** sul **solo** repo del tap (principio del minimo
+   privilegio: il token non deve toccare altri repo).
+
+## Pubblicazione automatica (`.github/workflows/publish-cask.yml`)
+
+Quando viene **pubblicata** una release (niente prerelease), il workflow:
+
+1. scarica l'asset `*-macOS-arm64.dmg` della release (senza DMG macOS → skip);
+2. calcola `sha256` e ricava la versione dal tag (senza `v`);
+3. aggiorna `version` e `sha256` in `homebrew/Casks/rizzo-pii.rb`;
+4. committa e spinge su `main` di **questo** repo;
+5. clona il tap, copia la cask in `Casks/` e spinge con `TAP_REPO_TOKEN`.
+
+Limiti noti:
+
+- se `main` ha la **branch protection** (PR obbligatoria), il push diretto fallisce → sync
+  manuale del tap (copia del file) e aggiornamento del cask a mano;
+- se manca `TAP_REPO_TOKEN`, il workflow si ferma al passo 4 e il tap va aggiornato a mano;
+- se il nome del DMG cambia formato, va aggiornato il pattern `--pattern` nel workflow.
+
+## Checklist di release (se il workflow non è intervenuto)
+
+1. `shasum -a 256 Rizzo-PII-<v>-macOS-arm64.dmg`
+2. aggiornare `version` e `sha256` in `Casks/rizzo-pii.rb` (qui in `homebrew/`)
+3. copiare il file nel tap (`Rizzo-AI-Academy/homebrew-rizzo-pii`, `Casks/rizzo-pii.rb`)
+4. commit + push in entrambi i repo.
+
+Verifica di un aggiornamento della cask: `brew install --cask rizzo-pii` (dopo `brew tap`),
+oppure localmente `brew install --cask ./Casks/rizzo-pii.rb`.


### PR DESCRIPTION
## Cosa

Installazione macOS via **Homebrew cask**: `brew tap Rizzo-AI-Academy/rizzo-pii && brew install --cask rizzo-pii`.

- `homebrew/Casks/rizzo-pii.rb` — la cask (versione 1.0.0, sha256 del DMG rilasciato, `livecheck` su GitHub releases, solo Apple Silicon come l'asset attuale). Qui vive la copia "source of truth"; il tap dedicato `Rizzo-AI-Academy/homebrew-rizzo-pii` la legge in `Casks/`.
- `homebrew/README.md` — setup del tap (una volta), flusso di pubblicazione, checklist manuale.
- `.github/workflows/publish-cask.yml` — **auto-publish**: alla pubblicazione di una release (no prerelease) scarica il DMG, ricalcola lo sha256, aggiorna `version`/`sha256` della cask, committa su `main` e sincronizza il tap (serve il secret `TAP_REPO_TOKEN`, PAT fine-grained con write sui soli contenuti del tap).
- README (badge) + docs/BUILD.md (sezione "Distribuzione via Homebrew") + CHANGELOG.

## Perché

Homebrew è il package manager de-facto su macOS; la cask elimina il download manuale del DMG.
L'unico problema è che `latest` non è accettabile per Homebrew perché lo sha256 cambia se si aggiorna l'artefatto e quindi a ogni release la cask va rigenerata a ogni rilascio, quindi ho implementato un workflow.

## Verifiche effettuate

- `brew style` e `brew audit --cask` puliti (testati via tap locale `Rizzo-AI-Academy/rizzo-pii`).
- Installazione reale riuscita da tap locale (`Rizzo PII.app` → `/Applications`, firma Developer ID verificata con `codesign`/`spctl`)
- `brew livecheck` risolve `1.0.0 ==> 1.0.0`.
- Logica di aggiornamento cask del workflow testata localmente (rewrite `version`/`sha256`); `actionlint` pulito sul workflow.

## Azioni richieste al maintainer (una tantum)

1. Creare il repo `Rizzo-AI-Academy/homebrew-rizzo-pii` e copiare la cask in `Casks/` (la prima volta manualmente, finché il workflow non esiste).
2. Aggiungere il secret di GitHub Actions `TAP_REPO_TOKEN` (fine-grained PAT, Contents R/W sul solo tap).

## Nota

Il push diretto su `main` del workflow fallisce se `main` ha la branch protection (PR obbligatoria), caso documentato in `homebrew/README.md`; in quel caso la sync del tap resta manuale.

Ad ogni modo, grazie per questo sw! Un saluto.