### PR TITLE
fix(pdf): sanitizza PII fuori dal testo pagina e nei target dei link

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,23 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-07 — PII fuori dal page text nei PDF (`src/app/pdf_export.py`)
+
+Il mapping usato da `/pdf` nasceva dal solo `page.get_text()`: una PII presente esclusivamente
+in un'annotazione, campo modulo, segnalibro o target URI poteva quindi non essere scoperta. I
+target dei link, inoltre, non venivano né sostituiti né inclusi nella verifica dei residui.
+
+La detection PDF ora tratta page text, ogni campo di annotazione, widget, TOC e URI come
+superfici indipendenti, senza concatenarle né aggiungerle al testo anonimizzato mostrato
+all'utente. Contatori e deduplicazione dei placeholder restano globali all'intero documento.
+Gli URI literal vengono aggiornati con un placeholder percent-encoded; quelli che rivelano la
+PII soltanto dopo un singolo `unquote` perdono selettivamente l'azione-link, perché ricostruirne
+gli offset encoded non è affidabile. Discovery, sanitizzazione e verifica dei residui applicano
+la stessa regola di decoding (mai `unquote_plus`). Il guardrail accetta un PDF senza redazioni
+di pagina soltanto quando è avvenuta almeno una reale sostituzione ausiliaria; i PDF image-only
+senza superfici sanificate restano rifiutati. Test sintetici coprono annotazione-only, widget,
+TOC, URI literal/encoded, confini fra superfici e il caso scansione.
+
 ## 2026-08-07 — `Dockerfile`: l'app come webapp in un container
 
 Finora l'unico modo di far girare l'app era l'installer desktop o `python src/app/app.py` con

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -280,25 +280,45 @@ def chunk_text(text, max_words=MAX_WORDS, overlap=OVERLAP):
     return chunks
 
 
+def _detect_model_surfaces(texts):
+    """Inferenza batch su superfici indipendenti, senza concatenarle.
+
+    I chunk di tutte le superfici viaggiano in un'unica chiamata al modello per
+    non trasformare annotazioni/link numerosi in altrettante inference lente.
+    Gli offset restano relativi alla rispettiva superficie.
+    """
+    chunks, refs = [], []
+    counts = [0] * len(texts)
+    entities = [[] for _ in texts]
+    for surface_i, text in enumerate(texts):
+        surface_chunks = chunk_text(text)
+        counts[surface_i] = len(surface_chunks)
+        for chunk, offset in surface_chunks:
+            chunks.append(chunk)
+            refs.append((surface_i, offset))
+    if not chunks:
+        return entities, counts
+
+    results = nlp(chunks)
+    if isinstance(results, dict):                    # binding/pipeline non-batch
+        results = [results]
+    for (surface_i, offset), result in zip(refs, results):
+        for entity in result:
+            entities[surface_i].append({
+                "label": entity["entity_group"],
+                "start": int(entity["start"]) + offset,
+                "end": int(entity["end"]) + offset,
+                "score": float(entity["score"]),
+                "validated": False,
+                "source": "modello",
+            })
+    return entities, counts
+
+
 def detect_model(text):
     """Entita' trovate dal modello mmBERT su tutti i chunk, su offset globali."""
-    chunks = chunk_text(text)
-    ents = []
-    if chunks:
-        results = nlp([c for c, _ in chunks])
-        if isinstance(results, dict):                 # singolo chunk -> normalizza
-            results = [results]
-        for (_, off), res in zip(chunks, results):
-            for e in res:
-                ents.append({
-                    "label": e["entity_group"],
-                    "start": int(e["start"]) + off,
-                    "end": int(e["end"]) + off,
-                    "score": float(e["score"]),
-                    "validated": False,
-                    "source": "modello",
-                })
-    return ents, len(chunks)
+    entities, counts = _detect_model_surfaces([text])
+    return entities[0], counts[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -374,6 +394,38 @@ def _norm(s):
     return re.sub(r"\s+", " ", s.strip()).casefold()
 
 
+def _assign_placeholders(kept, text, counters, seen, mapping, mapping_enabled=True):
+    """Assegna ID con stato condivisibile fra piu' superfici indipendenti."""
+    for entity in kept:
+        value = text[entity["start"]:entity["end"]]
+        key = (entity["label"], _norm(value))
+        if key in seen:
+            entity["ph"] = seen[key]
+            continue
+        label = entity["label"]
+        counters[label] = counters.get(label, 0) + 1
+        placeholder = f"[{label}_{counters[label]}]"
+        seen[key] = placeholder
+        if mapping_enabled:
+            mapping[placeholder] = value
+        entity["ph"] = placeholder
+
+
+def _mapping_for_surfaces(texts, excluded=None):
+    """Mapping PDF globale, rilevando ogni superficie in isolamento."""
+    texts = [text for text in texts if isinstance(text, str) and text.strip()]
+    excluded = set(excluded or ())
+    model_entities, _counts = _detect_model_surfaces(texts)
+    counters, seen, mapping = {}, {}, {}
+    for text, model_ents in zip(texts, model_entities):
+        candidates = model_ents + detect_regex(text)
+        if excluded:
+            candidates = [e for e in candidates if e["label"] not in excluded]
+        kept = _merge(candidates, text)
+        _assign_placeholders(kept, text, counters, seen, mapping)
+    return mapping
+
+
 def analyze(text, excluded=None, mapping_enabled=True):
     """excluded = tag da NON anonimizzare: le entita' di quel tipo vengono scartate
     prima della fusione, quindi il valore resta in chiaro nel testo di output.
@@ -392,18 +444,7 @@ def analyze(text, excluded=None, mapping_enabled=True):
 
     # ID reversibili: stesso (label, valore-normalizzato) -> stesso placeholder.
     counters, seen, mapping = {}, {}, {}
-    for e in kept:
-        val = text[e["start"]:e["end"]]
-        key = (e["label"], _norm(val))
-        if key in seen:
-            e["ph"] = seen[key]
-        else:
-            counters[e["label"]] = counters.get(e["label"], 0) + 1
-            ph = f"[{e['label']}_{counters[e['label']]}]"
-            seen[key] = ph
-            if mapping_enabled:
-                mapping[ph] = val
-            e["ph"] = ph
+    _assign_placeholders(kept, text, counters, seen, mapping, mapping_enabled)
 
     # segmenti per la preview + testo anonimizzato + statistiche
     segments, anon, by_label, by_source, pos = [], [], {}, {}, 0
@@ -619,28 +660,43 @@ def _build_anonymized_pdf():
         raw_excl = payload.get("exclude_tags")
 
     text = (text or "").strip()
-    if not text:
+    source_is_pdf = bool(data and _is_pdf(name, data))
+    if source_is_pdf:
+        try:
+            detection_surfaces = pdf_export.extract_detection_surfaces(data)
+        except pdf_export.PdfError as e:
+            raise _ReqError(str(e))
+    else:
+        detection_surfaces = [text] if text else []
+    if not detection_surfaces:
         raise _ReqError("Nessun testo da anonimizzare.")
 
     stem = os.path.splitext(_safe_name(name, "documento.pdf"))[0] or "documento"
     out_name = f"{stem}_anonimizzato.pdf"
 
     excl = server_config.parse_tag_list(raw_excl) if raw_excl is not None else EXCLUDED_TAGS
-    # mapping_enabled=True e' interno: il risultato non esce da questa funzione.
-    res = analyze(text, excl, mapping_enabled=True)
-    if not res["mapping"]:
+    if source_is_pdf:
+        # Ogni page/annotation/widget/TOC/URI resta una superficie indipendente;
+        # il mapping globale condivide invece contatori e valori normalizzati.
+        mapping = _mapping_for_surfaces(detection_surfaces, excl)
+    else:
+        # mapping_enabled=True e' interno: il risultato non esce da questa funzione.
+        res = analyze(text, excl, mapping_enabled=True)
+        mapping = res["mapping"]
+    if not mapping:
         raise _ReqError("Nessuna PII trovata: non c'e' niente da "
                         "anonimizzare in questo documento.", 422)
 
-    if data and _is_pdf(name, data):
+    if source_is_pdf:
         try:
-            out, report = pdf_export.redact_pdf(data, res["mapping"])
+            out, report = pdf_export.redact_pdf(data, mapping)
         except pdf_export.PdfError as e:
             raise _ReqError(str(e))
-        if report["occurrences"] == 0:
+        if report["sanitizations"] == 0:
             raise _ReqError("Nessuna occorrenza trovata nel PDF: se il documento "
                             "e' una scansione (testo dentro un'immagine) la "
                             "redazione del layer testuale non puo' agire.", 422)
+        # API storica: redactions = sole occorrenze nel page content stream.
         return out, report, report["occurrences"], out_name
 
     try:

--- a/src/app/pdf_export.py
+++ b/src/app/pdf_export.py
@@ -30,11 +30,13 @@ che apply_redactions() da solo NON tocca):
   - contenuto delle ANNOTAZIONI (commenti, FreeText, note);
   - valore dei CAMPI MODULO (widget AcroForm);
   - titoli dei SEGNALIBRI (outline/TOC);
+  - target URI dei LINK (placeholder URI-safe per i match literal; rimozione
+    selettiva dell'azione-link se la PII e' visibile solo dopo un `unquote`);
   - ALLEGATI incorporati (embedded files), rimossi in blocco.
 
 Rete di sicurezza finale: `report["residual"]` elenca i placeholder il cui valore
-e' ANCORA leggibile nell'output (testo di pagina + annotazioni + widget + TOC).
-Deve essere vuota; l'UI avvisa se non lo e'.
+e' ANCORA leggibile nell'output (testo di pagina + annotazioni + widget + TOC +
+target URI dei link). Deve essere vuota; l'UI avvisa se non lo e'.
 
 Limiti noti (= punti 2-4 della issue #7):
   - testo dentro immagini raster (scansioni, loghi, blocchi firma): non esiste nel
@@ -48,6 +50,7 @@ Limiti noti (= punti 2-4 della issue #7):
 
 import re
 import unicodedata
+from urllib.parse import quote, unquote
 
 import fitz  # PyMuPDF
 
@@ -225,6 +228,101 @@ def _sub_all(patterns, s):
     return s, n
 
 
+# Le chiavi testuali persistenti che sappiamo anche aggiornare in modo affidabile
+# con Page.update_link(). Altri tipi di destinazione sono coordinate/pagine.
+_LINK_TEXT_KEYS = ("uri",)
+
+
+def _link_text_parts(link):
+    """Rappresentazioni testuali di un URI, raw e decodificata UNA volta.
+
+    `unquote` (non unquote_plus) conserva i `+` legittimi e permette a discovery
+    e residual verification di vedere PII nascoste dietro percent-encoding.
+    """
+    parts = []
+    for key in _LINK_TEXT_KEYS:
+        value = link.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        parts.append(value)
+        decoded = unquote(value)
+        if decoded != value:
+            parts.append(decoded)
+    return parts
+
+
+def _aux_text_parts(doc):
+    """Superfici testuali persistenti fuori dal normale page text.
+
+    Questa e' l'unica enumerazione usata sia per la discovery sia per la verifica
+    finale: aggiungere una superficie qui evita che i due percorsi divergano.
+    Superficie assente = sequenza vuota; enumerazione fallita = PdfError, perche'
+    un PDF che non possiamo ispezionare non puo' essere dichiarato sanificato.
+    """
+    parts = []
+    for page in doc:
+        try:
+            annots = page.annots()
+            for annot in annots or ():
+                if annot.type[0] == fitz.PDF_ANNOT_REDACT:
+                    continue
+                info = annot.info
+                parts.extend(str(info.get(k)) for k in ("content", "subject", "title")
+                             if info.get(k))
+        except Exception as e:
+            raise PdfError("Impossibile ispezionare le annotazioni del PDF.") from e
+        try:
+            widgets = page.widgets()
+            for widget in widgets or ():
+                if isinstance(widget.field_value, str):
+                    parts.append(widget.field_value)
+        except Exception as e:
+            raise PdfError("Impossibile ispezionare i campi modulo del PDF.") from e
+        try:
+            links = page.get_links()
+            for link in links or ():
+                parts.extend(_link_text_parts(link))
+        except Exception as e:
+            raise PdfError("Impossibile ispezionare i link del PDF.") from e
+    try:
+        toc = doc.get_toc(simple=True)
+        parts.extend(str(entry[1]) for entry in toc or () if entry[1])
+    except Exception as e:
+        raise PdfError("Impossibile ispezionare l'indice del PDF.") from e
+    return parts
+
+
+def _readable_parts(doc):
+    """Superfici persistenti indipendenti: nessun match puo' attraversarle."""
+    parts = [page.get_text() for page in doc]
+    parts.extend(_aux_text_parts(doc))
+    return [part for part in parts if part]
+
+
+def extract_detection_surfaces(pdf_bytes):
+    """Superfici PDF indipendenti destinate SOLO alla detection delle PII.
+
+    Non modifica il documento e non va aggiunto al testo anonimizzato mostrato
+    all'utente. Ogni page text, campo ausiliario e rappresentazione URI resta una
+    stringa distinta, cosi' il detector non costruisce entita' fra due superfici.
+    """
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception:
+        raise PdfError("File PDF non valido o danneggiato.")
+    if doc.needs_pass:
+        doc.close()
+        raise PdfError("PDF protetto da password: rimuovi la protezione e riprova.")
+    try:
+        return _readable_parts(doc)
+    except PdfError:
+        raise
+    except Exception as e:
+        raise PdfError("Impossibile ispezionare il contenuto del PDF.") from e
+    finally:
+        doc.close()
+
+
 def _scrub_annots(page, patterns):
     """Contenuto e titolo delle annotazioni (commenti, FreeText, note adesive):
     testo vero e proprio, invisibile a get_text() e non toccato dalle redazioni."""
@@ -276,6 +374,63 @@ def _scrub_widgets(page, patterns):
     return done
 
 
+def _scrub_links(page, patterns):
+    """Sanifica URI literal; rimuove l'azione se la PII e' solo encoded.
+
+    Il placeholder dei match literal viene percent-encoded per lasciare intatti
+    schema, query, fragment e tutti gli altri byte del target. Se la PII compare
+    soltanto dopo `unquote`, ricostruire gli offset raw sarebbe fragile: si elimina
+    quindi solo l'annotazione-link, mantenendo testo e layout della pagina.
+    """
+    done = 0
+    uri_patterns = [(pat, quote(ph, safe="")) for pat, ph in patterns]
+    try:
+        links = list(page.get_links())
+    except Exception:
+        return 0
+    for link in links:
+        try:
+            value = link.get("uri")
+            if not isinstance(value, str) or not value:
+                continue
+            decoded_value = unquote(value)
+
+            # La decisione va presa sul target ORIGINALE: sostituire prima un
+            # valore literal piu' corto (es. "mario") potrebbe mascherare una
+            # PII encoded piu' lunga (es. l'intera e-mail) e produrre un falso
+            # negativo. Se il decoding rivela nuove occorrenze, l'azione non e'
+            # riscrivibile in modo locale e viene neutralizzata per intero.
+            decoded_hits = 0
+            reveals_encoded_pii = False
+            for pat, _placeholder in patterns:
+                raw_count = sum(1 for _ in pat.finditer(value))
+                semantic_count = sum(1 for _ in pat.finditer(decoded_value))
+                decoded_hits += semantic_count
+                if semantic_count > raw_count:
+                    reveals_encoded_pii = True
+            if reveals_encoded_pii:
+                page.delete_link(link)
+                done += max(1, decoded_hits)
+                continue
+
+            new_value, literal_hits = _sub_all(uri_patterns, value)
+            # Un solo decoding, senza trasformare '+' in spazio. Se resta una PII
+            # nota nella forma semantica non tocchiamo genericamente il quoting:
+            # neutralizziamo esclusivamente questa azione del link.
+            _, encoded_hits = _sub_all(patterns, unquote(new_value))
+            if encoded_hits:
+                page.delete_link(link)
+                done += literal_hits + encoded_hits
+            elif literal_hits:
+                new = dict(link)
+                new["uri"] = new_value
+                page.update_link(new)
+                done += literal_hits
+        except Exception:
+            continue
+    return done
+
+
 def _scrub_toc(doc, patterns):
     """Titoli dei segnalibri: spesso ricalcano intestazioni con nomi e numeri."""
     try:
@@ -317,43 +472,28 @@ def _strip_embedded(doc):
 
 def _readable_text(doc):
     """TUTTO il testo leggibile del documento: pagine + annotazioni + campi
-    modulo + segnalibri. E' la base della verifica dei residui: se un valore
-    compare qui, l'anonimizzazione NON e' completa.
+    modulo + segnalibri + target URI dei link. E' la base della verifica dei
+    residui: se un valore compare qui, l'anonimizzazione NON e' completa.
     NB: non vede il testo dentro immagini raster (loghi, firme, scansioni)."""
-    parts = []
-    for page in doc:
-        parts.append(page.get_text())
-        try:
-            for a in page.annots():
-                if a.type[0] == fitz.PDF_ANNOT_REDACT:
-                    continue
-                info = a.info
-                parts.extend(str(info.get(k) or "") for k in ("content", "subject", "title"))
-        except Exception:
-            pass
-        try:
-            for w in page.widgets():
-                if isinstance(w.field_value, str):
-                    parts.append(w.field_value)
-        except Exception:
-            pass
-    try:
-        parts.extend(str(e[1] or "") for e in doc.get_toc(simple=True))
-    except Exception:
-        pass
-    return "\n".join(parts)
+    return "\n".join(_readable_parts(doc))
 
 
 def _verify_residuals(pdf_bytes, items):
     """Placeholder il cui valore e' ANCORA leggibile nell'output. Usa lo STESSO
     pattern della redazione (sillabazione inclusa), altrimenti dichiarerebbe
-    "0 residui" proprio nei casi che il matcher non sa gestire."""
-    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
-        text = _readable_text(doc)
+    "0 residui" proprio nei casi che il matcher non sa gestire. Se l'ispezione
+    non e' completa solleva PdfError invece di produrre un falso negativo."""
+    try:
+        with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+            parts = _readable_parts(doc)
+    except PdfError:
+        raise
+    except Exception as e:
+        raise PdfError("Impossibile verificare il PDF anonimizzato.") from e
     residual = []
     for ph, val in items:
         pat = _value_pattern(val)
-        if pat and pat.search(text):
+        if pat and any(pat.search(part) for part in parts):
             residual.append(ph)
     return residual
 
@@ -383,6 +523,8 @@ def redact_pdf(pdf_bytes, mapping, fill=REDACT_FILL, text_color=REDACT_TEXT):
         "annots":         sostituzioni nelle annotazioni,
         "widgets":        sostituzioni nei campi modulo,
         "toc":            sostituzioni nei segnalibri,
+        "links":          sostituzioni nei target URI dei link,
+        "sanitizations":  sostituzioni reali totali (pagina + superfici ausiliarie),
         "embedded":       allegati rimossi,
     }
     """
@@ -418,7 +560,7 @@ def redact_pdf(pdf_bytes, mapping, fill=REDACT_FILL, text_color=REDACT_TEXT):
 
     by_ph = {ph: 0 for ph, _, _ in usable}
     patterns = [(pat, ph) for ph, _, pat in usable]   # per annot/widget/TOC
-    total = n_annots = n_widgets = 0
+    total = n_annots = n_widgets = n_links = 0
 
     for page in doc:
         text, boxes = _page_char_index(page)
@@ -445,6 +587,7 @@ def redact_pdf(pdf_bytes, mapping, fill=REDACT_FILL, text_color=REDACT_TEXT):
         # dopo le redazioni: annotazioni e campi modulo non sono content stream
         n_annots += _scrub_annots(page, patterns)
         n_widgets += _scrub_widgets(page, patterns)
+        n_links += _scrub_links(page, patterns)
 
     n_toc = _scrub_toc(doc, patterns)
     n_emb = _strip_embedded(doc)
@@ -462,6 +605,8 @@ def redact_pdf(pdf_bytes, mapping, fill=REDACT_FILL, text_color=REDACT_TEXT):
         "annots": n_annots,
         "widgets": n_widgets,
         "toc": n_toc,
+        "links": n_links,
+        "sanitizations": total + n_annots + n_widgets + n_toc + n_links,
         "embedded": n_emb,
     }
 

--- a/src/app/smoke_pdf_export.py
+++ b/src/app/smoke_pdf_export.py
@@ -20,6 +20,8 @@ import fitz  # PyMuPDF
 import pdf_export as px
 
 OK = []
+CF_ONLY = "RSSMRA85H12H501V"
+LINK_EMAIL = "mario.rossi@example.com"
 
 
 def check(name, cond, extra=""):
@@ -118,6 +120,61 @@ pdf = px.text_to_pdf("Il sig. [FULLNAME_1] con IBAN [IBAN_1].\nRiga due — trat
 with fitz.open(stream=pdf, filetype="pdf") as d:
     t = d[0].get_text()
 check("text_to_pdf impagina i placeholder", "[FULLNAME_1]" in t and "[IBAN_1]" in t)
+
+# --- regressioni: PII scoperta solo fuori dal testo di pagina -----------------
+doc = fitz.open()
+p = doc.new_page()
+p.insert_text((50, 80), "Documento di prova senza identificativi personali.", fontsize=11)
+a = p.add_text_annot((200, 200), "Codice fiscale " + CF_ONLY)
+a.set_info(content="Codice fiscale " + CF_ONLY)
+a.update()
+aux_only_pdf = doc.tobytes()
+doc.close()
+with fitz.open(stream=aux_only_pdf, filetype="pdf") as d:
+    page_only_text = d[0].get_text()
+check("CF solo in annotazione assente dal page text", CF_ONLY not in page_only_text)
+aux_surfaces = px.extract_detection_surfaces(aux_only_pdf)
+check("CF solo in annotazione scoperto dal percorso auxiliary",
+      any(CF_ONLY in surface for surface in aux_surfaces))
+check("residuo noto in annotazione rilevato prima della sanitizzazione",
+      px._verify_residuals(aux_only_pdf, [("[CF_1]", CF_ONLY)]) == ["[CF_1]"])
+
+aux_out, aux_rep = px.redact_pdf(aux_only_pdf, {"[CF_1]": CF_ONLY})
+with fitz.open(stream=aux_out, filetype="pdf") as d:
+    aux_after = px._readable_text(d)
+check("CF solo in annotazione sanificato", CF_ONLY not in aux_after)
+check("sanitizzazione auxiliary conteggiata come lavoro reale",
+      aux_rep.get("sanitizations", 0) > 0, aux_rep)
+
+# --- regressioni: target mailto persistente e non sovrapposto al testo --------
+doc = fitz.open()
+p = doc.new_page()
+p.insert_text((50, 80), LINK_EMAIL, fontsize=11)
+p.insert_text((50, 130), "Invia un messaggio", fontsize=11)
+p.insert_link({"kind": fitz.LINK_URI, "from": fitz.Rect(45, 115, 180, 135),
+               "uri": "mailto:" + LINK_EMAIL})
+link_pdf = doc.tobytes()
+doc.close()
+
+doc = fitz.open()
+p = doc.new_page()
+p.insert_text((50, 80), "Invia un messaggio", fontsize=11)
+p.insert_link({"kind": fitz.LINK_URI, "from": fitz.Rect(45, 65, 180, 85),
+               "uri": "mailto:" + LINK_EMAIL})
+link_only_pdf = doc.tobytes()
+doc.close()
+check("target link incluso nella verifica residui prima della sanitizzazione",
+      px._verify_residuals(link_only_pdf, [("[EMAIL_1]", LINK_EMAIL)]) == ["[EMAIL_1]"])
+
+link_out, link_rep = px.redact_pdf(link_pdf, {"[EMAIL_1]": LINK_EMAIL})
+with fitz.open(stream=link_out, filetype="pdf") as d:
+    link_text = d[0].get_text()
+    links = d[0].get_links()
+check("testo email visibile sanificato", LINK_EMAIL not in link_text)
+check("link preservato", len(links) == 1, links)
+check("target mailto sanificato",
+      links and links[0].get("uri") == "mailto:%5BEMAIL_1%5D", links)
+check("nessun residuo solo dopo testo e link sanificati", link_rep["residual"] == [], link_rep)
 
 print("\n%d/%d PASS" % (sum(OK), len(OK)))
 sys.exit(0 if all(OK) else 1)

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,0 +1,543 @@
+# -*- coding: utf-8 -*-
+"""Regressioni per PII persistente fuori dal normale testo di pagina.
+
+Le fixture sono interamente sintetiche e non caricano il modello neurale.
+"""
+
+import importlib.util
+import io
+import sys
+import types
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+from unittest import mock
+
+import fitz
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = ROOT / "src" / "app"
+sys.path.insert(0, str(APP_DIR))
+
+import pdf_export as px  # noqa: E402
+
+
+CF = "RSSMRA85H12H501V"
+EMAIL = "mario.rossi@example.com"
+
+
+def annotation_only_pdf():
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text(
+        (50, 80),
+        "Documento di prova senza identificativi personali.",
+        fontsize=11,
+    )
+    annot = page.add_text_annot((200, 200), f"Codice fiscale {CF}")
+    annot.set_info(content=f"Codice fiscale {CF}")
+    annot.update()
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def link_pdf():
+    return uri_link_pdf(f"mailto:{EMAIL}", visible_email=True)
+
+
+def uri_link_pdf(uri, visible_email=False):
+    doc = fitz.open()
+    page = doc.new_page()
+    if visible_email:
+        page.insert_text((50, 80), EMAIL, fontsize=11)
+    page.insert_text((50, 130), "Invia un messaggio", fontsize=11)
+    page.insert_link({
+        "kind": fitz.LINK_URI,
+        "from": fitz.Rect(45, 115, 180, 135),
+        "uri": uri,
+    })
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def link_only_pdf():
+    """Target noto al verificatore, ma nessuna copia nel page text."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 80), "Invia un messaggio", fontsize=11)
+    page.insert_link({
+        "kind": fitz.LINK_URI,
+        "from": fitz.Rect(45, 65, 180, 85),
+        "uri": f"mailto:{EMAIL}",
+    })
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def all_auxiliary_surfaces_pdf():
+    values = {
+        "content": "content.person@example.com",
+        "subject": "subject.person@example.com",
+        "title": "title.person@example.com",
+        "widget": "widget.person@example.com",
+        "toc": "toc.person@example.com",
+        "link": "link.person@example.com",
+    }
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 80), "Documento sintetico.", fontsize=11)
+
+    annot = page.add_text_annot((200, 200), values["content"])
+    annot.set_info(
+        content=values["content"],
+        subject=values["subject"],
+        title=values["title"],
+    )
+    annot.update()
+
+    widget = fitz.Widget()
+    widget.rect = fitz.Rect(50, 250, 300, 275)
+    widget.field_name = "contatto"
+    widget.field_type = fitz.PDF_WIDGET_TYPE_TEXT
+    widget.field_value = values["widget"]
+    page.add_widget(widget)
+
+    doc.set_toc([[1, values["toc"], 1]])
+    page.insert_link({
+        "kind": fitz.LINK_URI,
+        "from": fitz.Rect(45, 300, 180, 320),
+        "uri": f"mailto:{values['link']}",
+    })
+    out = doc.tobytes()
+    doc.close()
+    return out, values
+
+
+def image_only_pdf():
+    doc = fitz.open()
+    page = doc.new_page()
+    pixmap = fitz.Pixmap(fitz.csRGB, fitz.IRect(0, 0, 16, 16), False)
+    pixmap.clear_with(255)
+    page.insert_image(fitz.Rect(50, 50, 150, 150), pixmap=pixmap)
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def split_iban_annotation_pdf(single_field=False):
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 80), "Documento sintetico senza PII.", fontsize=11)
+    first = "IT60 X054 2811"
+    second = "1010 0000 0123 456"
+    content = first + ("\n" + second if single_field else "")
+    annot = page.add_text_annot((200, 200), content)
+    annot.set_info(content=content, subject="" if single_field else second, title="")
+    annot.update()
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def plain_email_pdf():
+    """Page text con PII, ma nessuna superficie ausiliaria presente."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 80), EMAIL, fontsize=11)
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def auxiliary_failure_pdf(failed_surface):
+    """PII nella superficie che fallira' + una seconda superficie sanificabile."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 80), "Documento sintetico.", fontsize=11)
+
+    if failed_surface in ("annotations", "toc"):
+        annot = page.add_text_annot((200, 200), EMAIL)
+        annot.set_info(content=EMAIL)
+        annot.update()
+    if failed_surface == "links":
+        page.insert_link({
+            "kind": fitz.LINK_URI,
+            "from": fitz.Rect(45, 115, 180, 135),
+            "uri": f"mailto:{EMAIL}",
+        })
+    if failed_surface == "widgets":
+        widget = fitz.Widget()
+        widget.rect = fitz.Rect(50, 250, 300, 275)
+        widget.field_name = "contatto"
+        widget.field_type = fitz.PDF_WIDGET_TYPE_TEXT
+        widget.field_value = EMAIL
+        page.add_widget(widget)
+    doc.set_toc([[1, EMAIL, 1]])
+
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def load_app_without_model():
+    """Importa app.py con stub minimi: il test usa detector regex + Flask reali."""
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.pipeline = lambda *args, **kwargs: (
+        lambda texts: [[] for _ in texts]
+    )
+
+    spec = importlib.util.spec_from_file_location("_rizzo_pdf_test_app", APP_DIR / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {"torch": fake_torch, "transformers": fake_transformers},
+    ), mock.patch.dict(
+        "os.environ",
+        {"PII_MODEL_DIR": str(APP_DIR)},
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class PdfAuxiliarySurfaceTests(unittest.TestCase):
+    def _assert_enumeration_failure_is_closed(
+        self, pdf, owner, method, message, other_counter,
+    ):
+        _out, baseline = px.redact_pdf(pdf, {"[EMAIL_1]": EMAIL})
+        self.assertGreater(baseline[other_counter], 0)
+
+        with mock.patch.object(
+            owner,
+            method,
+            side_effect=RuntimeError("forced enumeration failure"),
+        ):
+            with self.assertRaisesRegex(px.PdfError, message):
+                px.redact_pdf(pdf, {"[EMAIL_1]": EMAIL})
+
+    def test_auxiliary_extraction_covers_supported_surfaces(self):
+        pdf, values = all_auxiliary_surfaces_pdf()
+        surfaces = px.extract_detection_surfaces(pdf)
+        for surface, value in values.items():
+            with self.subTest(surface):
+                self.assertTrue(any(value in text for text in surfaces))
+
+    def test_annotation_only_pii_is_discovered_and_sanitized_by_pdf_route(self):
+        pdf = annotation_only_pdf()
+        with fitz.open(stream=pdf, filetype="pdf") as doc:
+            self.assertNotIn(CF, doc[0].get_text())
+
+        app_module = load_app_without_model()
+        client = app_module.app.test_client()
+        analyze_response = client.post(
+            "/analyze",
+            data={"pdf": (io.BytesIO(pdf), "annotazione.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(200, analyze_response.status_code)
+        analysis = analyze_response.get_json()
+        self.assertNotIn(CF, analysis["source_text"])
+        self.assertNotIn(CF, analysis["anonymized_text"])
+
+        response = client.post(
+            "/pdf",
+            data={"pdf": (io.BytesIO(pdf), "annotazione.pdf")},
+            content_type="multipart/form-data",
+        )
+
+        self.assertEqual(200, response.status_code, response.get_data()[:200])
+        self.assertEqual("0", response.headers["X-PII-Redactions"])
+        with fitz.open(stream=response.data, filetype="pdf") as doc:
+            readable = px._readable_text(doc)
+            info = list(doc[0].annots())[0].info
+        self.assertNotIn(CF, readable)
+        self.assertNotIn(CF, info["content"])
+        self.assertIn("[CF_1]", info["content"])
+        self.assertEqual("0", response.headers["X-PII-Residual"])
+
+        preview_response = client.post(
+            "/pdf/preview",
+            data={"pdf": (io.BytesIO(pdf), "annotazione.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(200, preview_response.status_code)
+        self.assertEqual(0, preview_response.get_json()["redactions"])
+
+    def test_link_target_is_included_in_residual_verification(self):
+        self.assertEqual(
+            ["[EMAIL_1]"],
+            px._verify_residuals(link_only_pdf(), [("[EMAIL_1]", EMAIL)]),
+        )
+
+    def test_mailto_target_is_scrubbed_without_removing_link(self):
+        out, report = px.redact_pdf(link_pdf(), {"[EMAIL_1]": EMAIL})
+        with fitz.open(stream=out, filetype="pdf") as doc:
+            visible = doc[0].get_text()
+            links = doc[0].get_links()
+            readable = px._readable_text(doc)
+
+        self.assertNotIn(EMAIL, visible)
+        self.assertEqual(1, len(links))
+        self.assertEqual("mailto:%5BEMAIL_1%5D", links[0]["uri"])
+        self.assertNotIn(EMAIL, readable)
+        self.assertGreater(report["links"], 0)
+        self.assertEqual([], report["residual"])
+
+    def _assert_encoded_mailto_is_neutralized(self, uri):
+        encoded_only_pdf = uri_link_pdf(uri, visible_email=False)
+        surfaces = px.extract_detection_surfaces(encoded_only_pdf)
+        self.assertTrue(any(EMAIL in surface for surface in surfaces))
+        self.assertEqual(
+            ["[EMAIL_1]"],
+            px._verify_residuals(encoded_only_pdf, [("[EMAIL_1]", EMAIL)]),
+        )
+
+        pdf = uri_link_pdf(uri, visible_email=True)
+        out, report = px.redact_pdf(pdf, {"[EMAIL_1]": EMAIL})
+        with fitz.open(stream=out, filetype="pdf") as doc:
+            visible = doc[0].get_text()
+            links = doc[0].get_links()
+            readable = px._readable_text(doc)
+        final_uris = [link.get("uri", "") for link in links]
+
+        self.assertNotIn(EMAIL, visible)
+        self.assertEqual([], links)
+        self.assertTrue(all(EMAIL not in unquote(final) for final in final_uris))
+        self.assertTrue(all(EMAIL not in final for final in final_uris))
+        self.assertTrue(all(uri not in final for final in final_uris))
+        self.assertNotIn(EMAIL, readable)
+        self.assertNotIn(uri, readable)
+        self.assertGreater(report["links"], 0)
+        self.assertEqual([], report["residual"])
+
+    def test_percent_encoded_mailto_target_is_neutralized(self):
+        self._assert_encoded_mailto_is_neutralized(
+            "mailto:mario.rossi%40example.com",
+        )
+
+    def test_more_encoded_mailto_target_is_neutralized(self):
+        self._assert_encoded_mailto_is_neutralized(
+            "mailto:mario%2Erossi%40example%2Ecom",
+        )
+
+    def test_short_literal_mapping_cannot_mask_encoded_email(self):
+        uri = "mailto:mario%2Erossi%40example%2Ecom"
+        out, report = px.redact_pdf(
+            uri_link_pdf(uri, visible_email=False),
+            {"[EMAIL_1]": EMAIL, "[FULLNAME_1]": "mario"},
+        )
+        with fitz.open(stream=out, filetype="pdf") as doc:
+            links = doc[0].get_links()
+            readable = px._readable_text(doc)
+        self.assertEqual([], links)
+        self.assertNotIn("rossi@example.com", readable)
+        self.assertGreater(report["links"], 0)
+        self.assertEqual([], report["residual"])
+
+    def test_unrelated_percent_encoded_uri_is_unchanged(self):
+        uri = "urn:example:chapter%201+appendix"
+        out, report = px.redact_pdf(
+            uri_link_pdf(uri, visible_email=True),
+            {"[EMAIL_1]": EMAIL},
+        )
+        with fitz.open(stream=out, filetype="pdf") as doc:
+            links = doc[0].get_links()
+        self.assertEqual(uri, links[0]["uri"])
+        self.assertEqual(0, report["links"])
+
+    def test_link_enumeration_failure_is_controlled_end_to_end(self):
+        app_module = load_app_without_model()
+        client = app_module.app.test_client()
+        for route in ("/pdf", "/pdf/preview"):
+            with self.subTest(route), mock.patch.object(
+                fitz.Page,
+                "get_links",
+                side_effect=RuntimeError("forced enumeration failure"),
+            ):
+                response = client.post(
+                    route,
+                    data={"pdf": (io.BytesIO(link_pdf()), "link.pdf")},
+                    content_type="multipart/form-data",
+                )
+            self.assertEqual(400, response.status_code)
+            self.assertEqual("application/json", response.mimetype)
+            error = response.get_json()["error"]
+            self.assertIn("link", error.lower())
+            self.assertNotIn(EMAIL, error)
+
+    def test_post_discovery_verification_failure_is_controlled_end_to_end(self):
+        app_module = load_app_without_model()
+        client = app_module.app.test_client()
+        original_get_links = fitz.Page.get_links
+        calls = 0
+
+        def fail_after_discovery(page, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return original_get_links(page, *args, **kwargs)
+            raise RuntimeError("forced post-discovery enumeration failure")
+
+        with mock.patch.object(fitz.Page, "get_links", new=fail_after_discovery):
+            response = client.post(
+                "/pdf",
+                data={
+                    "pdf": (
+                        io.BytesIO(auxiliary_failure_pdf("links")),
+                        "link_e_indice.pdf",
+                    ),
+                },
+                content_type="multipart/form-data",
+            )
+
+        self.assertGreaterEqual(calls, 3)
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertIn("link", response.get_json()["error"].lower())
+
+    def test_discovery_fails_closed_for_auxiliary_enumeration_errors(self):
+        all_aux_pdf, _values = all_auxiliary_surfaces_pdf()
+        cases = (
+            (annotation_only_pdf(), fitz.Page, "annots", "annotazioni"),
+            (all_aux_pdf, fitz.Page, "widgets", "campi modulo"),
+            (link_pdf(), fitz.Page, "get_links", "link"),
+            (all_aux_pdf, fitz.Document, "get_toc", "indice"),
+        )
+        for pdf, owner, method, message in cases:
+            with self.subTest(method), mock.patch.object(
+                owner,
+                method,
+                side_effect=RuntimeError("forced enumeration failure"),
+            ):
+                with self.assertRaisesRegex(px.PdfError, message):
+                    px.extract_detection_surfaces(pdf)
+
+    def test_link_enumeration_failure_aborts_residual_verification(self):
+        self._assert_enumeration_failure_is_closed(
+            auxiliary_failure_pdf("links"),
+            fitz.Page,
+            "get_links",
+            "link",
+            "toc",
+        )
+
+    def test_annotation_enumeration_failure_aborts_residual_verification(self):
+        self._assert_enumeration_failure_is_closed(
+            auxiliary_failure_pdf("annotations"),
+            fitz.Page,
+            "annots",
+            "annotazioni",
+            "toc",
+        )
+
+    def test_widget_enumeration_failure_aborts_residual_verification(self):
+        self._assert_enumeration_failure_is_closed(
+            auxiliary_failure_pdf("widgets"),
+            fitz.Page,
+            "widgets",
+            "campi modulo",
+            "toc",
+        )
+
+    def test_toc_enumeration_failure_aborts_residual_verification(self):
+        self._assert_enumeration_failure_is_closed(
+            auxiliary_failure_pdf("toc"),
+            fitz.Document,
+            "get_toc",
+            "indice",
+            "annots",
+        )
+
+    def test_absent_auxiliary_surfaces_are_not_inspection_failures(self):
+        pdf = plain_email_pdf()
+        with fitz.open(stream=pdf, filetype="pdf") as doc:
+            self.assertEqual([], list(doc[0].annots() or ()))
+            self.assertEqual([], list(doc[0].widgets() or ()))
+            self.assertEqual([], doc[0].get_links())
+            self.assertEqual([], doc.get_toc(simple=True))
+
+        app_module = load_app_without_model()
+        response = app_module.app.test_client().post(
+            "/pdf",
+            data={"pdf": (io.BytesIO(pdf), "senza_aux.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(200, response.status_code, response.get_data()[:200])
+        self.assertEqual("1", response.headers["X-PII-Redactions"])
+        self.assertEqual("0", response.headers["X-PII-Residual"])
+
+    def test_pdf_surface_mapping_uses_global_placeholder_namespace(self):
+        app_module = load_app_without_model()
+        mapping = app_module._mapping_for_surfaces([
+            "primo@example.com",
+            "secondo@example.com",
+            "PRIMO@example.com",
+            "altro valore secondo@example.com",
+            CF,
+        ])
+        self.assertEqual({
+            "[EMAIL_1]": "primo@example.com",
+            "[EMAIL_2]": "secondo@example.com",
+            "[CF_1]": CF,
+        }, mapping)
+
+    def test_detection_does_not_cross_annotation_fields(self):
+        pdf = split_iban_annotation_pdf(single_field=False)
+        app_module = load_app_without_model()
+        surfaces = px.extract_detection_surfaces(pdf)
+        mapping = app_module._mapping_for_surfaces(surfaces)
+        self.assertEqual({}, mapping)
+
+        client = app_module.app.test_client()
+        response = client.post(
+            "/pdf",
+            data={"pdf": (io.BytesIO(pdf), "iban_artificiale.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(422, response.status_code)
+
+        with fitz.open(stream=pdf, filetype="pdf") as doc:
+            info = list(doc[0].annots())[0].info
+        self.assertEqual("IT60 X054 2811", info["content"])
+        self.assertEqual("1010 0000 0123 456", info["subject"])
+
+    def test_multiline_iban_inside_one_annotation_is_sanitized(self):
+        pdf = split_iban_annotation_pdf(single_field=True)
+        app_module = load_app_without_model()
+        mapping = app_module._mapping_for_surfaces(px.extract_detection_surfaces(pdf))
+        self.assertEqual(
+            {"[IBAN_1]": "IT60 X054 2811\n1010 0000 0123 456"},
+            mapping,
+        )
+
+        client = app_module.app.test_client()
+        response = client.post(
+            "/pdf",
+            data={"pdf": (io.BytesIO(pdf), "iban_multilinea.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(200, response.status_code, response.get_data()[:200])
+        with fitz.open(stream=response.data, filetype="pdf") as doc:
+            info = list(doc[0].annots())[0].info
+        self.assertEqual("[IBAN_1]", info["content"])
+        self.assertEqual("0", response.headers["X-PII-Redactions"])
+        self.assertEqual("0", response.headers["X-PII-Residual"])
+
+    def test_image_only_pdf_without_sanitized_surface_is_still_rejected(self):
+        app_module = load_app_without_model()
+        client = app_module.app.test_client()
+        response = client.post(
+            "/pdf",
+            data={"pdf": (io.BytesIO(image_only_pdf()), "scansione.pdf")},
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Sintesi

Questa PR corregge due casi collegati nel percorso di sanitizzazione dei PDF:

1. le PII presenti esclusivamente in superfici ausiliarie del PDF — per esempio contenuto delle annotazioni, valori dei campi modulo o titoli dei segnalibri — non partecipavano necessariamente alla costruzione del mapping usato per la sanitizzazione;
2. i target persistenti dei link, come gli URI `mailto:`, potevano conservare una PII anche dopo la corretta redazione del valore visibile.

Il secondo caso poteva inoltre sfuggire alla verifica finale dei residui, perché il target URI non faceva parte delle superfici controllate.

La patch allinea quindi le tre fasi del percorso PDF:

**rilevamento → sanitizzazione → verifica**

sulle stesse superfici supportate.

## Riproduzione

Sono stati aggiunti test sintetici per coprire, tra gli altri:

* codice fiscale presente esclusivamente in un'annotazione PDF;
* e-mail presente nel testo visibile e duplicata nel target di un link `mailto:`;
* URI con percent-encoding;
* annotazioni (`content`, `subject`, `title`);
* valori dei widget AcroForm;
* titoli del TOC/segnalibri;
* isolamento fra superfici indipendenti, per evitare entità artificiali costruite attraversando due campi diversi;
* PDF image-only senza alcuna superficie effettivamente sanificata;
* errori durante l'ispezione delle superfici ausiliarie.

Tutti i dati utilizzati nei test sono sintetici.

## Comportamento precedente

Nel primo caso, un PDF con una PII presente soltanto in una superficie ausiliaria poteva non produrre alcun mapping e venire rifiutato come documento senza PII rilevate.

Nel secondo caso, il testo visibile poteva essere correttamente redatto mentre un link geometricamente separato conservava, per esempio:

```text
mailto:mario.rossi@example.com
```

senza che il valore comparisse nel controllo finale dei residui.

Anche le rappresentazioni percent-encoded degli URI richiedevano un trattamento coerente.

## Modifiche

La PR:

* rileva separatamente le PII nelle superfici PDF supportate, senza concatenare campi indipendenti;
* mantiene una numerazione globale e coerente dei placeholder;
* mantiene le superfici ausiliarie fuori da `/analyze`, `source_text` e `anonymized_text`;
* sanitizza i target URI contenenti PII;
* gestisce anche URI percent-encoded tramite un singolo decoding controllato;
* include i target dei link nella verifica finale;
* mantiene invariata la semantica storica delle redazioni del page content stream;
* accetta un documento con sole sanitizzazioni ausiliarie se è stato effettivamente modificato;
* continua a rifiutare PDF image-only quando non è stata sanificata alcuna superficie supportata;
* adotta un comportamento **fail-closed**: se una superficie PDF supportata non può essere enumerata durante il rilevamento o la verifica finale, il PDF non viene restituito come sanitizzato.

## Compatibilità

Restano invariati:

* `/analyze`;
* `anonymized_text`;
* `source_text`;
* la semantica di `report["occurrences"]`;
* `X-PII-Redactions`;
* `/pdf/preview.redactions`.

Un PDF con PII soltanto in una superficie ausiliaria può quindi avere:

```text
redactions = 0
sanitizations > 0
```

ed essere comunque processato correttamente.

## Fuori scope

Questa PR non:

* aggiunge OCR;
* modifica la tassonomia PII;
* modifica modello o pipeline di training;
* modifica la UI;
* introduce nuove dipendenze;
* modifica claim GDPR/compliance.

## Verifica

```text
python src/app/smoke_pdf_export.py
33/33 PASS

python -m pytest -q -s -rs -p no:cacheprovider tests
53 passed, 2 skipped

python -m compileall ...
PASS

git diff --check
PASS
```

I due test saltati richiedono l'ambiente completo dell'app con `torch` / `transformers` e non rappresentano regressioni introdotte da questa PR.
