### PR TITLE
Add JSON-aware mapping-restore helper

### DIFF
--- a/src/app/restore.py
+++ b/src/app/restore.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Ripristino del mapping di anonimizzazione senza rompere la sintassi JSON.
+
+``/analyze`` restituisce ``anonymized_text`` con i placeholder (``[AMOUNT_1]``)
+e un ``mapping`` {placeholder: valore} i cui valori sono le stringhe originali
+del documento (es. ``"1.500,00"``). Una sostituzione di sottostringa su un
+payload JSON produce ``""1.500,00""`` (sintassi rotta) quando il placeholder e'
+dentro una stringa quotata, e non normalizza gli importi in formato italiano.
+
+Questo modulo restituisce una copia del payload con i placeholder sostituiti:
+
+- su strutture JSON (dict/list, o stringa JSON anche con fence ```json)
+  la sintassi resta valida;
+- una foglia che e' ESATTAMENTE un placeholder di tipo monetario (``AMOUNT``)
+  diventa il numero normalizzato (``"1.500,00"`` -> ``1500.0``);
+- una foglia che contiene il placeholder come sottostringa resta una stringa
+  (``"Totale: [AMOUNT_1]"`` -> ``"Totale: 1.500,00"``);
+- un testo non-JSON usa la sostituzione diretta (compatibilita').
+
+Nessuna dipendenza oltre la stdlib: importabile e testabile in CI senza
+torch/transformers/flask. Le chiavi del mapping e del payload non vengono mai
+toccate; le chiavi del mapping non vengono mai sostituite nei valori.
+"""
+
+import json
+import re
+from typing import Any, Mapping
+
+# placeholder emessi da /analyze: [LABEL_n] (n progressivo per occorrenza)
+_PH_RE = re.compile(r"\[([A-Z]+)(?:_\d+)?\]")
+# etichette monetarie del vocabolario del progetto (detectors.py: AMOUNT)
+_MONEY_LABELS = frozenset({"AMOUNT"})
+# numero in formato italiano: 1.234,56 | 1234,56 | 1234.56 (€/EUR/euro tollerati)
+_NUM_IT_RE = re.compile(
+    r"[+-]?\d{1,3}(?:\.\d{3})+(?:,\d+)?|[+-]?\d+(?:[.,]\d+)?"
+)
+
+
+def restore(payload: Any, mapping: Mapping[str, str]) -> Any:
+    """Ripristina i placeholder di ``mapping`` in ``payload``.
+
+    ``payload`` puo' essere una stringa (testo libero o JSON, anche con fence
+    ```json```) oppure una struttura dict/list. Il risultato mantiene il tipo
+    di ingresso: stringa JSON -> stringa JSON ri-serializzata, struttura ->
+    struttura copiata, testo -> testo sostituito.
+    """
+    if not mapping:
+        return payload
+    if isinstance(payload, str):
+        stripped = _strip_json_fence(payload)
+        try:
+            data = json.loads(stripped)
+        except (ValueError, TypeError):
+            return _replace_text(payload, mapping)
+        if isinstance(data, (dict, list)):
+            restored = _restore_structure(data, mapping)
+            return json.dumps(restored, ensure_ascii=False)
+        # JSON scalare (es. la stringa nuda "[AMOUNT_1]"): ripristina il valore
+        # e lo ri-serializza (stringa o numero, mai sintassi rotta)
+        return json.dumps(_restore_leaf(data, mapping), ensure_ascii=False)
+    if isinstance(payload, (dict, list)):
+        return _restore_structure(payload, mapping)
+    return payload
+
+
+def _strip_json_fence(text: str) -> str:
+    """Rimuove una fence markdown ```json ... ``` attorno al payload."""
+    return re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.IGNORECASE)
+
+
+def _restore_structure(node: Any, mapping: Mapping[str, str]) -> Any:
+    """Copia ricorsiva con i placeholder sostituiti solo nei valori (foglie)."""
+    if isinstance(node, dict):
+        return {k: _restore_structure(v, mapping) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_restore_structure(v, mapping) for v in node]
+    if isinstance(node, str):
+        return _restore_leaf(node, mapping)
+    return node
+
+
+def _restore_leaf(value: str, mapping: Mapping[str, str]) -> Any:
+    """Foglia stringa: placeholder intero -> valore (numero se AMOUNT);
+    placeholder come sottostringa -> sostituzione in-stringa; altrimenti uguale."""
+    if value.strip() in mapping:
+        raw = mapping[value.strip()]
+        if _ph_tag(value) in _MONEY_LABELS:
+            num = _num_from_it(raw)
+            if num is not None:
+                return num
+        return raw
+    if any(k in value for k in mapping):
+        return _replace_text(value, mapping)
+    return value
+
+
+def _ph_tag(placeholder: str) -> str:
+    """Etichetta del placeholder ("[AMOUNT_3]" -> "AMOUNT"); "" se non placeholder."""
+    m = _PH_RE.fullmatch(placeholder.strip())
+    return m.group(1) if m else ""
+
+
+def _num_from_it(value: str) -> float | None:
+    """Parte numerica di una stringa in formato italiano -> float.
+
+    Virgola = decimali, punto = migliaia (``1.500,00`` -> ``1500.0``); tollera
+    prefissi/suffissi (``€ 12.500,00``, ``1.500,00 EUR``). ``1234.56`` (punto
+    decimale senza migliaia) resta ``1234.56``. None se non c'e' numero.
+    """
+    s = value.strip()
+    if not s:
+        return None
+    m = _NUM_IT_RE.search(s)
+    if not m:
+        return None
+    s = m.group(0)
+    if "," in s:
+        s = s.replace(".", "").replace(",", ".")
+    elif re.fullmatch(r"[+-]?\d{1,3}(?:\.\d{3})+", s):
+        s = s.replace(".", "")
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _replace_text(text: str, mapping: Mapping[str, str]) -> str:
+    """Sostituzione diretta (testo libero / placeholder in-stringa).
+
+    Le chiavi piu' lunghe prima: evita collisioni tipo ``[ORG_1]`` dentro
+    ``[ORG_10]``.
+    """
+    for ph in sorted(mapping, key=len, reverse=True):
+        text = text.replace(ph, mapping[ph])
+    return text

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Test del ripristino del mapping senza rompere la sintassi JSON.
+
+Il caso d'uso: /analyze restituisce ``anonymized_text`` con i placeholder
+(``[AMOUNT_1]``) e un ``mapping`` {placeholder: valore} con i valori originali
+come stringhe (``"1.500,00"``). Ripristinare con una sostituzione di
+sottostringa su un payload JSON produce ``""1.500,00""`` (sintassi rotta) se il
+placeholder e' dentro una stringa quotata, e non normalizza gli importi in
+formato italiano.
+
+Qui si verifica il comportamento del helper ``restore.restore``: sintassi JSON
+sempre valida, importi AMOUNT normalizzati a numero, placeholder in-stringa
+restati stringhe, testo libero sostituito, chiavi mai toccate.
+
+Nomi, importi e date sono SINTETICI.
+
+Solo stdlib: nessuna dipendenza pesante, il test gira anche in CI.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+from restore import restore  # noqa: E402
+
+
+class RestoreJsonTest(unittest.TestCase):
+    """Ripristino su payload JSON (stringa o struttura)."""
+
+    def test_mapping_vuoto_lascia_payload_invariato(self):
+        payload = {"totale": "[AMOUNT_1]"}
+        self.assertEqual(restore(payload, {}), payload)
+
+    def test_stringa_json_placeholder_intero_resta_json_valido(self):
+        payload = '{"totale": "[AMOUNT_1]"}'
+        out = restore(payload, {"[AMOUNT_1]": "1.500,00"})
+        self.assertEqual(json.loads(out)["totale"], 1500.0)
+
+    def test_stringa_json_con_fence_markdown(self):
+        payload = '```json\n{"totale": "[AMOUNT_1]"}\n```'
+        out = restore(payload, {"[AMOUNT_1]": "1.500,00"})
+        self.assertEqual(json.loads(out)["totale"], 1500.0)
+
+    def test_dict_diretto_restituisce_copia_con_numero(self):
+        payload = {"imponibile": "[AMOUNT_1]", "iva": "[AMOUNT_2]"}
+        out = restore(payload, {"[AMOUNT_1]": "500,00", "[AMOUNT_2]": "110,00"})
+        self.assertEqual(out, {"imponibile": 500.0, "iva": 110.0})
+        # il payload originale non viene modificato (copia)
+        self.assertEqual(payload["imponibile"], "[AMOUNT_1]")
+
+    def test_lista_di_valori(self):
+        payload = ["[AMOUNT_1]", "nota", {"x": "[AMOUNT_1]"}]
+        out = restore(payload, {"[AMOUNT_1]": "1.500,00"})
+        self.assertEqual(out, [1500.0, "nota", {"x": 1500.0}])
+
+    def test_placeholder_in_stringa_resta_stringa(self):
+        payload = {"descrizione": "Totale: [AMOUNT_1] IVA inclusa"}
+        out = restore(payload, {"[AMOUNT_1]": "1.500,00"})
+        self.assertEqual(out["descrizione"], "Totale: 1.500,00 IVA inclusa")
+
+    def test_importo_con_prefisso_euro(self):
+        out = restore({"x": "[AMOUNT_1]"}, {"[AMOUNT_1]": "€ 12.500,00"})
+        self.assertEqual(out["x"], 12500.0)
+
+    def test_importo_con_suffisso_eur(self):
+        out = restore({"x": "[AMOUNT_1]"}, {"[AMOUNT_1]": "12.500,00 EUR"})
+        self.assertEqual(out["x"], 12500.0)
+
+    def test_valore_non_numerico_su_amount_resta_stringa(self):
+        # valore AMOUNT che non e' un numero (raro): nessuna normalizzazione
+        out = restore({"x": "[AMOUNT_1]"}, {"[AMOUNT_1]": "N/D"})
+        self.assertEqual(out["x"], "N/D")
+
+    def test_tag_non_monetario_non_viene_normalizzato(self):
+        # "[FULLNAME_1]" con valore numerico resta stringa: solo AMOUNT diventa numero
+        out = restore({"x": "[FULLNAME_1]"}, {"[FULLNAME_1]": "1.500,00"})
+        self.assertEqual(out["x"], "1.500,00")
+
+    def test_placeholder_piu_lunghi_sostituiti_prima(self):
+        # [ORG_1] non deve essere sostituito dentro [ORG_10]
+        out = restore(
+            {"a": "[ORG_10]", "b": "[ORG_1]"},
+            {"[ORG_1]": "Beta S.r.l.", "[ORG_10]": "Gamma S.p.A."},
+        )
+        self.assertEqual(out, {"a": "Gamma S.p.A.", "b": "Beta S.r.l."})
+
+    def test_stessa_occorrenza_stesso_valore(self):
+        payload = {"a": "[FULLNAME_1]", "b": "[FULLNAME_1]"}
+        out = restore(payload, {"[FULLNAME_1]": "Mario Rossi"})
+        self.assertEqual(out, {"a": "Mario Rossi", "b": "Mario Rossi"})
+
+
+class RestoreTextTest(unittest.TestCase):
+    """Fallback su testo libero (non-JSON) e scalari JSON."""
+
+    def test_testo_libero_sostituzione_diretta(self):
+        out = restore(
+            "Fattura emessa da [ORG_1] il [DATE_1].",
+            {"[ORG_1]": "Alfa S.p.A.", "[DATE_1]": "10/03/2026"},
+        )
+        self.assertEqual(out, "Fattura emessa da Alfa S.p.A. il 10/03/2026.")
+
+    def test_stringa_json_scalare_resta_serializzata(self):
+        # la stringa nuda "[AMOUNT_1]" (senza struttura) torna serializzata:
+        # stringa o numero, mai sintassi rotta
+        out = restore('"[AMOUNT_1]"', {"[AMOUNT_1]": "1.500,00"})
+        self.assertEqual(json.loads(out), 1500.0)
+
+    def test_valore_non_stringa_resta_invariato(self):
+        self.assertEqual(restore({"x": 5}, {"[AMOUNT_1]": "1.500,00"}), {"x": 5})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

`/analyze` con `include_mapping=true` restituisce `anonymized_text` con i placeholder (`[AMOUNT_1]`) e un `mapping` {placeholder: valore} i cui valori sono le stringhe originali del documento (es. `"1.500,00"`). Chi ripristina i valori su un payload JSON oggi usa una sostituzione di sottostringa:

- il placeholder dentro una stringa quotata produce sintassi rotta: `"totale": "[AMOUNT_1]"` → `"totale": ""1.500,00""` (JSON non più parsabile);
- gli importi restano stringhe in formato italiano (`"1.500,00"`), mai numeri.

## Soluzione

Helper puro `src/app/restore.py` (solo stdlib: `json`/`re`/`typing`) che restituisce una **copia** del payload con i placeholder sostituiti:

- su strutture JSON (dict/list, o stringa JSON anche con fence ```json```) la sintassi resta sempre valida;
- una foglia che è esattamente un placeholder di tipo monetario (`AMOUNT`, vocabolario di `detectors.py`) diventa il numero normalizzato (`"1.500,00"` → `1500.0`; tollera `€`/`EUR`/`euro`);
- una foglia che contiene il placeholder come sottostringa resta una stringa (`"Totale: [AMOUNT_1]"` → `"Totale: 1.500,00"`);
- testo non-JSON → sostituzione diretta (compatibilità con l'uso attuale).

Il contratto di `/analyze` (mapping con valori stringa) resta invariato; le chiavi del mapping e del payload non vengono mai toccate. Nessuna dipendenza pesante: il modulo è importabile e testabile in CI.

## Test

`tests/test_restore.py` — 15 unittest, dati sintetici, solo stdlib (nessun import di `app.py`, gira in CI senza torch/transformers). Coprono: placeholder intero vs in-stringa, importi italiani con/senza prefisso `€`/`EUR`, collisioni `[ORG_1]` vs `[ORG_10]` (sostituzione lunghezza decrescente), fence JSON, mapping vuoto, tag non monetari non normalizzati, fallback testo, scalari JSON.

Eseguito: `python -m unittest tests.test_restore` → 15/15 ok.

Se il formato o il posizionamento non vi convince, dimmi e adatto volentieri.
