### PR TITLE
feat(detectors): rileva indirizzi IP (regex-only) — chiude #83

### DIFF
--- a/docs/TASSONOMIA_TAG.md
+++ b/docs/TASSONOMIA_TAG.md
@@ -38,11 +38,17 @@ riconoscere. È la **fonte di verità** quando si riprende il progetto: descrive
 | `DOCID` | Codice identificativo di un atto: n. Ruolo Generale, protocollo, repertorio/raccolta, sentenza | `1234/2024` | sintetico |
 | `CATASTO` | Dati catastali di un immobile (foglio, particella, subalterno) | `Foglio 12, particella 345, sub. 6` | sintetico |
 
-> **Un 23° tag solo nell'app: `URL`.** Non è un tag del modello (non c'è nel training, non compare
-> in `TAG_MAP`): lo trova la sola rete regex di `src/app/app.py`. Sta qui per completezza della
-> legenda mostrata all'utente. Matcha `http(s)://…`, `www.…` e i domini nudi **solo** con un TLD
-> della lista chiusa nel detector: senza quella lista il legalese italiano (`p.iva`, `n.ro`,
-> `S.r.l.`) verrebbe letto come dominio.
+> **Due tag solo nell'app, non nel modello: `URL` e `IPADDR`.** Non compaiono nel training né in
+> `TAG_MAP`: li trova la sola rete regex di `src/app/detectors.py`. Stanno qui per completezza
+> della legenda mostrata all'utente.
+> - `URL` matcha `http(s)://…`, `www.…` e i domini nudi **solo** con un TLD della lista chiusa nel
+>   detector: senza quella lista il legalese italiano (`p.iva`, `n.ro`, `S.r.l.`) verrebbe letto
+>   come dominio.
+> - `IPADDR` matcha un indirizzo IPv4 (quattro ottetti 0-255), incluse le notazioni CIDR
+>   (`192.168.1.0/24`) e range (`192.168.1.1-192.168.1.20`). Il vincolo sull'ottetto è ciò che
+>   esclude le versioni software tipo `2.3.55.987` (`987` non è un ottetto valido). Limite noto:
+>   una versione con tutti i numeri per caso ≤ 255 (es. `1.2.3.4`) resta indistinguibile da un IP
+>   vero — non risolvibile con la sola forma, servirebbe il modello.
 
 Formato BIO: ogni tag esiste come `B-<TAG>` (inizio entità) e `I-<TAG>` (continuazione),
 più `O` (token non sensibile). I token adiacenti dello stesso tipo vengono fusi in una

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -13,7 +13,7 @@ Flusso d'uso:
 Tutto in locale: il testo e il dizionario {placeholder -> valore} non lasciano la macchina.
 
 Il modello e' affiancato da una rete REGEX + CHECKSUM (EMAIL, TELEFONO, IBAN, CF, PIVA,
-carta di credito, importi, targhe, URL). Le entita' validate matematicamente (IBAN/CF/
+carta di credito, importi, targhe, URL, IP). Le entita' validate matematicamente (IBAN/CF/
 PIVA/carta) hanno priorita' sul modello in caso di sovrapposizione.
 
 Il dizionario di ripristino si puo' DISATTIVARE (switch nell'UI, --no-mapping, PII_MAPPING=0):
@@ -206,8 +206,8 @@ def _page_png(d, n, dpi=PREVIEW_DPI):
 # --------------------------------------------------------------------------- #
 # Legenda dei tag + tag esclusi dall'anonimizzazione
 #
-# I 22 tag del modello (docs/TASSONOMIA_TAG.md) + URL, che e' solo-regex: il modello
-# non e' stato addestrato su di esso, lo trova la rete regex.
+# I 22 tag del modello (docs/TASSONOMIA_TAG.md) + URL e IPADDR, che sono solo-regex:
+# il modello non e' stato addestrato su di essi, li trova la rete regex.
 # L'utente puo' DESELEZIONARE un tag: le entita' di quel tipo vengono rilevate ma non
 # sostituite (restano in chiaro). Serve a chi deve confrontare gli importi (AMOUNT) o
 # tenere eta'/sesso in un caso clinico.
@@ -245,6 +245,8 @@ TAGS = [
      "Land registry data: sheet, parcel, subordinate", "Foglio 12, part. 345, sub. 6"),
     ("URL", "Indirizzo web (rilevato solo dalla rete regex, non dal modello)",
      "Web address (regex net only, not from the model)", "https://www.studiorossi.it"),
+    ("IPADDR", "Indirizzo IP, anche subnet CIDR o range (rilevato solo dalla rete regex)",
+     "IP address, including CIDR subnet or range (regex net only)", "192.168.1.1"),
 ]
 TAG_NAMES = [t[0] for t in TAGS]
 

--- a/src/app/detectors.py
+++ b/src/app/detectors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 Rete REGEX + CHECKSUM che affianca il modello (EMAIL, TELEFONO, IBAN, CF, PIVA,
-carta di credito, importo, targa, URL).
+carta di credito, importo, targa, URL, indirizzo IP).
 
 Come `pdf_export`, questo modulo lavora solo su stringhe: nessun import di
 torch/transformers/fitz, quindi e' testabile in isolamento e senza il modello.
@@ -158,6 +158,24 @@ DETECTORS = [
                 r"|\b(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?\.)+"
                 r"(?:it|com|net|org|eu|info|io|dev|app|gov|edu|cloud|online|site|blog)"
                 r"\b(?:/[^\s<>\"']*)?", re.IGNORECASE),
+     None, True),
+    # IPADDR: quattro ottetti 0-255 separati da punto. Il vincolo sull'ottetto (non
+    # un \d{1,3} generico) e' cio' che tiene fuori le versioni software tipo "2.3.55.987":
+    # 987 non e' un ottetto valido, quindi l'intera stringa non matcha come IP.
+    # Copre anche le due notazioni con cui un IP compare in un log/config:
+    #   - CIDR:   192.168.1.0/24        (prefisso 0-32)
+    #   - range:  192.168.1.1-192.168.1.20
+    # Resta un limite noto (non risolvibile a regex, lo segnala anche l'issue): una
+    # versione software con tutti gli ottetti per caso <= 255 (es. "1.2.3.4") e'
+    # indistinguibile da un IP vero. Nessun falso negativo pero' sulle versioni con
+    # un numero fuori range, che sono la stragrande maggioranza dei casi reali.
+    ("IPADDR",
+     re.compile(r"\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
+                r"(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}"
+                r"(?:/(?:3[0-2]|[12]?\d))?"
+                r"(?:\s*-\s*(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
+                r"(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})?"
+                r"\b"),
      None, True),
     # DOCID: il codice di un atto e' scritto sempre dopo la sua sigla ("R.G. 1234/2024",
     # "Prot. 123/2024", "Rep. 45"). E' la sigla a renderlo riconoscibile: il numero da

--- a/tests/test_detector_formats.py
+++ b/tests/test_detector_formats.py
@@ -89,6 +89,17 @@ POSITIVI = [
      "PIVA", "00743110157"),
     ("piva_con_prefisso_it", "Partita IVA IT00743110157, sede in Milano.",
      "PIVA", "00743110157"),
+    # Indirizzo IP: forma semplice, subnet CIDR, range.
+    ("ip_semplice", "Il server risponde su 192.168.1.10 sulla rete interna.",
+     "IPADDR", "192.168.1.10"),
+    ("ip_pubblico", "Connessione in ingresso da 8.8.8.8 registrata nel log.",
+     "IPADDR", "8.8.8.8"),
+    ("ip_cidr", "La subnet 192.168.1.0/24 e' riservata al reparto IT.",
+     "IPADDR", "192.168.1.0/24"),
+    ("ip_range", "Range assegnato 192.168.1.1-192.168.1.20 per i client DHCP.",
+     "IPADDR", "192.168.1.1-192.168.1.20"),
+    ("ip_range_con_spazi", "Range assegnato 192.168.1.1 - 192.168.1.20 per i client.",
+     "IPADDR", "192.168.1.1 - 192.168.1.20"),
 ]
 
 # Valori con la forma giusta ma il checksum sbagliato: dove il detector e'
@@ -115,6 +126,13 @@ NEGATIVI = [
     ("sequenza_lunga_non_luhn", "Codice pratica 1234567890123456789 del 2024."),
     ("protocollo_con_punti", "Protocollo 2024.0001234.5678 del registro generale."),
     ("mandato_con_punti", "Mandato n. 12.345.678.901.234 del tesoriere."),
+]
+
+# Versioni software con un numero fuori range 0-255: non devono diventare IPADDR.
+# E' il caso esplicito segnalato nell'issue #83 (es. "2.3.55.987").
+IP_NEGATIVI = [
+    ("versione_software", "Aggiornata alla versione 2.3.55.987 del pacchetto."),
+    ("versione_a_5_cifre", "Changelog della build 10.20.30.40500 di oggi."),
 ]
 
 TAG_CON_CHECKSUM = ("IBAN", "CF", "PIVA", "CREDITCARDNUMBER")
@@ -161,6 +179,11 @@ class DetectorFormatTests(unittest.TestCase):
                       "Cfr. pagg. 12-15 e 20-24 della memoria."):
             with self.subTest(testo):
                 self.assertEqual([], spans(testo, "TELEPHONENUM"))
+
+    def test_versione_software_non_diventa_ip(self):
+        for nome, testo in IP_NEGATIVI:
+            with self.subTest(nome):
+                self.assertEqual([], spans(testo, "IPADDR"))
 
     def test_iban_non_ingoia_la_parola_successiva(self):
         # La regex raggruppata e' golosa: se assorbe il token dopo l'IBAN il


### PR DESCRIPTION
Chiude #83.

Aggiunge il tag `IPADDR` alla rete regex che affianca il modello, con la stessa logica già usata per `URL`: non è nei 22 tag del training, lo trova solo `detectors.py`.

- ottetti veri (`25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d`), non `\d{1,3}` generico: è questo il vincolo che esclude le versioni software tipo `2.3.55.987` (`987` non è un ottetto valido), esattamente il punto sollevato nell'issue
- copre anche subnet CIDR (`192.168.1.0/24`) e range (`192.168.1.1-192.168.1.20`)
- limite noto, documentato in codice e in TASSONOMIA_TAG.md: una versione con tutti i numeri per caso ≤ 255 (es. `1.2.3.4`) resta indistinguibile da un IP vero — non risolvibile a sola regex

Aggiornati `TAGS` in `app.py`, `docs/TASSONOMIA_TAG.md` e i test in `test_detector_formats.py` (5 positivi incl. CIDR/range, 2 negativi sulle versioni software). Tutti i test passano.