### PR TITLE
fix(dataset): mostra il backend LLM reale nei log

### DIFF
--- a/src/data_pipeline/contribute_dataset.py
+++ b/src/data_pipeline/contribute_dataset.py
@@ -349,7 +349,7 @@ def generate(n, seed, handle, per_type, offline, boost, out_path=None,
     # la NOVITA' del testo viene dai template freschi di Gemini.
     templates = new_templates + gen.TEMPLATES + gen.load_external_templates()
     print(f"\nTemplate nel pool: {len(templates)} "
-          f"({len(new_templates)} nuovi da Gemini + {len(gen.TEMPLATES)} built-in + "
+          f"({len(new_templates)} nuovi da {tb.backend_name()} + {len(gen.TEMPLATES)} built-in + "
           f"{len(templates) - len(new_templates) - len(gen.TEMPLATES)} locali)")
 
     # selezione pesata: i template che coprono i tag potenziati escono piu' spesso
@@ -550,7 +550,7 @@ def main():
         args.n, seed, handle, args.per_type, args.offline, boost, out_path=tmp_path,
         max_per_structure=args.max_per_structure)
     if n_new:
-        print(f"\n{from_new}/{n_ok} esempi da template NUOVI di Gemini.")
+        print(f"\n{from_new}/{n_ok} esempi da template NUOVI di {tb.backend_name()}.")
     print(f"Generati {n_ok} esempi validi. Entita' per label:")
     for label, c in sorted(counts.items(), key=lambda x: -x[1]):
         print(f"  {label:18s} {c}")


### PR DESCRIPTION
## Cosa cambia

Quando `contribute_dataset.py` usa un backend LLM locale, alcuni log riportavano ancora "Gemini" in modo hard-coded.

Questa modifica usa `tb.backend_name()` nei due messaggi runtime interessati, così il backend mostrato nei log corrisponde a quello realmente configurato.

## Test

Verificato con backend OpenAI-compatible locale:

- modello: `unsloth/Ornith-1.0-35B-GGUF`
- endpoint locale: `http://127.0.0.1:8888/v1`
- generazione completata correttamente con `--n 5 --per-type 1 --no-upload`
- i log riportano ora il backend locale invece di "Gemini"