### PR TITLE
fix(app): extract AcroForm widget text so fillable PDFs analyze

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,21 @@ Le voci più recenti in alto. (Codice: `src/training/train_pii.py` salvo diverso
 
 ---
 
+## 2026-09-01 — PDF fillable: i campi modulo entrano in `/analyze` (`pdf_text.py`)
+
+`_text_from_bytes` leggeva solo `page.get_text()`. Nei PDF con AcroForm (moduli
+pagoPA, dichiarazioni compilabili) il valore sta nel widget, non nel content
+stream: l'estrazione tornava vuota e `POST /analyze` rispondeva 400
+"Nessun testo da analizzare" (issue #85, secondo punto).
+
+`pdf_export._readable_text` gia' raccoglieva widget, annotazioni e segnalibri,
+ma solo *dopo* l'analisi, per i residui. La stessa raccolta e' ora in
+`src/app/pdf_text.py` (niente fitz/torch: testabile in CI) e la usano sia
+l'estrazione per `/analyze`/`/preview` sia la verifica residui.
+
+Non risolve il primo punto della issue (FULLNAME spezzato su campi Nome/Cognome):
+quello e' un limite del modello, non dell'estrazione.
+
 ## 2026-08-07 — `Dockerfile`: l'app come webapp in un container
 
 Finora l'unico modo di far girare l'app era l'installer desktop o `python src/app/app.py` con

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -58,6 +58,7 @@ from flask import (Flask, jsonify, render_template_string, request,
                    send_from_directory)
 
 import pdf_export
+import pdf_text
 import server_config
 # Rete REGEX + CHECKSUM: modulo a parte, senza dipendenze dal modello. I nomi
 # restano importabili da qui (`app.detect_regex`) per non rompere chi li usa.
@@ -499,12 +500,19 @@ def _is_pdf(name, data):
 
 
 def _text_from_bytes(name, data):
-    """Testo dai bytes di un upload: PDF via PyMuPDF, .md/.txt come testo puro."""
+    """Testo dai bytes di un upload: PDF via PyMuPDF, .md/.txt come testo puro.
+
+    Per i PDF non basta `page.get_text()`: nei moduli AcroForm il valore sta
+    nei widget (issue #85). `pdf_text.collect_readable_text` allinea
+    l'estrazione a quanto `pdf_export` gia' ispezionava per i residui.
+    """
     name = (name or "").lower()
     ext = os.path.splitext(name)[1]
     if _is_pdf(name, data):
         with fitz.open(stream=data, filetype="pdf") as doc:
-            return "\n".join(page.get_text() for page in doc)
+            # Non solo page.get_text(): nei PDF fillable il valore sta nei
+            # widget AcroForm (issue #85). Stesso contratto di pdf_export.
+            return pdf_text.collect_readable_text(doc)
     if ext in TEXT_EXTS or not ext:
         for enc in ("utf-8-sig", "utf-16", "latin-1"):
             try:

--- a/src/app/pdf_export.py
+++ b/src/app/pdf_export.py
@@ -50,6 +50,7 @@ import re
 import unicodedata
 
 import fitz  # PyMuPDF
+import pdf_text
 
 
 class PdfError(ValueError):
@@ -320,28 +321,7 @@ def _readable_text(doc):
     modulo + segnalibri. E' la base della verifica dei residui: se un valore
     compare qui, l'anonimizzazione NON e' completa.
     NB: non vede il testo dentro immagini raster (loghi, firme, scansioni)."""
-    parts = []
-    for page in doc:
-        parts.append(page.get_text())
-        try:
-            for a in page.annots():
-                if a.type[0] == fitz.PDF_ANNOT_REDACT:
-                    continue
-                info = a.info
-                parts.extend(str(info.get(k) or "") for k in ("content", "subject", "title"))
-        except Exception:
-            pass
-        try:
-            for w in page.widgets():
-                if isinstance(w.field_value, str):
-                    parts.append(w.field_value)
-        except Exception:
-            pass
-    try:
-        parts.extend(str(e[1] or "") for e in doc.get_toc(simple=True))
-    except Exception:
-        pass
-    return "\n".join(parts)
+    return pdf_text.collect_readable_text(doc, redact_annot_type=fitz.PDF_ANNOT_REDACT)
 
 
 def _verify_residuals(pdf_bytes, items):

--- a/src/app/pdf_text.py
+++ b/src/app/pdf_text.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Testo leggibile di un PDF: content stream + annotazioni + campi modulo + TOC.
+
+Come `detectors` e `pdf_export`, questo modulo lavora solo su oggetti duck-typed:
+nessun import di torch/transformers/fitz, quindi e' testabile in isolamento.
+`app._text_from_bytes` e `pdf_export._readable_text` lo usano sullo stesso
+documento aperto da PyMuPDF.
+
+Nei PDF fillable (AcroForm) il valore sta nel widget, non nel content stream:
+`page.get_text()` torna vuoto e /analyze rispondeva 400 (issue #85).
+"""
+
+# PyMuPDF: fitz.PDF_ANNOT_REDACT. Le annotazioni di redazione non sono testo
+# del documento, e in verifica residui andrebbero contate due volte.
+REDACT_ANNOT = 12
+
+
+def collect_readable_text(doc, redact_annot_type=REDACT_ANNOT):
+    """TUTTO il testo leggibile: pagine + annotazioni + campi modulo + segnalibri.
+
+    `doc` e' un iterabile di pagine con `get_text()`, `annots()`, `widgets()`
+    e (sul documento) `get_toc(simple=True)`: il contratto di PyMuPDF, senza
+    importarlo. NB: non vede il testo dentro immagini raster.
+    """
+    parts = []
+    for page in doc:
+        parts.append(page.get_text() or "")
+        try:
+            for a in page.annots() or ():
+                if a.type[0] == redact_annot_type:
+                    continue
+                info = a.info or {}
+                parts.extend(str(info.get(k) or "") for k in ("content", "subject", "title"))
+        except Exception:
+            pass
+        try:
+            for w in page.widgets() or ():
+                val = w.field_value
+                if isinstance(val, str) and val:
+                    parts.append(val)
+        except Exception:
+            pass
+    try:
+        parts.extend(str(e[1] or "") for e in (doc.get_toc(simple=True) or ()))
+    except Exception:
+        pass
+    return "\n".join(parts)

--- a/tests/test_pdf_fillable_text.py
+++ b/tests/test_pdf_fillable_text.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Regressione issue #85: il testo dei campi modulo deve entrare in /analyze.
+
+`_text_from_bytes` leggeva solo `page.get_text()`. Nei PDF fillable (AcroForm)
+il valore sta nel widget, non nel content stream: get_text() torna vuoto, lo
+strip in /analyze produce 400 \"Nessun testo da analizzare\", e i campi restano
+in chiaro. `pdf_export._readable_text` gia' raccoglie i widget: l'estrazione
+per l'analisi deve fare lo stesso.
+
+Nessun import di fitz: le pagine sono duck-typed, come i detector. Gira in CI
+sulla sola libreria standard. I valori sono SINTETICI.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src" / "app"))
+
+import pdf_text  # noqa: E402
+
+
+class FakeWidget:
+    def __init__(self, value):
+        self.field_value = value
+
+
+class FakeAnnot:
+    def __init__(self, content="", subject="", title="", type_id=0):
+        self.type = (type_id, "Text")
+        self.info = {"content": content, "subject": subject, "title": title}
+
+
+class FakePage:
+    def __init__(self, text="", widgets=(), annots=()):
+        self._text = text
+        self._widgets = list(widgets)
+        self._annots = list(annots)
+
+    def get_text(self):
+        return self._text
+
+    def widgets(self):
+        return iter(self._widgets)
+
+    def annots(self):
+        return iter(self._annots)
+
+
+class FakeDoc(list):
+    def __init__(self, pages, toc=None):
+        super().__init__(pages)
+        self._toc = toc or []
+
+    def get_toc(self, simple=True):
+        return self._toc
+
+
+class FillablePdfText(unittest.TestCase):
+    def test_widget_value_is_collected_when_page_stream_is_empty(self):
+        """Il caso della issue: modulo pagoPA / AcroForm, get_text() vuoto."""
+        doc = FakeDoc([
+            FakePage(text="", widgets=[FakeWidget("Mario Rossi")]),
+        ])
+        out = pdf_text.collect_readable_text(doc)
+        self.assertIn("Mario Rossi", out)
+        self.assertTrue(out.strip(), "senza il widget /analyze risponderebbe 400")
+
+    def test_page_stream_text_is_still_collected(self):
+        doc = FakeDoc([FakePage(text="Il sottoscritto dichiara.")])
+        out = pdf_text.collect_readable_text(doc)
+        self.assertIn("Il sottoscritto dichiara.", out)
+
+    def test_empty_and_non_string_widgets_are_ignored(self):
+        doc = FakeDoc([
+            FakePage(text="corpo", widgets=[
+                FakeWidget(""),
+                FakeWidget(None),
+                FakeWidget(True),
+                FakeWidget("CF RSSMRA80A01H501U"),
+            ]),
+        ])
+        out = pdf_text.collect_readable_text(doc)
+        self.assertIn("corpo", out)
+        self.assertIn("CF RSSMRA80A01H501U", out)
+
+    def test_annot_content_is_collected_redact_marks_are_not(self):
+        doc = FakeDoc([
+            FakePage(
+                text="",
+                annots=[
+                    FakeAnnot(content="nota con PII", type_id=0),
+                    FakeAnnot(content="redazione interna", type_id=12),
+                ],
+            ),
+        ])
+        out = pdf_text.collect_readable_text(doc)
+        self.assertIn("nota con PII", out)
+        self.assertNotIn("redazione interna", out)
+
+    def test_bookmark_titles_are_collected(self):
+        doc = FakeDoc(
+            [FakePage(text="pagina")],
+            toc=[[1, "Atto Rossi Mario", 1]],
+        )
+        out = pdf_text.collect_readable_text(doc)
+        self.assertIn("Atto Rossi Mario", out)
+
+    def test_truly_empty_pdf_stays_empty(self):
+        doc = FakeDoc([FakePage(text="", widgets=[FakeWidget("")])])
+        self.assertFalse(pdf_text.collect_readable_text(doc).strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Cosa

`POST /analyze` (e `/preview`) su un PDF fillable rispondeva 400
"Nessun testo da analizzare" quando il content stream era vuoto.
I valori stanno nei widget AcroForm, non in `page.get_text()`.

Riguarda il secondo punto di #85. Il primo (FULLNAME spezzato su
campi Nome/Cognome) resta: e' un limite del modello, non
dell'estrazione.

## Come

`pdf_export._readable_text` gia' raccoglieva widget, annotazioni e
segnalibri, ma solo *dopo* l'analisi, per i residui. La stessa
raccolta e' in `src/app/pdf_text.py` (niente fitz/torch) e la usano
sia `_text_from_bytes` sia la verifica residui.

## Test eseguiti

```
python -m unittest discover -v tests
```

41 test, 0 fallimenti, 2 skipped (`test_tsv_anonymize`: serve
torch/transformers/flask/fitz, la CI non li installa). I 6 nuovi
test in `tests/test_pdf_fillable_text.py` girano sulla sola
stdlib con pagine duck-typed. Senza questa modifica falliscono
sull'asserzione dei widget; con questa modifica passano.

Non verificato: `/analyze` live sul PDF pagoPA dell'issue (serve
il modello e PyMuPDF). I valori nei test sono sintetici.
