### PR TITLE
fix(app): tre bug di concorrenza/config nel server Flask

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -182,11 +182,13 @@ def _page_png(d, n, dpi=PREVIEW_DPI):
     if not (0 <= n < d["n_pages"]):
         return None
     key = (n, dpi)
-    png = d["pages"].get(key)
+    with _DOCS_LOCK:
+        png = d["pages"].get(key)
     if png is None:
         with fitz.open(stream=d["pdf"], filetype="pdf") as doc:
             png = doc.load_page(n).get_pixmap(dpi=dpi).tobytes("png")
-        d["pages"][key] = png
+        with _DOCS_LOCK:
+            d["pages"][key] = png
     return png
 
 

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -247,6 +247,13 @@ TAG_NAMES = [t[0] for t in TAGS]
 _prefs = server_config.load_prefs()
 EXCLUDED_TAGS = _prefs["excluded_tags"]
 MAPPING_ENABLED = _prefs["mapping_enabled"]
+_PREFS_LOCK = threading.Lock()   # protegge la lettura/scrittura ATOMICA della coppia sopra
+
+
+def _get_prefs():
+    """Snapshot coerente di (excluded_tags, mapping_enabled): mai una POST /settings a meta'."""
+    with _PREFS_LOCK:
+        return EXCLUDED_TAGS, MAPPING_ENABLED
 
 
 # --------------------------------------------------------------------------- #
@@ -469,6 +476,7 @@ def health():
     """Liveness/readiness SENZA inference: sonda economica per orchestratori e sidecar.
     200 = modello caricato e pronto; 503 = server su ma modello non disponibile."""
     ready = nlp is not None
+    excl, mapping = _get_prefs()
     body = {
         "status": "ok" if ready else "loading",
         "model_loaded": ready,
@@ -477,8 +485,8 @@ def health():
         "app_version": APP_VERSION,
         "device": "cuda" if device == 0 else "cpu",
         "tags": len(TAG_NAMES),
-        "excluded_tags": EXCLUDED_TAGS,
-        "mapping_enabled": MAPPING_ENABLED,
+        "excluded_tags": excl,
+        "mapping_enabled": mapping,
     }
     return jsonify(body), (200 if ready else 503)
 
@@ -541,9 +549,12 @@ def analyze_route():
         return jsonify({"error": "Nessun testo da analizzare."}), 400
 
     # override per-richiesta; senza override vale la configurazione del server
-    excl = server_config.parse_tag_list(raw_excl) if raw_excl is not None else EXCLUDED_TAGS
-    keep_map = (server_config.parse_bool(raw_map, MAPPING_ENABLED)
-                if raw_map is not None else MAPPING_ENABLED)
+    # (snapshot atomico: una POST /settings concorrente non deve far leggere
+    # un tag escluso aggiornato insieme a un mapping_enabled non ancora aggiornato, o viceversa)
+    default_excl, default_map = _get_prefs()
+    excl = server_config.parse_tag_list(raw_excl) if raw_excl is not None else default_excl
+    keep_map = (server_config.parse_bool(raw_map, default_map)
+                if raw_map is not None else default_map)
     out = analyze(text, excl, keep_map)
     out["source_text"] = text
     return jsonify(out)
@@ -614,7 +625,8 @@ def _build_anonymized_pdf():
     stem = os.path.splitext(_safe_name(name, "documento.pdf"))[0] or "documento"
     out_name = f"{stem}_anonimizzato.pdf"
 
-    excl = server_config.parse_tag_list(raw_excl) if raw_excl is not None else EXCLUDED_TAGS
+    excl = (server_config.parse_tag_list(raw_excl) if raw_excl is not None
+            else _get_prefs()[0])
     # mapping_enabled=True e' interno: il risultato non esce da questa funzione.
     res = analyze(text, excl, mapping_enabled=True)
     if not res["mapping"]:
@@ -732,10 +744,11 @@ def doc_file(doc_id):
 @app.route("/settings", methods=["GET"])
 @app.route("/tags", methods=["GET"])
 def settings_get():
+    excl, mapping = _get_prefs()
     return jsonify({
         "tags": [{"tag": t, "it": it, "en": en, "example": ex} for t, it, en, ex in TAGS],
-        "excluded_tags": EXCLUDED_TAGS,
-        "mapping_enabled": MAPPING_ENABLED,
+        "excluded_tags": excl,
+        "mapping_enabled": mapping,
         "config_path": str(server_config.prefs_path()),
         "env_override": "PII_EXCLUDE_TAGS" in os.environ or "PII_MAPPING" in os.environ,
     })
@@ -756,8 +769,9 @@ def settings_post():
     if tags is None and mapping is None:
         return jsonify({"error": "Niente da salvare: passa excluded_tags e/o mapping_enabled."}), 400
     saved = server_config.save_prefs(excluded_tags=tags, mapping_enabled=mapping)
-    EXCLUDED_TAGS = saved["excluded_tags"]
-    MAPPING_ENABLED = saved["mapping_enabled"]
+    with _PREFS_LOCK:
+        EXCLUDED_TAGS = saved["excluded_tags"]
+        MAPPING_ENABLED = saved["mapping_enabled"]
     return jsonify({"ok": True, "excluded_tags": EXCLUDED_TAGS,
                     "mapping_enabled": MAPPING_ENABLED})
 

--- a/src/app/server_config.py
+++ b/src/app/server_config.py
@@ -171,7 +171,10 @@ def resolve(cli_host=None, cli_port=None):
     """
     cfg = load_config()
     host = cli_host or os.environ.get("PII_HOST") or cfg.get("host") or DEFAULT_HOST
-    port = cli_port or os.environ.get("PII_PORT") or cfg.get("port") or DEFAULT_PORT
+    port = (cli_port if cli_port is not None else
+            os.environ.get("PII_PORT") if "PII_PORT" in os.environ else
+            cfg.get("port") if cfg.get("port") is not None else
+            DEFAULT_PORT)
     return str(host), int(port)
 
 


### PR DESCRIPTION
## Cosa  
Tre bug trovati analizzando `app.py` e `server_config.py`, uno per commit:
  
**1. `--port 0` veniva ignorato.** `resolve()` costruiva la precedenza CLI > env > config.json > default con `or`, e `0` è falsy in Python: passando `--port 0` esplicitamente, la CLI veniva scartata e si scendeva al livello successivo. Sostituiti i controlli con `is not None`. 
  
**2. Race condition sulla cache di render PDF.** `_page_png()` leggeva e scriveva `d["pages"]` fuori da `_DOCS_LOCK`, ma il server gira sempre con `threaded=True` e il frontend richiede più pagine in parallelo quando apre un documento (anteprima a griglia). Richieste concorrenti sulla stessa pagina potevano finire per renderizzarla due volte. Get e set ora passano dal lock.
  
**3. `EXCLUDED_TAGS`/`MAPPING_ENABLED` letti senza sincronizzazione.** Sono variabili globali, mutate da `POST /settings` e lette da `/analyze`, `/pdf`, `GET /settings` senza alcun lock — in un server multi-thread una richiesta poteva leggere una combinazione incoerente delle due (tag già aggiornati ma mapping no, o viceversa). Aggiunto `_PREFS_LOCK` e l'helper `_get_prefs()`, che ritorna uno snapshot atomico della coppia.
  
## Verifiche
`py_compile` pulito su entrambi i file; testata a mano la nuova precedenza della porta (0 esplicito, nessun override, override normale). Non ci sono test automatici esistenti per queste aree.
