### PR TITLE
feat(app): zoom sulle anteprime PDF

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-08-23 — anteprima PDF: zoom sulle pagine ([issue #92](https://github.com/Rizzo-AI-Academy/rizzo-pii/issues/92))
+
+Le due colonne di anteprima PDF (documento originale e "PDF censurato") mostravano le pagine
+sempre alla stessa dimensione: su un documento con testo piccolo o un layout denso (moduli,
+tabelle) non c'era modo di ingrandire per verificare cosa fosse stato anonimizzato senza
+scaricare il file. Aggiunta una barra di zoom (`−`/`+`/percentuale, che resetta a 100%) sticky
+in alto a destra di ciascuna anteprima, più `Ctrl`/`Cmd` + rotellina come scorciatoia; le due
+colonne zoomano in modo indipendente, dal 50% al 300%. Puro frontend: le pagine restano le
+stesse PNG renderizzate server-side, lo zoom è solo CSS (`width` della pagina in funzione di
+una custom property `--z`) — nessuna modifica al backend, nessun modello coinvolto.
+
+---
+
 ## 2026-08-07 — `Dockerfile`: l'app come webapp in un container
 
 Finora l'unico modo di far girare l'app era l'installer desktop o `python src/app/app.py` con

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -940,12 +940,28 @@ PAGE = r"""
   /* render del PDF (pagine PNG servite da /doc/<id>/page/<n>.png).
      Sfondo scuro come un lettore PDF: le pagine bianche si staccano. */
   .pdfview{padding:12px;background:#e8e6ef}
-  .pdfview .pg{position:relative;width:100%;margin:0 0 12px;background:#fff;border-radius:4px;
-               overflow:hidden;box-shadow:0 1px 3px rgba(33,26,48,.18),0 6px 18px rgba(33,26,48,.10)}
+  .pdfview .pg{position:relative;width:calc(100% * var(--z,1));margin:0 auto 12px;background:#fff;
+               border-radius:4px;overflow:hidden;
+               box-shadow:0 1px 3px rgba(33,26,48,.18),0 6px 18px rgba(33,26,48,.10)}
   .pdfview .pg:last-child{margin-bottom:0}
   .pdfview .pg img{display:block;width:100%;height:auto;min-height:24px}
   .pdfview .pgn{position:absolute;right:7px;bottom:7px;background:rgba(28,35,48,.6);color:#fff;
                 font-size:11px;font-weight:700;border-radius:6px;padding:2px 7px;letter-spacing:.02em}
+  /* zoom: pulsanti +/- sticky in alto a destra, ctrl+rotellina fa lo stesso (issue #92).
+     La barra e' a tutta larghezza ma "vuota" (pointer-events:none) cosi' non ruba i click
+     sulla pagina sotto: solo la pillola dei pulsanti li riceve. */
+  .zoomctl{position:sticky;top:0;z-index:3;display:flex;justify-content:flex-end;
+           pointer-events:none;margin-bottom:8px}
+  .zoomctl .pill{pointer-events:auto;display:flex;align-items:center;gap:1px;
+                 background:rgba(255,255,255,.94);border:1px solid var(--line);border-radius:999px;
+                 padding:3px;box-shadow:0 1px 4px rgba(33,26,48,.15)}
+  .zoomctl button{width:23px;height:23px;border:none;background:transparent;border-radius:999px;
+                  font-size:14px;font-weight:700;color:var(--ink);cursor:pointer;line-height:1;
+                  transition:.12s}
+  .zoomctl button:hover{background:var(--line2)}
+  .zoomctl .zpct{font-size:11px;font-weight:700;color:var(--muted);min-width:36px;text-align:center;
+                 cursor:pointer;user-select:none}
+  .zoomctl .zpct:hover{color:var(--ink)}
   .pdfbusy{display:flex;align-items:center;justify-content:center;gap:10px;height:100%;
            color:var(--muted);font-size:13.5px;font-weight:600}
   .pdfbusy .spin{border-color:rgba(124,58,158,.25);border-top-color:var(--brand)}
@@ -1504,6 +1520,7 @@ function toast(msg,ok=true,ms=1800){const t=$('toast');t.textContent=msg;t.class
    `loading=lazy` -> un PDF di 200 pagine non scarica 200 immagini all'apertura. */
 function renderPages(el,doc){
   el.innerHTML='';
+  el.appendChild(zoomBar(el));
   for(let i=0;i<doc.n_pages;i++){
     const pg=document.createElement('div');pg.className='pg';
     const im=document.createElement('img');
@@ -1515,6 +1532,26 @@ function renderPages(el,doc){
     el.appendChild(pg);
   }
   el.scrollTop=0;
+}
+
+/* barra zoom (issue #92): +/- e reset sulla %, piu' ctrl/cmd+rotellina sull'intera vista.
+   Il livello vive in --z su el stesso, letto da .pdfview .pg{width:...} in CSS; si azzera
+   a ogni nuovo rendering (nuovo documento = vista pulita, come per gli altri stati del pane). */
+function zoomBar(el){
+  const bar=document.createElement('div');bar.className='zoomctl';
+  const pill=document.createElement('div');pill.className='pill';
+  const out=document.createElement('button');out.type='button';out.textContent='−';out.title='Riduci zoom';
+  const pct=document.createElement('span');pct.className='zpct';pct.title='Reimposta zoom';
+  const inn=document.createElement('button');inn.type='button';inn.textContent='+';inn.title='Aumenta zoom';
+  const setZ=z=>{z=Math.max(.5,Math.min(3,z));el.style.setProperty('--z',z);pct.textContent=Math.round(z*100)+'%';};
+  const curZ=()=>parseFloat(el.style.getPropertyValue('--z'))||1;
+  out.onclick=()=>setZ(curZ()-.25);
+  inn.onclick=()=>setZ(curZ()+.25);
+  pct.onclick=()=>setZ(1);
+  el.onwheel=e=>{if(!e.ctrlKey&&!e.metaKey)return;e.preventDefault();setZ(curZ()+(e.deltaY<0?.1:-.1));};
+  pill.append(out,pct,inn);bar.appendChild(pill);
+  setZ(1);
+  return bar;
 }
 function busy(el,msg){
   el.innerHTML='<div class="pdfbusy"><span class="spin"></span>'+msg+'</div>';}


### PR DESCRIPTION
Closes #92

## Cosa cambia

Le due colonne di anteprima PDF (documento originale e "PDF censurato") mostravano
le pagine sempre alla stessa dimensione: su un documento con testo piccolo o un
layout denso (moduli, tabelle) non c'era modo di ingrandire per verificare cosa
fosse stato anonimizzato senza scaricare il file.

Aggiunta una barra di zoom sticky in alto a destra di ciascuna anteprima:
- pulsanti `−`/`+` (passo 25%, range 50%–300%)
- percentuale al centro, cliccabile per resettare a 100%
- `Ctrl`/`Cmd` + rotellina come scorciatoia sull'intera vista

Le due colonne (sinistra/destra) zoomano **in modo indipendente**. Lo zoom si
azzera a ogni nuovo rendering (nuovo documento caricato, o nuovo risultato), come
già succede per gli altri stati del pane.

## Come funziona

Puro frontend, nessun cambio al backend: le pagine restano le stesse PNG
renderizzate server-side da `/doc/<id>/page/<n>.png`. Lo zoom è solo CSS — la
larghezza di ogni pagina (`.pdfview .pg`) è `calc(100% * var(--z,1))`, e i
pulsanti aggiornano la custom property `--z` sul contenitore. La barra è sticky
e a tutta larghezza ma "vuota" (`pointer-events:none`sulla barra, `auto` solo
sulla pillola dei pulsanti) così non ruba i click sulla pagina sottostante.

## Verifica

- `python -m unittest discover -s tests` → 35/35 passano (nessun test tocca
  questa parte di frontend, il che è coerente: nessuna logica server-side toccata).
- Testato a mano in Chrome: upload PDF → zoom su "Anteprima PDF" (50%–300%,
  overflow orizzontale gestito dallo scroll già esistente del contenitore) →
  anonimizzazione → zoom indipendente su "PDF censurato", reset funzionante su
  entrambe le colonne.